### PR TITLE
Reduce Intel macOS to Tier 3

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -135,16 +135,34 @@ module OS
           tier = 2
           who = +"We"
           remediation = nil
-          what = if OS::Mac.version.prerelease?
-            "pre-release version."
-          elsif OS::Mac.version.outdated_release?
+          version = MacOS.version
+          macports_url = Formatter.url("https://www.macports.org")
+          what = if OS::Mac.version.outdated_release?
             tier = 3
             who << " (and Apple)"
             remediation = <<~EOS
-              You may have better luck with MacPorts which supports older versions of macOS:
-              #{Formatter.url("https://www.macports.org")}
+              You will have better luck with MacPorts which still supports older versions of macOS:
+                #{macports_url}
             EOS
             "old version."
+          elsif ::Hardware::CPU.intel?
+            tier = 3
+            version = "on Intel x86_64"
+            remediation = <<~EOS
+              You will have better luck with MacPorts which still supports macOS Intel x86_64:
+                #{macports_url}
+            EOS
+            <<~EOS
+              platform (as-of September 2026, announced August 2025).
+
+              Apple have dropped Intel x86_64 support in macOS Golden Gate (27).
+              GitHub Actions are dropping macOS Intel x86_64 runners in 2027.
+              Homebrew is a non-profit project run entirely by volunteers, not employees.
+              If the biggest companies in the world cannot support macOS Intel x86_64
+              any longer, sadly neither can we.
+            EOS
+          elsif OS::Mac.version.prerelease?
+            "pre-release version."
           end
           return if what.blank?
 
@@ -152,41 +170,11 @@ module OS
 
           ::Homebrew::Diagnostic::Finding.new(
             <<~EOS,
-              You are using macOS #{MacOS.version}.
-              #{who} do not provide support for this #{what}
+              You are using macOS #{version}.
+              #{who} do not provide support for this #{what.chomp}
             EOS
             remediation:,
             tier:,
-          )
-        end
-
-        sig { returns(T.nilable(::Homebrew::Diagnostic::Finding)) }
-        def check_for_opencore
-          return if ::Hardware::CPU.physical_cpu_arm64?
-
-          # https://dortania.github.io/OpenCore-Legacy-Patcher/UPDATE.html#checking-oclp-and-opencore-versions
-          begin
-            opencore_version = Utils.safe_popen_read("/usr/sbin/nvram",
-                                                     "4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:opencore-version").split[1]
-            oclp_version = Utils.safe_popen_read("/usr/sbin/nvram",
-                                                 "4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:OCLP-Version").split[1]
-            return if opencore_version.blank? || oclp_version.blank?
-          rescue ErrorDuringExecution
-            return
-          end
-
-          oclp_support_tier = if ::Hardware::CPU.features.include?(:pclmulqdq) && !OS::Mac.version.outdated_release?
-            2
-          else
-            3
-          end
-
-          ::Homebrew::Diagnostic::Finding.new(
-            <<~EOS,
-              You have booted macOS using OpenCore Legacy Patcher.
-              We do not provide support for this configuration.
-            EOS
-            tier: oclp_support_tier,
           )
         end
 

--- a/Library/Homebrew/extend/os/mac/formula_installer.rb
+++ b/Library/Homebrew/extend/os/mac/formula_installer.rb
@@ -10,7 +10,9 @@ module OS
 
       sig { params(formula: Formula).returns(T.nilable(T::Boolean)) }
       def fresh_install?(formula)
-        !::Homebrew::EnvConfig.developer? && !OS::Mac.version.outdated_release? &&
+        ::Hardware::CPU.arm? &&
+          !::Homebrew::EnvConfig.developer? &&
+          !OS::Mac.version.outdated_release? &&
           (installed_on_request? || !formula.any_version_installed?)
       end
     end

--- a/Library/Homebrew/os.rb
+++ b/Library/Homebrew/os.rb
@@ -109,11 +109,11 @@ module OS
     # Don't tell people to report issues on non-Tier 1 configurations.
     if nix_managed_homebrew
       ISSUES_URL = OS.nix_managed_homebrew_issues_url.freeze
-    elsif !OS::Mac.version.prerelease? &&
+    elsif Hardware::CPU.arm? &&
+          !OS::Mac.version.prerelease? &&
           !OS::Mac.version.outdated_release? &&
           ARGV.none? { |v| v.start_with?("--cc=") } &&
