### PR TITLE
Harden build prefix relocation of poured bottles

### DIFF
--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -23,10 +23,7 @@ module OS
         candidates = if files
           # Metadata-driven pour: only the files recorded at bottle time carry
           # placeholdered linkage, so skip the whole-keg walk.
-          files.filter_map do |relative_path|
-            file = path/relative_path
-            ELFPathname.wrap(file) if file.file? && !file.symlink?
-          end
+          keg_files(files).map { |file| ELFPathname.wrap(file) }
         else
           elf_files
         end

--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -36,10 +36,7 @@ module OS
         candidates = if files
           # Metadata-driven pour: only the files recorded at bottle time carry
           # placeholdered linkage, so skip the whole-keg walk.
-          files.filter_map do |relative_path|
-            file = path/relative_path
-            MachOPathname.wrap(file) if file.file? && !file.symlink?
-          end
+          keg_files(files).map { |file| MachOPathname.wrap(file) }
         else
           mach_o_files
         end

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -257,25 +257,38 @@ class Keg
            files: T.nilable(T::Array[Pathname])).void
   }
   def relocate_build_prefix(keg, old_prefix, new_prefix, files: nil)
-    candidates = T.let([], T::Array[Pathname])
-    if files
-      # Metadata-driven pour: only the files recorded at bottle time carry raw
-      # prefix strings, so skip the whole-keg scan.
-      hardlinks = Set.new
-      files.each do |relative_path|
-        file = path/relative_path
-        next if !file.file? || file.symlink?
-        # Hardlinks share an inode, so patch each inode only once.
-        next unless hardlinks.add? file.stat.ino
-
-        candidates << file
-      end
-    else
-      each_unique_file_matching(old_prefix) { |file| candidates << file }
+    old_prefix = old_prefix.to_s
+    new_prefix = new_prefix.to_s
+    # A raw C string can only be replaced in place by an equal-or-shorter
+    # string, so refuse before touching any file rather than failing midway.
+    if new_prefix.bytesize > old_prefix.bytesize
+      raise ArgumentError, "Cannot relocate build prefix #{old_prefix} to longer prefix #{new_prefix}"
     end
 
-    patched_files = T.let([], T::Array[Pathname])
-    candidates.each do |file|
+    # Hardlinked names share one inode: patch it once through the first name
+    # and re-link the rest afterwards, as the patched file gets a new inode.
+    inode_groups = if files
+      # Metadata-driven pour: only the files recorded at bottle time carry raw
+      # prefix strings, so skip the whole-keg scan.
+      candidates = keg_files(files)
+      # Bottle metadata records one name per inode, so the other names of a
+      # hardlinked file are only found by a walk; do that only when needed.
+      hardlinked_inodes = candidates.select { |file| file.stat.nlink > 1 }.to_set { |file| file.stat.ino }
+      unless hardlinked_inodes.empty?
+        path.find do |file|
+          next if file.symlink? || !file.file?
+
+          candidates << file if hardlinked_inodes.include?(file.stat.ino)
+        end
+      end
+      candidates.uniq.group_by { |file| file.stat.ino }.values
+    else
+      files_matching_by_inode(old_prefix)
+    end
+
+    patched_groups = T.let([], T::Array[T::Array[Pathname]])
+    inode_groups.each do |group|
+      file = group.fetch(0)
       # Skip files which are not binary, as they do not need null padding.
       next unless keg.binary_file?(file)
 
