### PR TITLE
Drop macOS Intel CI in Homebrew/core

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -11,7 +11,6 @@ class GitHubRunnerMatrix
   # to allow people to jump to specific commits based on their macOS version.
   NEWEST_HOMEBREW_CORE_MACOS_RUNNER = :tahoe
   OLDEST_HOMEBREW_CORE_MACOS_RUNNER = :sonoma
-  NEWEST_HOMEBREW_CORE_INTEL_MACOS_RUNNER = :sonoma
 
   RunnerSpec = T.type_alias { T.any(LinuxRunnerSpec, MacOSRunnerSpec) }
   private_constant :RunnerSpec
@@ -137,7 +136,7 @@ class GitHubRunnerMatrix
         ["#{version}-arm64", @runner_timeout]
       end
 
-      # We test recursive dependents on ARM macOS, so they can be slower than our Intel runners.
+      # Testing recursive dependents takes longer, so give those jobs two hours.
       timeout *= 2 if @dependent_matrix && timeout < GITHUB_ACTIONS_RUNNER_TIMEOUT
       spec = MacOSRunnerSpec.new(
         name:    "macOS #{version}-arm64",
@@ -146,35 +145,6 @@ class GitHubRunnerMatrix
         cleanup: !runner.end_with?(ephemeral_suffix),
       )
       @runners << create_runner(:macos, :arm64, spec, macos_version)
-
-      skip_intel_runner = !@all_supported && macos_version > NEWEST_HOMEBREW_CORE_INTEL_MACOS_RUNNER
-      skip_intel_runner &&= @dependent_matrix || @testing_formulae.none? do |testing_formula|
-        bottle_spec = testing_formula.formula.bottle_specification
-        bottle_spec.tag?(Utils::Bottles.tag(macos_version.to_sym), no_older_versions: true) &&
-          !bottle_spec.tag?(Utils::Bottles.tag(:all), no_older_versions: true)
-      end
-      next if skip_intel_runner
-
-      github_runner_available = macos_version.between?(OLDEST_GITHUB_ACTIONS_INTEL_MACOS_RUNNER,
-                                                       NEWEST_GITHUB_ACTIONS_INTEL_MACOS_RUNNER)
-
-      runner, timeout = if use_github_runner && github_runner_available
-        ["macos-#{version}", GITHUB_ACTIONS_RUNNER_TIMEOUT]
-      else
-        ["#{version}-x86_64#{ephemeral_suffix}", @runner_timeout]
-      end
-
-      # macOS 12-x86_64 is usually slower.
-      timeout += 30 if macos_version <= :monterey
-      # The ARM runners are typically over twice as fast as the Intel runners.
-      timeout *= 2 if !(use_github_runner && github_runner_available) && timeout < GITHUB_ACTIONS_LONG_TIMEOUT
-      spec = MacOSRunnerSpec.new(
-        name:    "macOS #{version}-x86_64",
-        runner:,
-        timeout:,
-        cleanup: !runner.end_with?(ephemeral_suffix),
-      )
-      @runners << create_runner(:macos, :x86_64, spec, macos_version)
     end
 
     @runners.freeze
@@ -251,13 +221,10 @@ class GitHubRunnerMatrix
     end, T.nilable(String))
   end
 
-  NEWEST_GITHUB_ACTIONS_INTEL_MACOS_RUNNER = :ventura
-  OLDEST_GITHUB_ACTIONS_INTEL_MACOS_RUNNER = :ventura
   NEWEST_GITHUB_ACTIONS_ARM_MACOS_RUNNER = :tahoe
   OLDEST_GITHUB_ACTIONS_ARM_MACOS_RUNNER = :sonoma
   GITHUB_ACTIONS_RUNNER_TIMEOUT = 360
-  private_constant :NEWEST_GITHUB_ACTIONS_INTEL_MACOS_RUNNER, :OLDEST_GITHUB_ACTIONS_INTEL_MACOS_RUNNER,
-                   :NEWEST_GITHUB_ACTIONS_ARM_MACOS_RUNNER, :OLDEST_GITHUB_ACTIONS_ARM_MACOS_RUNNER,
+  private_constant :NEWEST_GITHUB_ACTIONS_ARM_MACOS_RUNNER, :OLDEST_GITHUB_ACTIONS_ARM_MACOS_RUNNER,
                    :GITHUB_ACTIONS_RUNNER_TIMEOUT
 
   sig { params(runner: GitHubRunner).returns(T::Array[String]) }

--- a/Library/Homebrew/test/dev-cmd/determine-test-runners_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/determine-test-runners_spec.rb
@@ -37,9 +37,6 @@ RSpec.describe Homebrew::DevCmd::DetermineTestRunners do
       next if macos_version > GitHubRunnerMatrix::NEWEST_HOMEBREW_CORE_MACOS_RUNNER
 
       out << "#{v}-arm64"
-      next if macos_version > GitHubRunnerMatrix::NEWEST_HOMEBREW_CORE_INTEL_MACOS_RUNNER
-
-      out << "#{v}-x86_64"
     end
 
     out << linux_runner


### PR DESCRIPTION
macOS 14 Intel has been having serious issues and we'd planned to stop bottling for it in September. Pulling that forward now.

Sonoma was our only Intel bottling target, so this removes Intel from the Homebrew/core runner matrix entirely. Existing Intel bottles stay installable, and new or updated formulae will build from source on Intel. `portable-ruby` still builds on the 10.15-cross x86_64 runner, so `brew` itself keeps working there.

Reducing Intel to Tier 3 in the documentation and `brew doctor` will follow in a separate pull request.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation; I reviewed the diff and ran `brew lgtm` plus the `github_runner_matrix` and `determine-test-runners` specs.

-----
