### PR TITLE
Add tap protocol and host shorthands

### DIFF
--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -8,20 +8,30 @@ module Homebrew
   module Cmd
     class TapCmd < AbstractCommand
       cmd_args do
-        usage_banner "`tap` [<options>] [<user>`/`<repo>] [<URL>]"
+        usage_banner "`tap` [<options>] [<protocol>`:`][<host>`@`][<user>`/`<repo>] [<URL>]"
         description <<~EOS
-          Tap a formula repository.
+          Tap a repository containing formulae, casks, or external commands.
           If no arguments are provided, list all installed taps.
 
-          With <URL> unspecified, tap a formula repository from GitHub using HTTPS.
-          Since so many taps are hosted on GitHub, this command is a shortcut for
-          `brew tap` <user>`/`<repo> `https://github.com/`<user>`/homebrew-`<repo>.
+          With <host>`@`, <protocol>`:`, and <URL> unspecified, tap a repository from
+          GitHub using HTTPS. Since so many taps are hosted on GitHub, this command is
+          a shortcut for:
 
-          With <URL> specified, tap a formula repository from anywhere, using
-          any transport protocol that `git`(1) handles. The one-argument form of `tap`
-          simplifies but also limits. This two-argument command makes no
-          assumptions, so taps can be cloned from places other than GitHub and
-          using protocols other than HTTPS, e.g. SSH, git, HTTP, FTP(S), rsync.
+          `brew tap` <user>`/`<repo> `https://github.com/`<user>`/homebrew-`<repo>
+
+          With <host>`@` or <protocol>`:` specified, tap a repository from anywhere
+          using any transport protocol that `git`(1) handles (e.g. SSH, git, HTTP(S),
+          FTP(S), rsync). Using them is a shortcut for:
+
+          `brew tap` <user>`/`<repo> <protocol>`://`<host>`/`<user>`/homebrew-`<repo>
+
+          When SSH is the specified <protocol>`:`, this is instead a shortcut for:
+
+          `brew tap` <user>`/`<repo> `git@`<host>`:`<user>`/homebrew-`<repo>
+
+          With <URL> specified, tap a repository from anywhere, using any transport
+          protocol that `git`(1) handles. Unlike the one-argument form of `tap` which
+          simplifies things, the two-argument form makes no assumptions.
         EOS
         switch "--custom-remote",
                description: "Install or change a tap with a custom remote. Useful for mirrors."
@@ -56,7 +66,8 @@ module Homebrew
                         quiet:         args.quiet?,
                         verify:        args.eval_all?,
                         force:         args.force?
-          rescue Tap::InvalidNameError, TapRemoteMismatchError, TapNoCustomRemoteError => e
+          rescue Tap::InvalidNameError, Tap::InvalidShorthandError, TapRemoteMismatchError,
+                 TapNoCustomRemoteError => e
             odie e
           rescue TapAlreadyTappedError
             nil

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -48,29 +48,58 @@ class Tap
   ].freeze
 
   class InvalidNameError < ArgumentError; end