@@ -287,7 +300,7 @@ class Keg
       file.ensure_writable do
         binary = File.binread file
         binary_strings = binary.split(/#{NULL_BYTE}/o, -1)
-        match_indices = binary_strings.each_index.select { |i| binary_strings.fetch(i).include?(old_prefix.to_s) }
+        match_indices = binary_strings.each_index.select { |i| binary_strings.fetch(i).include?(old_prefix) }
 
         # Bottle metadata records files pinned by any prefix, cellar or
         # repository reference, so a recorded file may not contain this
@@ -296,31 +309,85 @@ class Keg
 
         odebug "Replacing build prefix in: #{file}"
 
-        # Only perform substitution on strings which match prefix regex.
+        # Linkers merge a string with the suffix of another, so a string in
+        # the dynamic string table can be referenced from its interior.
+        interior_references = Keg.elf_dynamic_string_references_in(file)
+        string_starts = T.let([], T::Array[Integer])
+        binary_strings.reduce(0) do |start, binary_string|
+          string_starts << start
+          start + binary_string.bytesize + 1
+        end
+
         match_indices.each do |i|
-          s = binary_strings.fetch(i)
-          binary_strings[i] = s.gsub(old_prefix.to_s, new_prefix.to_s)
-                               .ljust(s.size, NULL_BYTE)
+          binary_string = binary_strings.fetch(i)
+          start = string_starts.fetch(i)
+          preserve_suffix_offsets = interior_references.any? do |reference|
+            reference > start && reference < start + binary_string.bytesize
+          end
+          binary_strings[i] = Keg.replace_prefix_preserving_length(binary_string, old_prefix, new_prefix,
+                                                                   preserve_suffix_offsets:)
         end
 
         # Rejoin strings by null bytes.
         patched_binary = binary_strings.join(NULL_BYTE)
-        if patched_binary.size != binary.size
+        if patched_binary.bytesize != binary.bytesize
           raise <<~EOS
             Patching failed!  Original and patched binary sizes do not match.
-            Original size: #{binary.size}
-            Patched size: #{patched_binary.size}
+            Original size: #{binary.bytesize}
+            Patched size: #{patched_binary.bytesize}
           EOS
         end
 
         file.atomic_write patched_binary
-        patched_files << file
+        patched_groups << group
       end
     end
 
     # Each patch broke the file's signature, so re-sign each patched file
     # exactly once, parallelised across files.
-    codesign_patched_binaries(patched_files)
+    codesign_patched_binaries(patched_groups.map { |group| group.fetch(0) })
+
+    patched_groups.each do |group|
+      first = group.fetch(0)
+      group.drop(1).each { |file| FileUtils.ln(first, file, force: true) }
+    end
+  end
+
+  # Replaces the prefix in a NUL-terminated string without changing its
+  # length. Trailing NUL padding is invisible to C string readers but shifts
+  # any suffix-merged reference into the string, so when the string has such
+  # references pad each occurrence with extra path separators instead, which
+  # path resolution ignores (`//` is `/`, as is a trailing `/`). An
+  # occurrence followed by anything else is not a path under the prefix and
+  # cannot be padded that way, so such strings fall back to NUL padding with
+  # every occurrence replaced rather than being left partly relocated.
+  sig {
+    params(string: String, old_prefix: String, new_prefix: String, preserve_suffix_offsets: T::Boolean).returns(String)
+  }
+  def self.replace_prefix_preserving_length(string, old_prefix, new_prefix, preserve_suffix_offsets:)
+    if preserve_suffix_offsets
+      separators = "/" * (old_prefix.bytesize - new_prefix.bytesize)
+      padded = string.gsub(%r{#{Regexp.escape(old_prefix)}(?=/|\z)}) { "#{new_prefix}#{separators}" }
+      return padded unless padded.include?(old_prefix)
+    end
+
+    string.gsub(old_prefix) { new_prefix }.ljust(string.bytesize, NULL_BYTE)
+  end
+
+  # Absolute file offsets of the strings the dynamic loader references in
+  # the file's dynamic string table, or none for files that are not ELF or
+  # cannot be parsed.
+  sig { params(file: Pathname).returns(T::Array[Integer]) }
+  def self.elf_dynamic_string_references_in(file)
+    require "os/linux/elf"
+    return [] unless T.cast(Pathname.new(file.to_s).extend(ELFShim), ELFShim).elf?
+
+    require "elftools"
+    file.open("rb") do |stream|
+      elf_dynamic_string_references(ELFTools::ELFFile.new(stream))&.offsets || []
+    end
+  rescue ELFTools::ELFError, IOError, SystemCallError
+    []
   end
 
   sig { params(_options: T::Hash[Symbol, T::Boolean]).returns(T::Array[Symbol]) }
@@ -346,21 +413,40 @@ class Keg
     [grep_bin, grep_args]
   end
 
-  sig { params(string: T.any(String, Pathname), _block: T.proc.params(arg0: Pathname).void).void }
-  def each_unique_file_matching(string, &_block)
-    Utils.popen_read("fgrep", recursive_fgrep_args, string, to_s) do |io|
-      hardlinks = Set.new
+  # The regular files the keg-relative paths recorded in bottle metadata refer
+  # to. Metadata may come from a mirror, so paths that would escape the keg
+  # (absolute or via `..`) are ignored rather than followed.
+  sig { params(relative_paths: T::Array[Pathname]).returns(T::Array[Pathname]) }
+  def keg_files(relative_paths)
+    relative_paths.filter_map do |relative_path|
+      file = (path/relative_path).cleanpath
+      next unless file.to_s.start_with?("#{path}/")
+      next if file.symlink? || !file.file?
 
+      file
+    end
+  end
+
+  # Files containing the string, grouped by inode so that hardlinks to the
+  # same file appear together.
+  sig { params(string: T.any(String, Pathname)).returns(T::Array[T::Array[Pathname]]) }
+  def files_matching_by_inode(string)
+    files = T.let([], T::Array[Pathname])
+    Utils.popen_read("fgrep", recursive_fgrep_args, string, to_s) do |io|
       until io.eof?
         file = Pathname.new(io.readline.chomp)
         # Don't return symbolic links.
-        next if file.symlink?
-
-        # To avoid returning hardlinks, only return files with unique inodes.
-        # Hardlinks will have the same inode as the file they point to.
-        yield file if hardlinks.add? file.stat.ino
+        files << file unless file.symlink?
       end
     end
+    files.group_by { |file| file.stat.ino }.values
+  end
+
+  sig { params(string: T.any(String, Pathname), block: T.proc.params(arg0: Pathname).void).void }
+  def each_unique_file_matching(string, &block)
+    # Hardlinks share an inode with the file they point to, so only the first
+    # name of each inode is yielded.
+    files_matching_by_inode(string).map { |group| group.fetch(0) }.each(&block)
   end
 
   sig { params(file: Pathname).returns(T::Boolean) }
@@ -551,56 +637,16 @@ class Keg
       end
 
       string_table_range = T.let(nil, T.nilable(T::Range[Integer]))
-      if (dynamic = elf.segment_by_type(:dynamic))
-        # Dynamic tags whose value is an offset into the dynamic string
-        # table, i.e. the strings the loader can actually see.
-        string_tags = [
-          ELFTools::Constants::DT::DT_NEEDED,
-          ELFTools::Constants::DT::DT_SONAME,
-          ELFTools::Constants::DT::DT_RPATH,
-          ELFTools::Constants::DT::DT_RUNPATH,
-          ELFTools::Constants::DT::DT_AUXILIARY,
-          # elftools 1.3.1 mislabels `DT_USED` (0x7ffffffe) as `DT_FILTER`;
-          # both hold string-table offsets, so keep the mislabelled value
-          # and add the ELF ABI's real `DT_FILTER`.
-          ELFTools::Constants::DT::DT_FILTER,
-          0x7fffffff, # DT_FILTER
-          ELFTools::Constants::DT::DT_AUDIT,
-          ELFTools::Constants::DT::DT_DEPAUDIT,
-          ELFTools::Constants::DT::DT_CONFIG,
-        ]
-        string_table_vaddr = T.let(nil, T.nilable(Integer))
-        string_table_size = T.let(nil, T.nilable(Integer))
-        string_offsets = []
-        dynamic.tags.each do |tag|
-          case tag.header.d_tag.to_i
-          when ELFTools::Constants::DT::DT_STRTAB then string_table_vaddr = tag.header.d_val.to_i
-          when ELFTools::Constants::DT::DT_STRSZ then string_table_size = tag.header.d_val.to_i
-          when *string_tags then string_offsets << tag.header.d_val.to_i
-          end
-        end
-        if string_table_vaddr && (string_table_offset = elf.offset_from_vma(string_table_vaddr))
-          string_table_range = string_table_offset...(string_table_offset + string_table_size) if string_table_size
-
-          # Dynamic symbol names are loader-visible strings in the same
-          # table, referenced by `.dynsym` `st_name` rather than by dynamic
-          # tags. Version table strings also index the table but hold
-          # version names, never paths, so they are not collected.
-          elf.sections_by_type(ELFTools::Constants::SHT::SHT_DYNSYM).each do |section|
-            section.symbols.each do |symbol|
-              name_offset = symbol.header.st_name.to_i
-              string_offsets << name_offset unless name_offset.zero?
-            end
-          end
-
-          # A referenced string runs from its offset to the terminating NUL,
-          # so a suffix-merged reference to the interior `libfoo.so` of
-          # `/old/prefix/libfoo.so` never yields the dead prefix before it.
-          string_offsets.uniq.each do |offset|
-            stream.pos = string_table_offset + offset
-            referenced = stream.gets("\0")&.delete_suffix("\0")
-            strings << [string_table_offset + offset, referenced] if referenced
-          end
+      if (references = elf_dynamic_string_references(elf))
+        string_table_range = references.string_table_range
+        referenced_offsets = references.offsets
+        # A referenced string runs from its offset to the terminating NUL,
+        # so a suffix-merged reference to the interior `libfoo.so` of
+        # `/old/prefix/libfoo.so` never yields the dead prefix before it.
+        referenced_offsets.each do |offset|
+          stream.pos = offset
+          referenced = stream.gets("\0")&.delete_suffix("\0")
+          strings << [offset, referenced] if referenced
         end
       end
 
@@ -641,6 +687,68 @@ class Keg
     # pointing outside the file mid-parse (Linux raises `Errno::EINVAL`
     # for the resulting seek where macOS returns EOF).
     nil
+  end
+
+  class DynamicStringReferences < T::Struct
+    # The file range of the dynamic string table, when its size is known.
+    const :string_table_range, T.nilable(T::Range[Integer])
+    # Absolute file offsets of the strings the loader references in it.
+    const :offsets, T::Array[Integer]
+  end
+
+  # The strings the dynamic loader references in the file's dynamic string
+  # table, or nil without a dynamic segment or string table.
+  sig { params(elf: ELFTools::ELFFile).returns(T.nilable(DynamicStringReferences)) }
+  def self.elf_dynamic_string_references(elf)
+    dynamic = elf.segment_by_type(:dynamic)
+    return if dynamic.nil?
+
+    # Dynamic tags whose value is an offset into the dynamic string table,
+    # i.e. the strings the loader can actually see.
+    string_tags = [
+      ELFTools::Constants::DT::DT_NEEDED,
+      ELFTools::Constants::DT::DT_SONAME,
+      ELFTools::Constants::DT::DT_RPATH,
+      ELFTools::Constants::DT::DT_RUNPATH,
+      ELFTools::Constants::DT::DT_AUXILIARY,
+      # elftools 1.3.1 mislabels `DT_USED` (0x7ffffffe) as `DT_FILTER`;
+      # both hold string-table offsets, so keep the mislabelled value
+      # and add the ELF ABI's real `DT_FILTER`.
+      ELFTools::Constants::DT::DT_FILTER,
+      0x7fffffff, # DT_FILTER
+      ELFTools::Constants::DT::DT_AUDIT,
+      ELFTools::Constants::DT::DT_DEPAUDIT,
+      ELFTools::Constants::DT::DT_CONFIG,
+    ]
+    string_table_vaddr = T.let(nil, T.nilable(Integer))
+    string_table_size = T.let(nil, T.nilable(Integer))
+    string_offsets = []
+    dynamic.tags.each do |tag|
+      case tag.header.d_tag.to_i
+      when ELFTools::Constants::DT::DT_STRTAB then string_table_vaddr = tag.header.d_val.to_i
+      when ELFTools::Constants::DT::DT_STRSZ then string_table_size = tag.header.d_val.to_i
+      when *string_tags then string_offsets << tag.header.d_val.to_i
+      end
+    end
+    return if string_table_vaddr.nil?
+
+    string_table_offset = elf.offset_from_vma(string_table_vaddr)
+    return if string_table_offset.nil?
+
+    # Dynamic symbol names are loader-visible strings in the same table,
+    # referenced by `.dynsym` `st_name` rather than by dynamic tags. Version
+    # table strings also index the table but hold version names, never
+    # paths, so they are not collected.
+    elf.sections_by_type(ELFTools::Constants::SHT::SHT_DYNSYM).each do |section|
+      section.symbols.each do |symbol|
+        name_offset = symbol.header.st_name.to_i
+        string_offsets << name_offset unless name_offset.zero?
+      end
+    end
+
+    string_table_range = string_table_offset...(string_table_offset + string_table_size) if string_table_size
+    DynamicStringReferences.new(string_table_range:,
+                                offsets:            string_offsets.uniq.map { |offset| string_table_offset + offset })
   end
 
   sig { params(_file: Pathname, _string: String).returns(T::Array[String]) }

--- a/Library/Homebrew/plans/relocatable-bottles.md
+++ b/Library/Homebrew/plans/relocatable-bottles.md
@@ -83,7 +83,9 @@ Raw C strings are the only length-limited content at pour time:
 - ELF RPATHs and interpreters can grow because patchelf.rb rewrites them into
   a new segment.
 - A raw C string can only be replaced by an equal-or-shorter string, padded
-  with NUL bytes.
+  with NUL bytes; a string in an ELF dynamic string table that a linker has
+  suffix-merged (referenced from its interior) is instead padded with extra
+  path separators after the prefix so those references keep their offsets.
 
 `Keg#relocate_build_prefix` (`keg_relocate.rb`) implements that NUL-padded
 patching and re-signs patched Mach-O files, and
@@ -212,11 +214,6 @@ Whole dependency closures become pourable at prefixes up to the bottled
 default length (13 bytes arm64 macOS, 26 Linux), covering the hub formulae
 (`openssl@3`, `gettext`, `glib`, `python@3.x`) that Phase 1 cannot.
 
-8. Hardening tests and fixes for `Keg#relocate_build_prefix`:
-   multi-occurrence strings, several strings per file, hardlinks, the
-   sharball skip, the size-mismatch failure path, codesign on macOS and
-   no-op on Linux, suffix-merged string tables and prefix strings inside
-   load commands.
 9. Observability and diagnostics: the poured keg's tab records patched state
    and files; the pour decline message (`formula_installer.rb`) compares
    prefix lengths and states the actionable cause ("prefix 8 characters too

--- a/Library/Homebrew/test/keg_relocate/binary_relocation_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/binary_relocation_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Keg do
 
   before do
     dir.mkpath
+    allow(keg).to receive(:codesign_patched_binaries)
   end
 
   def setup_binary_file
@@ -49,6 +50,120 @@ RSpec.describe Keg do
 
       null_padding = "\x00" * (dir.to_s.length - newdir.to_s.length)
       expect(binary_file.binread).to eq "\x00#{newdir}#{null_padding}\x00\n"
+    end
+
+    specify "replaces every occurrence in every string" do
+      binary_file.atomic_write "\x00#{dir}/a:#{dir}/b\x00#{dir}/c\x00"
+
+      keg.relocate_build_prefix(keg, dir, newdir)
+
+      null_padding = "\x00" * (dir.to_s.length - newdir.to_s.length)
+      expect(binary_file.binread)
+        .to eq "\x00#{newdir}/a:#{newdir}/b#{null_padding * 2}\x00#{newdir}/c#{null_padding}\x00"
+    end
+
+    specify "patches hardlinks once and keeps them linked" do
+      setup_binary_file
+      hardlink = dir/"hardlink.bin"
+      FileUtils.ln binary_file, hardlink
+
+      keg.relocate_build_prefix(keg, dir, newdir)
+
+      expect(hardlink.stat.ino).to eq binary_file.stat.ino
+      expect(hardlink.binread).to include newdir.to_s
+    end
+
+    specify "patches every name of a hardlinked file recorded once in metadata" do
+      setup_binary_file
+      hardlink = dir/"hardlink.bin"
+      FileUtils.ln binary_file, hardlink
+
+      keg.relocate_build_prefix(keg, dir, newdir, files: [Pathname("file.bin")])
+
+      expect(hardlink.stat.ino).to eq binary_file.stat.ino
+      expect(hardlink.binread).to include newdir.to_s
+    end
+
+    specify "ignores recorded paths that escape the keg" do
+      outside = dir.parent/"escape.bin"
+      outside.atomic_write "\x00#{dir}\x00"
+
+      keg.relocate_build_prefix(keg, dir, newdir, files: [Pathname("../escape.bin"), outside])
+
+      expect(outside.binread).to include dir.to_s
+    end
+
+    specify "leaves sharballs untouched" do
+      binary_file.atomic_write "#!/bin/sh\n\x00#{dir}\x00"
+
+      keg.relocate_build_prefix(keg, dir, newdir)
+
+      expect(binary_file.binread).to include dir.to_s
+    end
+
+    specify "refuses a longer prefix before touching any file" do
+      setup_binary_file
+      original = binary_file.binread
+
+      expect { keg.relocate_build_prefix(keg, newdir, dir) }.to raise_error(ArgumentError, /longer/)
+      expect(binary_file.binread).to eq original
+    end
+
+    specify "re-signs patched files" do
+      setup_binary_file
+
+      expect(keg).to receive(:codesign_patched_binaries).with([binary_file])
+
+      keg.relocate_build_prefix(keg, dir, newdir)
+    end
+
+    specify "keeps suffix-merged references into ELF string tables valid" do
+      require "patchelf"
+      require "elftools"
+
+      elf = dir/"program"
+      FileUtils.cp TEST_FIXTURE_DIR/"elf/hello", elf
+      patcher = PatchELF::Patcher.new(elf.to_s, on_error: :silent)
+      patcher.rpath = "#{dir}/lib/x"
+      patcher.save(patchelf_compatible: true)
+      # Point DT_RPATH into the interior `lib/x`, as a tail-merging linker does.
+      value_offset = elf.open("rb") do |stream|
+        dynamic = ELFTools::ELFFile.new(stream).segment_by_type(:dynamic)
+        index = dynamic.tags.find_index { |tag| tag.header.d_tag.to_i == ELFTools::Constants::DT::DT_RPATH }
+        dynamic.header.p_offset.to_i + (index * 16) + 8
+      end
+      referenced = File.binread(elf, 8, value_offset).unpack1("Q<")
+      File.open(elf, "r+b") do |f|
+        f.seek(value_offset)
+        f.write([referenced + dir.to_s.length + 1].pack("Q<"))
+      end
+      suffix_offset = elf.binread.index("#{dir}/lib/x") + dir.to_s.length + 1
+
+      keg.relocate_build_prefix(keg, dir, newdir, files: [Pathname("program")])
+
+      separators = "/" * (dir.to_s.length - newdir.to_s.length + 1)
+      expect(elf.binread).to include "#{newdir}#{separators}lib/x\x00"
+      expect(File.binread(elf, 6, suffix_offset)).to eq "lib/x\x00"
+    end
+
+    specify "pads every occurrence with separators when offsets must be kept" do
+      string = "#{dir}/lib:#{dir}"
+      separators = "/" * (dir.to_s.length - newdir.to_s.length)
+
+      padded = described_class.replace_prefix_preserving_length(string, dir.to_s, newdir.to_s,
+                                                                preserve_suffix_offsets: true)
+
+      expect(padded).to eq "#{newdir}#{separators}/lib:#{newdir}#{separators}"
+    end
+
+    specify "falls back to null padding when an occurrence is not a path under the prefix" do
+      string = "#{dir}-extra:#{dir}/lib"
+      null_padding = "\x00" * ((dir.to_s.length - newdir.to_s.length) * 2)
+
+      padded = described_class.replace_prefix_preserving_length(string, dir.to_s, newdir.to_s,
+                                                                preserve_suffix_offsets: true)
+
+      expect(padded).to eq "#{newdir}-extra:#{newdir}/lib#{null_padding}"
     end
 
     specify "does not rewrite recorded files without the old prefix" do

--- a/Library/Homebrew/test/os/mac/keg_spec.rb
+++ b/Library/Homebrew/test/os/mac/keg_spec.rb
@@ -165,6 +165,27 @@ RSpec.describe Keg do
     end
   end
 
+  describe "#relocate_build_prefix" do
+    let(:keg_path) { HOMEBREW_CELLAR/"a/1.0" }
+    let(:file) { keg_path/"lib/libfoo.dylib" }
+
+    before do
+      file.dirname.mkpath
+      cp dylib_path("x86_64"), file
+      MachOPathname.wrap(file).change_install_name("/usr/lib/libSystem.B.dylib", "/old/pfx/libSys.B.dylib")
+      allow(keg).to receive(:codesign_patched_binaries)
+    end
+
+    after { keg.unlink }
+
+    it "patches prefix strings inside load commands" do
+      keg.relocate_build_prefix(keg, "/old/pfx", "/new", files: [Pathname("lib/libfoo.dylib")])
+
+      expect(MachOPathname.wrap(file).dynamically_linked_libraries(resolve_variable_references: false))
+        .to eq ["/new/libSys.B.dylib"]
+    end
+  end
+
   describe "#codesign_patched_binaries" do
     let(:keg_path) { HOMEBREW_CELLAR/"a/1.0" }
     let(:files) { [keg_path/"bin/a", keg_path/"bin/b"] }


### PR DESCRIPTION
- `Keg#relocate_build_prefix` NUL-pads raw prefix strings in pinned bottles at pour time but had no tests beyond one happy path; the hardening cases in the plan each get a spec, and three found bugs.
- Patching wrote the file atomically, giving it a new inode, so any hardlinked names kept the unpatched content. Files are now grouped by inode, patched once and re-linked afterwards, as text relocation already does.
- A prefix longer than the bottled one failed midway with a size mismatch after earlier files had already been rewritten; it is now refused up front.
- Linkers suffix-merge strings, so a dynamic string table entry can be referenced from its interior (`libfoo.so` inside `/old/prefix/libfoo.so`); trailing NUL padding shifted such references onto garbage. Strings with interior loader references are now padded with extra path separators after the prefix, which path resolution ignores, keeping every reference's offset valid. Other strings keep NUL padding.
- Also covered: several occurrences per string and several strings per file, the sharball skip, re-signing of patched files and prefix strings inside Mach-O load commands.

This change is part of [`plans/relocatable-bottles.md`](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/plans/relocatable-bottles.md)

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude with Fable at High effort, with local review and testing.

-----