-          (HOMEBREW_PREFIX.to_s == HOMEBREW_DEFAULT_PREFIX ||
-          (HOMEBREW_PREFIX.to_s == HOMEBREW_MACOS_ARM_DEFAULT_PREFIX && Hardware::CPU.arm?))
+          HOMEBREW_PREFIX.to_s == HOMEBREW_MACOS_ARM_DEFAULT_PREFIX
       ISSUES_URL = "https://docs.brew.sh/Troubleshooting"
     end
     PATH_OPEN = "/usr/bin/open"

--- a/Library/Homebrew/plans/relocatable-bottles.md
+++ b/Library/Homebrew/plans/relocatable-bottles.md
@@ -5,8 +5,8 @@
 Every Homebrew/core bottle pours at every prefix under 65 characters long.
 
 - This applies on x86_64 Linux, arm64 Linux and arm64 macOS; longer prefixes
-  build from source. Intel macOS keeps its legacy `/usr/local` bottling
-  until EOL and is out of scope.
+  build from source. Intel macOS is out of scope: Homebrew/core no longer
+  builds Intel bottles outside the portable Ruby toolchain.
 - It includes today's non-relocatable (cellar-pinned) bottles, i.e. those
   that are neither `cellar :any` nor `cellar :any_skip_relocation`. The
   padded-prefix scheme below handles most of them; the residual classes in

--- a/Library/Homebrew/test/os/mac/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/mac/diagnostic_spec.rb
@@ -6,50 +6,49 @@ require "diagnostic"
 RSpec.describe Homebrew::Diagnostic::Checks do
   subject(:checks) { described_class.new }
 
-  specify "#check_for_unsupported_macos" do
-    ENV.delete("HOMEBREW_DEVELOPER")
-
-    macos_version = MacOSVersion.new("30")
-    allow(OS::Mac).to receive_messages(version: macos_version, full_version: macos_version)
-    allow(OS::Mac.version).to receive_messages(outdated_release?: false, prerelease?: true)
-
-    expect(checks.check_for_unsupported_macos&.to_s)
-      .to match("We do not provide support for this pre-release version.")
-  end
-
-  describe "#check_for_opencore" do
-    let(:macos_version) { MacOSVersion.new("13") }
-
+  describe "#check_for_unsupported_macos" do
     before do
+      ENV.delete("HOMEBREW_DEVELOPER")
+    end
+
+    it "reports Tier 2 for a pre-release macOS version on Apple Silicon" do
+      macos_version = MacOSVersion.new("30")
+      allow(Hardware::CPU).to receive(:intel?).and_return(false)
       allow(OS::Mac).to receive_messages(version: macos_version, full_version: macos_version)
-      allow(Hardware::CPU).to receive(:physical_cpu_arm64?).and_return(false)
-      allow(Utils).to receive(:safe_popen_read)
-        .with("/usr/sbin/nvram", "4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:opencore-version")
-        .and_return("opencore-version\t1.0.0")
-      allow(Utils).to receive(:safe_popen_read)
-        .with("/usr/sbin/nvram", "4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:OCLP-Version")
-        .and_return("OCLP-Version\t2.0.0")
+      allow(OS::Mac.version).to receive_messages(outdated_release?: false, prerelease?: true)
+
+      finding = checks.check_for_unsupported_macos
+      expect(finding).to have_attributes(
+        tier: 2,
+        text: match("We do not provide support for this pre-release version."),
+      )
     end
 
-    it "reports Tier 2 on a modern CPU running a supported macOS" do
-      allow(Hardware::CPU).to receive(:features).and_return([:pclmulqdq])
-      allow(macos_version).to receive(:outdated_release?).and_return(false)
+    it "reports Tier 3 on Intel macOS" do
+      macos_version = MacOSVersion.new("26")
+      allow(Hardware::CPU).to receive(:intel?).and_return(true)
+      allow(OS::Mac).to receive_messages(version: macos_version, full_version: macos_version)
+      allow(OS::Mac.version).to receive_messages(outdated_release?: false, prerelease?: false)
 
