### PR TITLE
Relativise absolute symlinks into the prefix when bottling

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -520,6 +520,7 @@ module Homebrew
             keg.delete_pyc_files!
             keg.delete_node_gyp_debris!
             keg.strip_node_gyp_addons!
+            keg.relativize_prefix_symlinks!
 
             unless args.skip_relocation?
               changed_files, linkage_files = keg.replace_locations_with_placeholders

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1713,6 +1713,18 @@ on_request: installed_on_request?, options:)
     end
     keg.replace_placeholders_with_locations(tab.changed_files, skip_linkage:, linkage_files: tab.linkage_files)
 
+    # Older bottles may still contain absolute symlinks into their build prefix.
+    build_cellar = if tab.built_prefix
+      "#{tab.built_prefix}/Cellar"
+    else
+      Utils::Bottles.tag.default_cellar
+    end
+    build_prefix = Pathname(build_cellar).parent.to_s
+    if build_prefix != HOMEBREW_PREFIX.to_s
+      keg.relativize_prefix_symlinks!(prefix: build_prefix,
+                                      cellar: build_cellar)
+    end
+
     cellar = formula.bottle_specification.tag_to_cellar(Utils::Bottles.tag)
     return if BottleSpecification::RELOCATABLE_CELLARS.include?(cellar)
 

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -70,16 +70,26 @@ class Keg
 
   sig { void }
   def fix_dynamic_linkage
+    relativize_prefix_symlinks!
+  end
+
+  # Relocation never rewrites symlink targets, so make absolute symlinks into
+  # the given prefix or cellar relative to keep them resolving anywhere.
+  sig { params(prefix: String, cellar: String).void }
+  def relativize_prefix_symlinks!(prefix: HOMEBREW_PREFIX.to_s, cellar: HOMEBREW_CELLAR.to_s)
     symlink_files.each do |file|
       link = file.readlink
       # Don't fix relative symlinks
       next unless link.absolute?
 
-      link_starts_cellar = link.to_s.start_with?(HOMEBREW_CELLAR.to_s)
-      link_starts_prefix = link.to_s.start_with?(HOMEBREW_PREFIX.to_s)
-      next if !link_starts_cellar && !link_starts_prefix
+      target = if link.to_s.start_with?("#{cellar}/")
+        HOMEBREW_CELLAR/link.to_s.delete_prefix("#{cellar}/")
+      elsif link.to_s.start_with?("#{prefix}/")
+        HOMEBREW_PREFIX/link.to_s.delete_prefix("#{prefix}/")
+      end
+      next if target.nil?
 
-      new_src = link.relative_path_from(file.parent)
+      new_src = target.relative_path_from(file.parent)
       file.unlink
       FileUtils.ln_s(new_src, file)
     end

--- a/Library/Homebrew/plans/relocatable-bottles.md
+++ b/Library/Homebrew/plans/relocatable-bottles.md
@@ -280,11 +280,10 @@ The padded-prefix scheme alone does not cover every non-`:any` bottle. Each
 residual class below is a goal with its own strategy, tracked to zero or to
 a named, formula-annotated exception:
 
-1. **Absolute symlinks into the prefix.** The checker pins bottles
-   containing them and nothing rewrites symlink targets at pour. Strategy:
-   at bottle time convert self-keg absolute symlinks to relative ones
-   (functionally identical); at pour time retarget remaining absolute
-   in-prefix targets as part of patching. Lands with Phase 2 hardening.
+1. **Absolute symlinks into the prefix.** Done: `brew bottle` rewrites
+   absolute symlinks into the prefix or cellar as relative ones
+   (functionally identical) and pouring retargets any left in older
+   bottles from the prefix they were built for.
 2. **Files patchelf must skip** (`protodesc_cold`/`.bun` sections, e.g.
    bun): these keep raw RPATH strings and auto-pin today. Strategy: the
    NUL-padded string patcher handles them at pour. A shortened NUL-padded

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -312,7 +312,7 @@ RSpec.describe FormulaInstaller do
     let(:downloadable) { instance_double(Resource, downloader:) }
     let(:tab) do
       instance_double(Tab, changed_files: nil, linkage_files: nil, binary_relocation_files: nil,
-                      source: { "versions" => {} }, write: nil).as_null_object
+                      built_prefix: nil, source: { "versions" => {} }, write: nil).as_null_object
     end
     let(:keg) { instance_double(Keg) }
 
@@ -322,7 +322,15 @@ RSpec.describe FormulaInstaller do
       allow(Tab).to receive(:clear_cache)
       allow(Keg).to receive(:new).with(f.prefix).and_return(keg)
       allow(keg).to receive(:replace_placeholders_with_locations)
+      allow(keg).to receive(:relativize_prefix_symlinks!)
       allow(f.bottle_specification).to receive(:skip_relocation?).with(tab:).and_return(true)
+    end
+
+    it "retargets absolute symlinks from the prefix the bottle was built for" do
+      cellar = Utils::Bottles.tag.default_cellar
+      expect(keg).to receive(:relativize_prefix_symlinks!).with(prefix: Pathname(cellar).parent.to_s, cellar:)
+
+      installer.pour
     end
 
     it "preserves the skip-linkage decision for the default bottle domain" do

--- a/Library/Homebrew/test/keg_spec.rb
+++ b/Library/Homebrew/test/keg_spec.rb
@@ -390,6 +390,32 @@ RSpec.describe Keg do
     end
   end
 
+  describe "#relativize_prefix_symlinks!" do
+    let(:keg_path) { HOMEBREW_CELLAR/"foo/1.0" }
+
+    it "rewrites absolute symlinks into the prefix and cellar as relative ones" do
+      (HOMEBREW_PREFIX/"opt/bar/lib").mkpath
+      touch keg_path/"bin/hiworld"
+      ln_s keg_path/"bin/hiworld", keg_path/"bin/self"
+      ln_s HOMEBREW_PREFIX/"opt/bar/lib", keg_path/"bin/other"
+      ln_s "/usr/bin/true", keg_path/"bin/system"
+
+      keg.relativize_prefix_symlinks!
+
+      expect((keg_path/"bin/self").readlink).to eq Pathname("hiworld")
+      expect((keg_path/"bin/other").readlink).to eq Pathname("../../../../opt/bar/lib")
+      expect((keg_path/"bin/system").readlink).to eq Pathname("/usr/bin/true")
+    end
+
+    it "retargets symlinks from the prefix a bottle was built for" do
+      ln_s "/build/prefix/Cellar/foo/1.0/bin/hiworld", keg_path/"bin/built"
+
+      keg.relativize_prefix_symlinks!(prefix: "/build/prefix", cellar: "/build/prefix/Cellar")
+
+      expect((keg_path/"bin/built").readlink).to eq Pathname("hiworld")
+    end
+  end
+
   describe "#delete_node_gyp_debris!" do
     it "deletes intermediate node-gyp objects but keeps addons and other objects" do
       keg_path = HOMEBREW_CELLAR/"foo/1.0"


### PR DESCRIPTION
- Relocation never rewrites symlink targets, so an absolute symlink into the prefix or cellar dangles wherever a bottle is poured other than the prefix it was built at; only the `/usr/local` checker path even looked for them.
- `brew bottle` now rewrites such symlinks as relative ones, which resolve identically, using the same logic source builds already apply after installation (`Keg#fix_dynamic_linkage`).
- Pouring retargets any left in bottles built before this change from the prefix they were built for, so those keep working at custom prefixes too.

This change is part of [`plans/relocatable-bottles.md`](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/plans/relocatable-bottles.md)

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude with Fable 5 at High effort, with local review and testing.

-----