+  class InvalidShorthandError < ArgumentError; end
+
+  SHORTHAND_PROTOCOLS = %w[git ftps ftp https ssh].freeze
+  private_constant :SHORTHAND_PROTOCOLS
+  SHORTHANDS_REGEX = /(?:(?:(?<protocol>\w+):)?(?:(?<host>[A-Za-z0-9\-.]+)@)?)/
+  private_constant :SHORTHANDS_REGEX
+  SHORTHANDS_USER_REGEX = /^#{SHORTHANDS_REGEX.source}?(?<user>[\w\-.]+)$/
+  private_constant :SHORTHANDS_USER_REGEX
+  SHORTHANDS_NAME_REGEX = %r{^#{SHORTHANDS_REGEX.source}?(?<user>[\w\-.]+)/(?<repository>[\w\-.]+)$}
+  private_constant :SHORTHANDS_NAME_REGEX
 
   # Fetch a {Tap} by name.
   #
   # @api public
-  sig { params(user: String, repository: String).returns(Tap) }
-  def self.fetch(user, repository = T.unsafe(nil))
-    user, repository = user.split("/", 2) if repository.nil?
+  sig { params(user_or_name: String, repository: String).returns(Tap) }
+  def self.fetch(user_or_name, repository = T.unsafe(nil))
+    if repository.nil? && (match = user_or_name.match(SHORTHANDS_NAME_REGEX))
+      protocol = match[:protocol]
+      host = match[:host]
+      user = match[:user]
+      repository = match[:repository]
+    elsif (match = user_or_name.match(SHORTHANDS_USER_REGEX))
+      protocol = match[:protocol]
+      host = match[:host]
+      user = match[:user]
+    end
+
+    if !protocol.nil? && SHORTHAND_PROTOCOLS.exclude?(protocol)
+      raise InvalidShorthandError,
+            "Invalid protocol shorthand. The accepted values are: #{SHORTHAND_PROTOCOLS.join(", ")}"
+    end
 
     if [user, repository].any? { |part| part.nil? || part.include?("/") }
-      raise InvalidNameError, "Invalid tap name: '#{[*user, *repository].join("/")}'"
+      raise InvalidNameError, "Invalid tap name: '#{[*user_or_name, *repository].join("/")}'"
     end
 
     user = T.must(user)
+    repository = T.cast(repository, String)
 
     # We special case homebrew and linuxbrew so that users don't have to shift in a terminal.
     user = user.capitalize if ["homebrew", "linuxbrew"].include?(user)
     repository = repository.sub(HOMEBREW_OFFICIAL_REPO_PREFIXES_REGEX, "")
 
+    # Downcase protocol and host if they have been declared
+    protocol = protocol.downcase unless protocol.nil?
+    host = host.downcase unless host.nil?
+
     return CoreTap.instance if ["Homebrew", "Linuxbrew"].include?(user) && ["core", "homebrew"].include?(repository)
     return CoreCaskTap.instance if user == "Homebrew" && repository == "cask"
 
     cache_key = "#{user}/#{repository}".downcase
-    cache.fetch(cache_key) { |key| cache[key] = new(user, repository) }
+    cache.fetch(cache_key) { |key| cache[key] = new(protocol, host, user, repository) }
   end
 
   # Get a {Tap} from its path or a path inside of it.
@@ -142,7 +171,7 @@ class Tap
   # Hosts where a `.git` suffix and trailing slashes are known not to change which repository a
   # remote identifies, so we can safely strip them. We don't assume this for arbitrary hosts
   # (including self-hosted GitLab and GitHub Enterprise) where `repo.git` and `repo` may differ.
-  NORMALIZE_REMOTE_HOSTS = %w[github.com gitlab.com].freeze
+  NORMALIZE_REMOTE_HOSTS = %w[codeberg.org github.com gitlab.com].freeze
 
   # An optional RFC 3986-ish `scheme://` (e.g. `https://`, `ssh://` or `git+https://`) followed by
   # optional `user@` userinfo: the part of a remote URL that can precede the host.
@@ -234,6 +263,18 @@ class Tap
     include Enumerable
   end
 
+  # The protocol used to fetch this {Tap}'s remote repository.
+  #
+  # @api public
+  sig { returns(T.nilable(String)) }
+  attr_reader :protocol
+
+  # The host of this {Tap}'s remote repository.
+  #
+  # @api public
+  sig { returns(T.nilable(String)) }
+  attr_reader :host
+
   # The user name of this {Tap}. Usually, it's the GitHub username of
   # this {Tap}'s remote repository.
   #
@@ -289,10 +330,12 @@ class Tap
   # Always use `Tap.fetch` instead of `Tap.new`.
   private_class_method :new
 
-  sig { params(user: String, repository: String).void }
-  def initialize(user, repository)
+  sig { params(protocol: T.nilable(String), host: T.nilable(String), user: String, repository: String).void }
+  def initialize(protocol, host, user, repository)
     require "git_repository"
 
+    @protocol = protocol
+    @host = host
     @user = user
     @repository = repository
     @name = T.let("#{@user}/#{@repository}".downcase, String)
@@ -401,6 +444,19 @@ class Tap
     return unless (match = remote.match(HOMEBREW_TAP_REPOSITORY_REGEX))
 
     @remote_repository ||= T.let(T.must(match[:remote_repository]), T.nilable(String))
+  end
+
+  # The remote path to this {Tap} when using the shorthand notations.
+  sig { returns(T.nilable(String)) }
+  def shorthand_remote
+    case [protocol, host]
+    when [nil, nil] then nil
+    when ["ssh", nil] then "git@github.com:#{full_name}"
+    when [protocol, nil] then "#{protocol}://github.com/#{full_name}"
+    when [nil, host] then "https://#{host}/#{full_name}"
+    when ["ssh", host] then "git@#{host}:#{full_name}"
+    when [protocol, host] then "#{protocol}://#{host}/#{full_name}"
+    end
   end
 
   # The default remote path to this {Tap}.
@@ -578,6 +634,8 @@ class Tap
       FileUtils.mv(old_path, redirected_tap.path)
       old_path.parent.rmdir_if_possible
 
+      @protocol = redirected_tap.protocol
+      @host = redirected_tap.host
       @user = redirected_tap.user
       @repository = redirected_tap.repository
       @name = redirected_tap.name
@@ -650,7 +708,7 @@ class Tap
 
     raise TapNoCustomRemoteError, name if custom_remote && clone_target.nil?
 
-    requested_remote = (clone_target || default_remote).to_s
+    requested_remote = (clone_target || shorthand_remote || default_remote).to_s
 
     if installed? && !custom_remote
       raise TapRemoteMismatchError.new(name, @remote, requested_remote) if clone_target && requested_remote != remote
@@ -1187,6 +1245,8 @@ class Tap
     require "trust"
 
     hash = {
+      "protocol"      => protocol,
+      "host"          => host,
       "name"          => name,
       "user"          => user,
       "repo"          => repository,

--- a/Library/Homebrew/tap/core_cask_tap.rb
+++ b/Library/Homebrew/tap/core_cask_tap.rb
@@ -10,7 +10,7 @@ class CoreCaskTap < AbstractCoreTap
 
   sig { void }
   def initialize
-    super "Homebrew", "cask"
+    super nil, nil, "Homebrew", "cask"
   end
 
   sig { override.returns(T::Boolean) }

--- a/Library/Homebrew/tap/core_tap.rb
+++ b/Library/Homebrew/tap/core_tap.rb
@@ -10,7 +10,7 @@ class CoreTap < AbstractCoreTap
 
   sig { void }
   def initialize
-    super "Homebrew", "core"
+    super nil, nil, "Homebrew", "core"
   end
 
   sig { override.void }

--- a/Library/Homebrew/test/bundle/tap_spec.rb
+++ b/Library/Homebrew/test/bundle/tap_spec.rb
@@ -25,15 +25,16 @@ RSpec.describe Homebrew::Bundle::Tap do
       before do
         described_class.reset!
 
-        bar = instance_double(Tap, name: "bitbucket/bar", custom_remote?: true,
+        bar = instance_double(Tap, protocol: nil, host: nil, name: "bitbucket/bar", custom_remote?: true,
                               remote: "https://bitbucket.org/bitbucket/bar.git",
                               default_remote: "https://github.com/bitbucket/homebrew-bar")
-        baz = instance_double(Tap, name: "homebrew/baz", custom_remote?: false, remote: nil)
-        foo = instance_double(Tap, name: "homebrew/foo", custom_remote?: false, remote: nil)
+        baz = instance_double(Tap, protocol: nil, host: nil, name: "homebrew/baz", custom_remote?: false, remote: nil)
+        foo = instance_double(Tap, protocol: nil, host: nil, name: "homebrew/foo", custom_remote?: false, remote: nil)
 
         ENV["HOMEBREW_GITHUB_API_TOKEN_BEFORE"] = ENV.fetch("HOMEBREW_GITHUB_API_TOKEN", nil)
         ENV["HOMEBREW_GITHUB_API_TOKEN"] = "some-token"
-        private_tap = instance_double(Tap, name: "privatebrew/private", custom_remote?: true,
+        private_tap = instance_double(Tap, protocol: nil, host: nil, name: "privatebrew/private",
+          custom_remote?: true,
           remote: "https://#{ENV.fetch("HOMEBREW_GITHUB_API_TOKEN")}@github.com/privatebrew/homebrew-private",
           default_remote: "https://github.com/privatebrew/homebrew-private")
 
@@ -75,7 +76,7 @@ RSpec.describe Homebrew::Bundle::Tap do
 
       it "dumps GitHub clone targets matching a tap's default repository" do
         described_class.reset!
-        tap = instance_double(Tap, name: "alternatert/tap", custom_remote?: false,
+        tap = instance_double(Tap, protocol: nil, host: nil, name: "alternatert/tap", custom_remote?: false,
           remote: "git@github.com:AlternateRT/homebrew-tap.git",
           default_remote: "https://github.com/alternatert/homebrew-tap")
 

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -101,6 +101,10 @@ RSpec.describe Tap do
     tap = described_class.fetch("Homebrew", "foo")
     expect(tap).to be_a(described_class)
     expect(tap.name).to eq("homebrew/foo")
+    tap_shorthand = described_class.fetch("ssh:gitlab.com@Homebrew/bar")
+    expect(tap_shorthand.protocol).to eq("ssh")
+    expect(tap_shorthand.host).to eq("gitlab.com")
+    expect(tap_shorthand.name).to eq("homebrew/bar")
 
     expect do
       described_class.fetch("foo")
@@ -113,6 +117,18 @@ RSpec.describe Tap do
     expect do
       described_class.fetch("homebrew", "homebrew/baz")
     end.to raise_error(Tap::InvalidNameError, /Invalid tap name/)
+
+    expect do
+      described_class.fetch("s-sh:homebrew/baz")
+    end.to raise_error(Tap::InvalidNameError, /Invalid tap name/)
+
+    expect do
+      described_class.fetch("git_hub.com@homebrew/baz")
+    end.to raise_error(Tap::InvalidNameError, /Invalid tap name/)
+
+    expect do
+      described_class.fetch("http:homebrew/baz")
+    end.to raise_error(Tap::InvalidShorthandError, /Invalid protocol shorthand/)
   end
 
   describe "::from_path" do
@@ -212,9 +228,19 @@ RSpec.describe Tap do
                                           "https://gitlab.com/other/repo")).to be true
     end
 
+    it "ignores a `.git` suffix on Codeberg remotes" do
+      expect(described_class.same_remote?("https://codeberg.org/other/repo.git",
+                                          "https://codeberg.org/other/repo")).to be true
+    end
+
     it "ignores a trailing slash on GitLab remotes" do
       expect(described_class.same_remote?("https://gitlab.com/other/repo/",
                                           "https://gitlab.com/other/repo")).to be true
+    end
+
+    it "ignores a trailing slash on Codeberg remotes" do
+      expect(described_class.same_remote?("https://codeberg.org/other/repo/",
+                                          "https://codeberg.org/other/repo")).to be true
     end
 
     it "keeps a `.git` suffix and trailing slash significant on a self-hosted remote" do
@@ -352,6 +378,8 @@ RSpec.describe Tap do
   end
 
   specify "attributes" do
+    expect(homebrew_foo_tap.protocol).to be_nil
+    expect(homebrew_foo_tap.host).to be_nil
     expect(homebrew_foo_tap.user).to eq("Homebrew")
     expect(homebrew_foo_tap.repository).to eq("foo")
     expect(homebrew_foo_tap.name).to eq("homebrew/foo")
@@ -404,6 +432,8 @@ RSpec.describe Tap do
     expect(homebrew_foo_tap.command_files).to eq([cmd_file])
     expect(homebrew_foo_tap.to_hash).to eq(
       {
+        "protocol"      => nil,
+        "host"          => nil,
         "name"          => "homebrew/foo",
         "user"          => "Homebrew",
         "repo"          => "foo",
@@ -504,6 +534,38 @@ RSpec.describe Tap do
       setup_git_repo
       allow(Utils::Git).to receive(:available?).and_return(false)
       expect(homebrew_foo_tap.remote_repository).to eq("Homebrew/homebrew-foo")
+    end
+  end
+
+  describe "#shorthand_remote" do
+    it "returns an SCP remote when SSH is the specified protocol" do
+      tap = described_class.fetch("ssh:third-party/foo")
+      expect(tap.shorthand_remote).to eq("git@github.com:third-party/homebrew-foo")
+    end
+
+    it "returns a remote with the specified protocol" do
+      tap = described_class.fetch("https:third-party/foo")
+      expect(tap.shorthand_remote).to eq("https://github.com/third-party/homebrew-foo")
+    end
+
+    it "returns a remote with the specified host" do
+      tap = described_class.fetch("codeberg.org@third-party/foo")
+      expect(tap.shorthand_remote).to eq("https://codeberg.org/third-party/homebrew-foo")
+    end
+
+    it "returns an SCP remote with the specified host when SSH is the specified protocol" do
+      tap = described_class.fetch("ssh:codeberg.org@third-party/foo")
+      expect(tap.shorthand_remote).to eq("git@codeberg.org:third-party/homebrew-foo")
+    end
+
+    it "returns a remote with the specified protocol and host" do
+      tap = described_class.fetch("https:codeberg.org@third-party/foo")
+      expect(tap.shorthand_remote).to eq("https://codeberg.org/third-party/homebrew-foo")
+    end
+
+    it "returns nil when no protocol or host has been specified" do
+      tap = described_class.fetch("third-party/foo")
+      expect(tap.shorthand_remote).to be_nil
     end
   end
 
@@ -1372,6 +1434,8 @@ RSpec.describe Tap do
     subject(:core_tap) { described_class.instance }
 
     specify "attributes" do
+      expect(core_tap.protocol).to be_nil
+      expect(core_tap.host).to be_nil
       expect(core_tap.user).to eq("Homebrew")
       expect(core_tap.repository).to eq("core")
       expect(core_tap.name).to eq("homebrew/core")

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -1878,7 +1878,7 @@ __fish_brew_complete_arg 'tab; and not __fish_seen_argument -l cask -l casks' -a
 __fish_brew_complete_arg 'tab; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_installed)'
 
 
-__fish_brew_complete_cmd 'tap' 'Tap a formula repository'
+__fish_brew_complete_cmd 'tap' 'Tap a repository containing formulae, casks, or external commands'
 __fish_brew_complete_arg 'tap' -l custom-remote -d 'Install or change a tap with a custom remote. Useful for mirrors'
 __fish_brew_complete_arg 'tap' -l debug -d 'Display any debugging information'
 __fish_brew_complete_arg 'tap' -l force -d 'Force install core taps even under API mode'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -240,7 +240,7 @@ __brew_internal_commands() {
     'source:Open a formula'\''s source repository in a browser, or open Homebrew'\''s own repository if no argument is provided'
     'style:Check formulae or files for conformance to Homebrew style guidelines'
     'tab:Edit tab information for installed formulae or casks'
-    'tap:Tap a formula repository'
+    'tap:Tap a repository containing formulae, casks, or external commands'
     'tap-info:Show detailed information about one or more taps'
     'tap-new:Generate the template files for a new tap'
     'test:Run the test method provided by an installed formula'

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -2164,19 +2164,31 @@ request.
 
 : Only mark casks.
 
-### `tap` \[*`options`*\] \[*`user`*`/`*`repo`*\] \[*`URL`*\]
+### `tap` \[*`options`*\] \[*`protocol`*`:`\]\[*`host`*`@`\]\[*`user`*`/`*`repo`*\] \[*`URL`*\]
 
-Tap a formula repository. If no arguments are provided, list all installed taps.
+Tap a repository containing formulae, casks, or external commands. If no
+arguments are provided, list all installed taps.
 
-With *`URL`* unspecified, tap a formula repository from GitHub using HTTPS.
-Since so many taps are hosted on GitHub, this command is a shortcut for `brew
-tap` *`user`*`/`*`repo`* `https://github.com/`*`user`*`/homebrew-`*`repo`*.
+With *`host`*`@`, *`protocol`*`:`, and *`URL`* unspecified, tap a repository
+from GitHub using HTTPS. Since so many taps are hosted on GitHub, this command
+is a shortcut for:
 
-With *`URL`* specified, tap a formula repository from anywhere, using any
-transport protocol that `git`(1) handles. The one-argument form of `tap`
-simplifies but also limits. This two-argument command makes no assumptions, so
-taps can be cloned from places other than GitHub and using protocols other than
-HTTPS, e.g. SSH, git, HTTP, FTP(S), rsync.
+`brew tap` *`user`*`/`*`repo`* `https://github.com/`*`user`*`/homebrew-`*`repo`*
+
+With *`host`*`@` or *`protocol`*`:` specified, tap a repository from anywhere
+using any transport protocol that `git`(1) handles (e.g. SSH, git, HTTP(S),
+FTP(S), rsync). Using them is a shortcut for:
+
+`brew tap` *`user`*`/`*`repo`*
+*`protocol`*`://`*`host`*`/`*`user`*`/homebrew-`*`repo`*
+
+When SSH is the specified *`protocol`*`:`, this is instead a shortcut for:
+
+`brew tap` *`user`*`/`*`repo`* `git@`*`host`*`:`*`user`*`/homebrew-`*`repo`*
+
+With *`URL`* specified, tap a repository from anywhere, using any transport
+protocol that `git`(1) handles. Unlike the one-argument form of `tap` which
+simplifies things, the two-argument form makes no assumptions.
 
 `--custom-remote`
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1371,12 +1371,22 @@ Only mark formulae\.
 .TP
 \fB\-\-cask\fP
 Only mark casks\.
-.SS "\fBtap\fP \fR[\fIoptions\fP] \fR[\fIuser\fP\fB/\fP\fIrepo\fP] \fR[\fIURL\fP]"
-Tap a formula repository\. If no arguments are provided, list all installed taps\.
+.SS "\fBtap\fP \fR[\fIoptions\fP] \fR[\fIprotocol\fP\fB:\fP][\fIhost\fP\fB@\fP][\fIuser\fP\fB/\fP\fIrepo\fP] \fR[\fIURL\fP]"
+Tap a repository containing formulae, casks, or external commands\. If no arguments are provided, list all installed taps\.
 .P
-With \fIURL\fP unspecified, tap a formula repository from GitHub using HTTPS\. Since so many taps are hosted on GitHub, this command is a shortcut for \fBbrew tap\fP \fIuser\fP\fB/\fP\fIrepo\fP \fBhttps://github\.com/\fP\fIuser\fP\fB/homebrew\-\fP\fIrepo\fP\&\.
+With \fIhost\fP\fB@\fP, \fIprotocol\fP\fB:\fP, and \fIURL\fP unspecified, tap a repository from GitHub using HTTPS\. Since so many taps are hosted on GitHub, this command is a shortcut for:
 .P
-With \fIURL\fP specified, tap a formula repository from anywhere, using any transport protocol that \fBgit\fP(1) handles\. The one\-argument form of \fBtap\fP simplifies but also limits\. This two\-argument command makes no assumptions, so taps can be cloned from places other than GitHub and using protocols other than HTTPS, e\.g\. SSH, git, HTTP, FTP(S), rsync\.
+\fBbrew tap\fP \fIuser\fP\fB/\fP\fIrepo\fP \fBhttps://github\.com/\fP\fIuser\fP\fB/homebrew\-\fP\fIrepo\fP
+.P
+With \fIhost\fP\fB@\fP or \fIprotocol\fP\fB:\fP specified, tap a repository from anywhere using any transport protocol that \fBgit\fP(1) handles (e\.g\. SSH, git, HTTP(S), FTP(S), rsync)\. Using them is a shortcut for:
+.P
+\fBbrew tap\fP \fIuser\fP\fB/\fP\fIrepo\fP \fIprotocol\fP\fB://\fP\fIhost\fP\fB/\fP\fIuser\fP\fB/homebrew\-\fP\fIrepo\fP
+.P
+When SSH is the specified \fIprotocol\fP\fB:\fP, this is instead a shortcut for:
+.P
+\fBbrew tap\fP \fIuser\fP\fB/\fP\fIrepo\fP \fBgit@\fP\fIhost\fP\fB:\fP\fIuser\fP\fB/homebrew\-\fP\fIrepo\fP
+.P
+With \fIURL\fP specified, tap a repository from anywhere, using any transport protocol that \fBgit\fP(1) handles\. Unlike the one\-argument form of \fBtap\fP which simplifies things, the two\-argument form makes no assumptions\.
 .TP
 \fB\-\-custom\-remote\fP
 Install or change a tap with a custom remote\. Useful for mirrors\.


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

## What

This tweaks `Tap#fetch` and `Tap#initialize` so they can parse `<protocol>:` and `<host>@` as shorthand notations on a tap's name; it introduces `Tap#shorthand_remote` to autogenerate the remote URL from them when using `brew tap` or `brew install`.

## Why

This started with a desire to tap repositories (on GitHub) via SSH more quickly, but as I began working on it, I figured it could be generalised for any protocol and host.

As it is well known, naming a repository `homebrew-<repository>` is recommended to be able to use the one-argument form of `brew tap`. Unfortunately, this convention becomes moot if you want to tap via SSH (as is often the case with private taps), so you end up needing to use the two-argument form anyways.

In addition to that, I noticed that taps hosted elsewhere (such as GitLab or Codeberg) often follow the convention even though they can't take advantage of the one-argument form of `brew tap`.

This is where the shorthand notations come into play. Since almost everyone likes to follow the naming convention anyhow, the shorthands can be used to parametrise the protocol and host parts of the URL.

Thus, only the more exotic cases require using the two-argument form of `brew tap` - i.e. repositories using non-conventional repository names and hosts that store their repositories with a different folder structure.

## Usage

With these changes, instead of running:

```sh
brew tap foo/tap git@github.com:foo/homebrew-tap
brew install foo/tap/package
brew tap bar/tap https://codeberg.org/bar/homebrew-tap
brew install bar/tap/package
brew tap baz/tap git@gitlab.com:baz/homebrew-tap
brew install baz/tap/package
brew tap qux/tap http://git.example.com/qux/homebrew-tap
...
brew install qux/tap/package
```

You can just run:

```sh
brew install ssh:foo/tap/package
brew install codeberg.org@bar/tap/package
brew install ssh:gitlab.com@baz/tap/package
brew tap http:git.example.com@qux/tap
...
brew install qux/tap/package
```

The shorthand notations are a no-op if the two-argument form of `brew tap` is used or if the repository has already been tapped.