-      expect(checks.check_for_opencore&.tier).to eq 2
+      finding = checks.check_for_unsupported_macos
+      expect(finding).to have_attributes(
+        tier: 3,
+        text: match("We do not provide support for this platform"),
+      )
     end
 
-    it "reports Tier 3 on an old CPU" do
-      allow(Hardware::CPU).to receive(:features).and_return([])
-      allow(macos_version).to receive(:outdated_release?).and_return(false)
+    it "preserves the remediation for outdated macOS on Intel" do
+      macos_version = MacOSVersion.new("13")
+      allow(Hardware::CPU).to receive(:intel?).and_return(true)
+      allow(OS::Mac).to receive_messages(version: macos_version, full_version: macos_version)
+      allow(OS::Mac.version).to receive_messages(outdated_release?: true, prerelease?: false)
 
-      expect(checks.check_for_opencore&.tier).to eq 3
-    end
-
-    it "reports Tier 3 on a modern CPU running an outdated macOS" do
-      allow(Hardware::CPU).to receive(:features).and_return([:pclmulqdq])
-      allow(macos_version).to receive(:outdated_release?).and_return(true)
-
-      expect(checks.check_for_opencore&.tier).to eq 3
+      finding = checks.check_for_unsupported_macos
+      expect(finding).to have_attributes(
+        tier:        3,
+        text:        include("We (and Apple) do not provide support for this old version."),
+        remediation: have_attributes(text: include("MacPorts")),
+      )
     end
   end
 

--- a/Library/Homebrew/test/os/mac/formula_installer_spec.rb
+++ b/Library/Homebrew/test/os/mac/formula_installer_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe FormulaInstaller do
   describe "#fresh_install" do
     subject(:formula_installer) { described_class.new(Testball.new) }
 
+    before do
+      allow(Hardware::CPU).to receive(:arm?).and_return(true)
+    end
+
     it "is true when non-developer and non-outdated" do
       formula = Testball.new
       allow(Homebrew::EnvConfig).to receive_messages(developer?: false)
@@ -28,6 +32,14 @@ RSpec.describe FormulaInstaller do
       formula = Testball.new
       allow(Homebrew::EnvConfig).to receive_messages(developer?: false)
       allow(OS::Mac.version).to receive_messages(outdated_release?: true)
+      expect(formula_installer.fresh_install?(formula)).to be false
+    end
+
+    it "is false on Intel" do
+      formula = Testball.new
+      allow(Hardware::CPU).to receive(:arm?).and_return(false)
+      allow(Homebrew::EnvConfig).to receive_messages(developer?: false)
+      allow(OS::Mac.version).to receive_messages(outdated_release?: false)
       expect(formula_installer.fresh_install?(formula)).to be false
     end
   end

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -1,12 +1,12 @@
 ---
-last_review_date: "2025-09-12"
+last_review_date: "2026-08-27"
 ---
 
 # Installation
 
 Instructions for a supported install of Homebrew are on the [homepage](https://brew.sh/).
 
-The script installs Homebrew to its default, supported, best prefix (`/opt/homebrew` for Apple Silicon, `/usr/local` for macOS Intel and `/home/linuxbrew/.linuxbrew` for Linux) so that [you don’t need *sudo* after Homebrew's initial installation](FAQ.md#why-does-homebrew-say-sudo-is-bad) when you `brew install`. This prefix is required for most bottles (binary packages) to be used. It is a careful script; it can be run even if you have stuff installed in the preferred prefix already. It tells you exactly what it will do before it does it too. You have to confirm everything it will do before it starts.
+The script installs Homebrew to its default prefix (`/opt/homebrew` for Apple Silicon, `/usr/local` for macOS Intel and `/home/linuxbrew/.linuxbrew` for Linux) so that [you don’t need *sudo* after Homebrew's initial installation](FAQ.md#why-does-homebrew-say-sudo-is-bad) when you `brew install`. This prefix is required for most bottles (binary packages) to be used. It is a careful script; it can be run even if you have stuff installed in the preferred prefix already. It tells you exactly what it will do before it does it too. You have to confirm everything it will do before it starts.
 
 The macOS `.pkg` installer also installs Homebrew to its default prefix (`/opt/homebrew` for Apple Silicon and `/usr/local` for macOS Intel) for the same reasons as above.
 It is available on [Homebrew/brew's latest GitHub release](https://github.com/Homebrew/brew/releases/latest).
@@ -25,7 +25,7 @@ The installer ignores an override that does not meet these requirements and fall
 
 ## macOS requirements
 
-* An Apple Silicon CPU or 64-bit Intel CPU <sup>[1](#1)</sup>
+* An Apple Silicon CPU; using a 64-bit Intel CPU is a [Tier 3](Support-Tiers.md#tier-3) configuration <sup>[1](#1)</sup>
 * macOS Sonoma (14) (or higher) installed on officially supported hardware<sup>[2](#2)</sup>
 * Command Line Tools (CLT) for Xcode (from `xcode-select --install` or
   [https://developer.apple.com/download/all/](https://developer.apple.com/download/all/)) or
@@ -95,7 +95,7 @@ Uninstallation is documented in the [FAQ](FAQ.md#how-do-i-uninstall-homebrew).
 
 <a data-proofer-ignore name="1"><sup>1</sup></a> For 32-bit or PPC support see [MacPorts](https://www.macports.org) or [Tigerbrew](https://github.com/mistydemeo/tigerbrew).
 
-<a data-proofer-ignore name="2"><sup>2</sup></a> macOS 14 (Sonoma) or higher is best and supported, 10.15 (Catalina) – 13 (Ventura) are unsupported but may work and 10.14 (Mojave) and older will not run Homebrew at all. Using OpenCore Legacy Patcher is a [Tier 2](Support-Tiers.md#tier-2) or [Tier 3](Support-Tiers.md#tier-3) configuration depending on CPU generation.
+<a data-proofer-ignore name="2"><sup>2</sup></a> On Apple Silicon, macOS 14 (Sonoma) or higher is best and supported; macOS 11 (Big Sur) – 13 (Ventura) are unsupported but may work. All Intel Mac configurations that can run Homebrew, including those using OpenCore Legacy Patcher, are [Tier 3](Support-Tiers.md#tier-3). macOS 10.14 (Mojave) and older will not run Homebrew at all.
 
 <a data-proofer-ignore name="3"><sup>3</sup></a> Xcode or the CLT is required to build formulae from source and remains a requirement for a supported installation. Casks and bottles can be installed without developer tools. Downloading Xcode may require an Apple Developer account on older versions of Mac OS X. Sign up for free at [Apple's website](https://developer.apple.com/account/).
 

--- a/docs/Support-Tiers.md
+++ b/docs/Support-Tiers.md
@@ -1,5 +1,5 @@
 ---
-last_review_date: "2026-04-03"
+last_review_date: "2026-08-27"
 ---
 
 # Support Tiers
@@ -27,12 +27,9 @@ Users can expect:
 
 To qualify as Tier 1, a macOS configuration must meet all of the following:
 
-- On official Apple hardware (not a Hackintosh or virtual machine)
+- On official Apple Silicon hardware (not a virtual machine)
 - Running the latest patch release of a macOS version supported by Apple for that hardware and included in Homebrew’s CI coverage (typically the latest stable or prerelease version and the two preceding versions)
-- Installed in the default prefix:
-  - `/opt/homebrew` on Apple Silicon
-  - `/usr/local` on Intel x86_64
-- Using a supported architecture (Apple Silicon or Intel x86_64)
+- Installed in the default prefix: `/opt/homebrew`
 - Not building official packages from source (i.e. using bottles)
 - Installed on the Mac’s internal storage (not external or removable drives)
 - Running with `sudo` access available
@@ -72,7 +69,6 @@ Tier 2 configurations include:
 - Linux systems with `glibc` versions between 2.13 and 2.38 (Homebrew’s own `glibc` formula will be installed automatically)
 - Homebrew installed outside the default prefix, requiring source builds for official packages (i.e. installing outside `/opt/homebrew`, `/usr/local` or `/home/linuxbrew/.linuxbrew`)
 - Architectures not yet officially supported by Homebrew
-- Macs using OpenCore Legacy Patcher with a Westmere or newer Intel CPU
 
 ## Tier 3
 
@@ -98,7 +94,7 @@ Tier 3 configurations include:
 - Homebrew installations managed by Nix (e.g. nix-darwin or nix-homebrew)
 - Installing formulae using `--HEAD`
 - Installing deprecated or disabled formulae
-- Macs using OpenCore Legacy Patcher with an Intel CPU older than Westmere
+- Intel x86_64 systems running macOS
 
 ## Unsupported
 
@@ -129,19 +125,18 @@ If you are using a Homebrew wrapper, get support from and file issues with that 
 
 ## Future macOS support
 
-Apple has announced that macOS Tahoe 26 will be the final version of macOS to support Intel x86_64 hardware. In alignment with this change, Homebrew plans to remove support for macOS on Intel in a future release after that point.
+macOS Tahoe 26 is the final version of macOS to run on Intel hardware. In alignment with this change, Homebrew has stopped building new bottles for Intel systems, and will remove the ability to run Homebrew on Intel systems in or after September 2027.
 
 The following timeline outlines expected Tier classifications based on Apple’s release cycle and Homebrew’s CI coverage.
 
-- As of November 2025:
+- As of September 2026:
 
   Apple Silicon:
   - Tier 1: macOS Tahoe 26, Sequoia 15, Sonoma 14
   - Tier 3: macOS Big Sur 11 through Ventura 13
 
   Intel x86_64:
-  - Tier 1: macOS Tahoe 26, Sequoia 15, Sonoma 14
-  - Tier 3: macOS Catalina 10.15 through Ventura 13
+  - Tier 3: macOS Catalina 10.15 through Tahoe 26
   - Unsupported: macOS Mojave 10.14 and earlier
 
 - Expected in or after September 2026:

--- a/package/Distribution.xml
+++ b/package/Distribution.xml
@@ -32,15 +32,33 @@
 
   <script>
     // See https://developer.apple.com/documentation/installer_js
+    function is_intel() {
+      try {
+        // `hw.machine` exists on both architectures. An unavailable lookup can
+        // return a falsey value instead of throwing, so compare positively.
+        return system.sysctl("hw.machine") == "x86_64";
+      } catch (error) {
+        // Never warn a Tier 1 Mac just because the probe failed.
+        return false;
+      }
+    }
+
     function installation_check() {
-      if (system.files.fileExistsAtPath("/Library/Developer/CommandLineTools/usr/bin/git")) {
-        return true;
-      } else {
+      if (!system.files.fileExistsAtPath("/Library/Developer/CommandLineTools/usr/bin/git")) {
         my.result.title = "Command Line Tools (CLT) are missing";
         my.result.message = "You must install the Command Line Tools (CLT) before installing Homebrew by running `xcode-select --install` from a Terminal.";
         my.result.type = "Fatal";
         return false;
       }
+
+      if (is_intel()) {
+        my.result.title = "Intel Macs are a Tier 3 configuration";
+        my.result.message = "Homebrew no longer routinely builds bottles for Intel Macs, so packages will increasingly be built from source, and issues affecting only Intel may be closed without investigation. See https://docs.brew.sh/Support-Tiers#tier-3";
+        my.result.type = "Warning";
+        return false;
+      }
+
+      return true;
     }
   </script>
   <installation-check script="installation_check()" />


### PR DESCRIPTION
Follow-up to #23677, which stopped routinely building Intel bottles in Homebrew/core. Tier 1 requires full CI coverage for testing and bottle builds, so Intel no longer qualifies.

`brew doctor` now reports Intel macOS as Tier 3, and we no longer point Intel users at the issue tracker. Outdated macOS still takes precedence over the new Intel finding, so those users keep the MacPorts remediation. The OpenCore Legacy Patcher check is removed: every Intel Mac is Tier 3 now, so it only duplicated the new finding without adding a classification.

`fresh_install?` is gated on Apple Silicon so Intel users fall back to source builds rather than hitting a hard "no bottle available!" error now that Intel bottles are gone. Portable Ruby still builds for Intel, so the docs say we have stopped routinely building Intel bottles rather than stopping outright.

The macOS `.pkg` now warns that Intel is a Tier 3 configuration instead of installing silently, and the stale "Intel keeps /usr/local bottling until EOL" note in the relocatable bottles plan is corrected. Companion pull requests will follow in Homebrew/install and Homebrew/brew.sh, which both still describe Intel as supported.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the fix and pass with it, and ran `brew lgtm` plus targeted specs.

-----
