### PR TITLE
Speed up and expand integration coverage

### DIFF
--- a/Library/Homebrew/.simplecov
+++ b/Library/Homebrew/.simplecov
@@ -34,52 +34,8 @@ SimpleCov.configure do
                .map { |p| "#{p}/**/*.rb" }.join(",")
   files = "{#{subdirs},*.rb}"
 
-  if (integration_test_number = ENV.fetch("HOMEBREW_INTEGRATION_TEST", nil))
-    # This needs a unique name so it won't be overwritten
-    command_name "brew_i:#{integration_test_number}"
-
-    # be quiet, the parent process will be in charge of output and checking coverage totals
-    SimpleCov.print_errors false
-
-    SimpleCov.at_exit do
-      # Just save result, but don't write formatted output.
-      coverage_result = Coverage.result.dup
-      simulated_files_path = File.join(
-        SimpleCov.coverage_path,
-        ".simulated_files#{ENV.fetch("TEST_ENV_NUMBER", "")}",
-      )
-      simulated_files = if File.exist?(simulated_files_path)
-        Set.new(File.readlines(simulated_files_path, chomp: true))
-      else
-        Set.new
-      end
-      simulated_files_count = simulated_files.size
-      Dir.glob(files, base: SimpleCov.root).each do |file|
-        absolute_path = File.expand_path(file, SimpleCov.root)
-        next if coverage_result.key?(absolute_path) || simulated_files.include?(absolute_path)
-
-        coverage_result[absolute_path] = SimpleCov::SimulateCoverage.call(absolute_path)
-        simulated_files << absolute_path
-      end
-      simplecov_result = SimpleCov::Result.new(coverage_result)
-      SimpleCov::ResultMerger.store_result(simplecov_result)
-      if simulated_files.size > simulated_files_count
-        FileUtils.mkdir_p(SimpleCov.coverage_path)
-        File.write(simulated_files_path, simulated_files.to_a.join("\n"))
-      end
-
-      # If an integration test raises a `SystemExit` exception on exit,
-      # exit immediately using the same status code to avoid reporting
-      # an error when expecting a non-successful exit status.
-      raise if $ERROR_INFO.is_a?(SystemExit)
-    end
-  else
-    command_name "brew:#{ENV.fetch("TEST_ENV_NUMBER", $PROCESS_ID)}"
-
-    # Not using this during integration tests makes the tests 4x times faster
-    # without changing the coverage.
-    cover files
-  end
+  command_name "brew:#{ENV.fetch("TEST_ENV_NUMBER", $PROCESS_ID)}"
+  cover files
 
   skip(/^build\.rb$/)
   skip(/^config\.rb$/)

--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -282,7 +282,6 @@ module Homebrew
         if args.coverage?
           ENV["HOMEBREW_TESTS_COVERAGE"] = "1"
           FileUtils.rm_f "test/coverage/.resultset.json"
-          FileUtils.rm_f Dir["test/coverage/.simulated_files*"]
         end
 
         # Override author/committer as global settings might be invalid and thus

--- a/Library/Homebrew/test/cmd/--caskroom_spec.rb
+++ b/Library/Homebrew/test/cmd/--caskroom_spec.rb
@@ -7,9 +7,22 @@ require "cmd/shared_examples/args_parse"
 RSpec.describe Homebrew::Cmd::Caskroom do
   it_behaves_like "parseable arguments"
 
-  it "prints Homebrew's Caskroom", :integration_test do
+  it "prints Homebrew's Caskroom and a Cask's Caskroom", :cask, :integration_test do
+    caskfile = HOMEBREW_TEMP/"local-caffeine.rb"
+    caskfile.write <<~RUBY
+      cask "local-caffeine" do
+        version "1.2.3"
+        sha256 :no_check
+        url "https://brew.sh/local-caffeine.zip"
+      end
+    RUBY
+
     expect { brew_sh "--caskroom" }
       .to output("#{ENV.fetch("HOMEBREW_PREFIX")}/Caskroom\n").to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+    expect { brew_sh "--caskroom", caskfile }
+      .to output("#{ENV.fetch("HOMEBREW_PREFIX")}/Caskroom/local-caffeine\n").to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
   end

--- a/Library/Homebrew/test/cmd/--cellar_spec.rb
+++ b/Library/Homebrew/test/cmd/--cellar_spec.rb
@@ -7,9 +7,15 @@ require "cmd/shared_examples/args_parse"
 RSpec.describe Homebrew::Cmd::Cellar do
   it_behaves_like "parseable arguments"
 
-  it "prints Homebrew's Cellar", :integration_test do
+  it "prints Homebrew's Cellar and a Formula's Cellar", :integration_test do
+    testball = setup_test_formula "testball"
+
     expect { brew_sh "--cellar" }
       .to output("#{ENV.fetch("HOMEBREW_CELLAR")}\n").to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+    expect { brew_sh "--cellar", testball }
+      .to output(%r{/Cellar/testball\n}).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
   end

--- a/Library/Homebrew/test/cmd/--env_spec.rb
+++ b/Library/Homebrew/test/cmd/--env_spec.rb
@@ -9,8 +9,13 @@ RSpec.describe Homebrew::Cmd::Env do
 
   describe "--shell=bash", :integration_test do
     it "prints the Homebrew build environment variables in Bash syntax" do
+      setup_test_formula "testball"
       path = [Superenv.bin&.parent, HOMEBREW_PREFIX].compact.join(File::PATH_SEPARATOR)
       expect { brew "--env", "--shell=bash" }
+        .to output(/export CMAKE_PREFIX_PATH="#{Regexp.quote(path)}"/).to_stdout
+        .and not_to_output.to_stderr
+        .and be_a_success
+      expect { brew "--env", "--shell=bash", "testball" }
         .to output(/export CMAKE_PREFIX_PATH="#{Regexp.quote(path)}"/).to_stdout
         .and not_to_output.to_stderr
         .and be_a_success

--- a/Library/Homebrew/test/cmd/--prefix_spec.rb
+++ b/Library/Homebrew/test/cmd/--prefix_spec.rb
@@ -7,9 +7,15 @@ require "cmd/shared_examples/args_parse"
 RSpec.describe Homebrew::Cmd::Prefix do
   it_behaves_like "parseable arguments"
 
-  it "prints Homebrew's prefix", :integration_test do
+  it "prints Homebrew's prefix and a Formula's prefix", :integration_test do
+    testball = setup_test_formula "testball"
+
     expect { brew_sh "--prefix" }
       .to output("#{ENV.fetch("HOMEBREW_PREFIX")}\n").to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+    expect { brew_sh "--prefix", testball }
+      .to output(%r{/opt/testball\n}).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
   end

--- a/Library/Homebrew/test/cmd/--repository_spec.rb
+++ b/Library/Homebrew/test/cmd/--repository_spec.rb
@@ -4,6 +4,8 @@
 require "open3"
 
 RSpec.describe "brew --repository", type: :system do
+  it_behaves_like "a documented command", "--repository", shell: true
+
   it "prints Homebrew and Tap repositories" do
     stdout, stderr, status = Open3.capture3(
       {

--- a/Library/Homebrew/test/cmd/--taps_spec.rb
+++ b/Library/Homebrew/test/cmd/--taps_spec.rb
@@ -1,0 +1,6 @@
+# typed: true
+# frozen_string_literal: true
+
+RSpec.describe "brew --taps", type: :system do
+  it_behaves_like "a documented command", "--taps", shell: true
+end

--- a/Library/Homebrew/test/cmd/alias_spec.rb
+++ b/Library/Homebrew/test/cmd/alias_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe Homebrew::Cmd::Alias do
       .to not_to_output.to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
-    expect { brew "alias" }
-      .to output(/brew alias foo-test='bar'/).to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
+
+    alias_file = HOMEBREW_ALIASES/"foo_test"
+    expect([alias_file.read.include?("brew bar $*"), (HOMEBREW_PREFIX/"bin/brew-foo-test").realpath])
+      .to eq([true, alias_file])
   end
 end

--- a/Library/Homebrew/test/cmd/analytics_spec.rb
+++ b/Library/Homebrew/test/cmd/analytics_spec.rb
@@ -16,15 +16,17 @@ RSpec.describe Homebrew::Cmd::Analytics do
       .to raise_error(Homebrew::CLI::MaxNamedArgumentsError)
   end
 
-  it "when HOMEBREW_NO_ANALYTICS is unset is disabled after running `brew analytics off`", :integration_test do
+  it "disables analytics when HOMEBREW_NO_ANALYTICS is unset", :integration_test do
     HOMEBREW_REPOSITORY.cd do
       system "git", "init"
     end
 
-    brew "analytics", "off"
-    expect { brew "analytics", "HOMEBREW_NO_ANALYTICS" => nil }
-      .to output(/analytics are disabled/i).to_stdout
+    expect { brew "analytics", "off", "HOMEBREW_NO_ANALYTICS" => nil }
+      .to not_to_output.to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
+
+    Homebrew::Settings.clear_cache
+    expect(Homebrew::Settings.read(:analyticsdisabled)).to eq("true")
   end
 end

--- a/Library/Homebrew/test/cmd/as-console-user_spec.rb
+++ b/Library/Homebrew/test/cmd/as-console-user_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Homebrew::Cmd::AsConsoleUser do
   end
 
   it_behaves_like "parseable arguments"
+  it_behaves_like "a documented command", "as-console-user", shell: true
 
   def run_as_console_user_shell(script, env = {})
     Bundler.with_unbundled_env do

--- a/Library/Homebrew/test/cmd/cleanup_spec.rb
+++ b/Library/Homebrew/test/cmd/cleanup_spec.rb
@@ -16,14 +16,17 @@ RSpec.describe Homebrew::Cmd::CleanupCmd do
 
   it_behaves_like "parseable arguments"
 
-  describe "--prune=all", :integration_test do
+  describe "--prune=all", :cask, :integration_test do
     it "removes all files in Homebrew's cache" do
+      setup_test_formula "testball"
       (HOMEBREW_CACHE/"test").write "test"
 
       expect { brew "cleanup", "--prune=all" }
         .to output(%r{#{Regexp.escape(HOMEBREW_CACHE)}/test}o).to_stdout
         .and not_to_output.to_stderr
         .and be_a_success
+      expect { brew "cleanup", "--dry-run", "testball", cask_path("local-caffeine") }
+        .to be_a_success
     end
   end
 end

--- a/Library/Homebrew/test/cmd/command-not-found-init_spec.rb
+++ b/Library/Homebrew/test/cmd/command-not-found-init_spec.rb
@@ -6,4 +6,5 @@ require "cmd/command-not-found-init"
 
 RSpec.describe Homebrew::Cmd::CommandNotFoundInit do
   it_behaves_like "parseable arguments"
+  it_behaves_like "a documented command", "command-not-found-init"
 end

--- a/Library/Homebrew/test/cmd/completions_spec.rb
+++ b/Library/Homebrew/test/cmd/completions_spec.rb
@@ -16,15 +16,17 @@ RSpec.describe Homebrew::Cmd::CompletionsCmd do
       .to raise_error(Homebrew::CLI::MaxNamedArgumentsError)
   end
 
-  it "runs the status subcommand correctly", :integration_test do
+  it "links completions", :integration_test do
     HOMEBREW_REPOSITORY.cd do
       system "git", "init"
     end
 
-    brew "completions", "link"
-    expect { brew "completions" }
-      .to output(/Completions are linked/).to_stdout
+    expect { brew "completions", "link" }
+      .to output(/Completions are now linked/).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
+
+    Homebrew::Settings.clear_cache
+    expect(Homebrew::Completions.link_completions?).to be(true)
   end
 end

--- a/Library/Homebrew/test/cmd/deps_spec.rb
+++ b/Library/Homebrew/test/cmd/deps_spec.rb
@@ -36,14 +36,19 @@ RSpec.describe Homebrew::Cmd::Deps, :integration_test, :no_api do
 
   it_behaves_like "parseable arguments"
 
-  it "outputs all of a Formula's dependencies and their dependencies on separate lines" do
+  it "outputs Formula and Cask dependencies on separate lines", :cask do
     setup_test_formula "installed"
+    setup_test_formula "unar"
     expect do
       brew "deps", "baz", "--include-test", "--missing", "--skip-recommended", "HOMEBREW_REQUIRE_TAP_TRUST" => "1"
     end
       .to be_a_success
       .and output("bar\nfoo\ntest\n").to_stdout
       .and output(/not the actual runtime dependencies/).to_stderr
+    expect { brew "deps", "--cask", "--direct", cask_path("with-depends-on-everything") }
+      .to output("unar\n").to_stdout
+      .and output(/not the actual runtime dependencies/).to_stderr
+      .and be_a_success
   end
 
   context "with --tree" do

--- a/Library/Homebrew/test/cmd/desc_spec.rb
+++ b/Library/Homebrew/test/cmd/desc_spec.rb
@@ -7,11 +7,11 @@ require "cmd/shared_examples/args_parse"
 RSpec.describe Homebrew::Cmd::Desc do
   it_behaves_like "parseable arguments"
 
-  it "shows a given Formula's description", :integration_test do
+  it "shows a given Formula and Cask description", :cask, :integration_test do
     setup_test_formula "testball"
 
-    expect { brew "desc", "testball" }
-      .to output("testball: Some test\n").to_stdout
+    expect { brew "desc", "testball", "local-transmission" }
+      .to output("local-transmission: (Transmission) BitTorrent client\ntestball: Some test\n").to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
   end

--- a/Library/Homebrew/test/cmd/gist-logs_spec.rb
+++ b/Library/Homebrew/test/cmd/gist-logs_spec.rb
@@ -7,6 +7,14 @@ require "cmd/shared_examples/args_parse"
 RSpec.describe Homebrew::Cmd::GistLogs do
   it_behaves_like "parseable arguments"
 
+  it "loads a Formula's build logs", :integration_test do
+    setup_test_formula "testball"
+
+    expect { brew "gist-logs", "testball", "HOMEBREW_TEST_GENERIC_OS" => "1" }
+      .to output(/No logs\./).to_stderr
+      .and be_a_failure
+  end
+
   describe ".truncate_text_to_approximate_size" do
     let(:glue) { "\n[...snip...]\n" } # hard-coded copy from truncate_text_to_approximate_size
 

--- a/Library/Homebrew/test/cmd/home_spec.rb
+++ b/Library/Homebrew/test/cmd/home_spec.rb
@@ -26,7 +26,15 @@ RSpec.describe Homebrew::Cmd::Home do
 
   it_behaves_like "parseable arguments"
 
-  it "opens the project page when no formula or cask is specified", :integration_test do
+  it "opens the homepages for a given Formula and Cask", :cask, :integration_test do
+    setup_test_formula "testballhome", <<~RUBY
+      homepage "#{testballhome_homepage}"
+    RUBY
+
+    expect { brew "home", "testballhome", local_caffeine_path, "HOMEBREW_BROWSER" => "echo" }
+      .to output(/#{Regexp.escape(testballhome_homepage)}.*#{Regexp.escape(local_caffeine_homepage)}/m).to_stdout
+      .and output(/Treating #{Regexp.escape(local_caffeine_path)} as a cask/).to_stderr
+      .and be_a_success
     expect { brew "home", "HOMEBREW_BROWSER" => "echo" }
       .to output("https://brew.sh\n").to_stdout
       .and not_to_output.to_stderr

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -55,10 +55,10 @@ RSpec.describe Homebrew::Cmd::Info do
       .and not_to_output.to_stderr
   end
 
-  it "prints as json with the --json=v2 flag", :integration_test do
+  it "prints Formula and Cask JSON with the --json=v2 flag", :cask, :integration_test do
     setup_test_formula "testball"
 
-    expect { brew "info", "testball", "--json=v2" }
+    expect { brew "info", "testball", "local-caffeine", "--json=v2" }
       .to output(a_json_string).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -560,7 +560,7 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
   end
 
   context "when installing Formulae" do
-    it "builds from source and pours a keg-only bottle", :integration_test do
+    it "installs Formulae and a Cask", :cask, :integration_test do
       source_formula_name = "sourceball"
       source_formula_prefix = HOMEBREW_CELLAR/source_formula_name/"0.1"
       bottle_formula_name = "testball_bottle"
@@ -577,11 +577,13 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
       setup_test_formula bottle_formula_name, <<~RUBY
         keg_only "test reason"
       RUBY
+      appdir = mktmpdir
 
       with_env(HOMEBREW_NO_INSTALL_FROM_API: "1") do
         expect do
-          brew "install", "--yes", source_formula_name, bottle_formula_name,
-               "HOMEBREW_NO_INSTALL_FROM_API" => "1"
+          brew "install", "--yes", "--no-ask", "--appdir=#{appdir}", source_formula_name, bottle_formula_name,
+               cask_path("local-caffeine"),
+               "HOMEBREW_NO_INSTALL_FROM_API" => "1", "HOMEBREW_TEST_GENERIC_OS" => "1"
         end
           .to output(/#{Regexp.escape(source_formula_prefix)}.*#{Regexp.escape(bottle_formula_prefix)}/m).to_stdout
           .and output(/✔︎.*/m).to_stderr
@@ -591,6 +593,7 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
       expect(bottle_formula_prefix/"foo/test").not_to be_a_file
       expect(bottle_formula_prefix/"bin/helloworld").to be_a_file
       expect(HOMEBREW_PREFIX/"bin/helloworld").not_to be_a_file
+      expect(appdir/"Caffeine.app").to be_a_directory
     end
   end
 
@@ -625,7 +628,8 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
         expect do
           brew "install", "-y", formula_name, "--HEAD",
                "HOMEBREW_DOWNLOAD_CONCURRENCY" => "1",
-               "HOMEBREW_NO_INSTALL_FROM_API"  => "1"
+               "HOMEBREW_NO_INSTALL_FROM_API"  => "1",
+               "HOMEBREW_TEST_GENERIC_OS"      => "1"
         end
           .to output(/#{Regexp.escape(testball1_prefix)}/o).to_stdout
           .and output(/Cloning into/).to_stderr

--- a/Library/Homebrew/test/cmd/log_spec.rb
+++ b/Library/Homebrew/test/cmd/log_spec.rb
@@ -7,7 +7,7 @@ require "cmd/shared_examples/args_parse"
 RSpec.describe Homebrew::Cmd::Log do
   it_behaves_like "parseable arguments"
 
-  it "shows the Git log for a given Formula", :integration_test do
+  it "shows the Git log for a given Formula and Cask", :cask, :integration_test do
     setup_test_formula "testball"
 
     core_tap = CoreTap.instance
@@ -28,5 +28,15 @@ RSpec.describe Homebrew::Cmd::Log do
       .and be_a_success
 
     expect(shallow_tap.path/".git/shallow").to exist, "A shallow clone should have been created."
+
+    CoreCaskTap.instance.path.cd do
+      system "git", "init"
+      system "git", "add", "--all"
+      system "git", "commit", "-m", "This is a test commit for local-caffeine"
+    end
+    expect { brew "log", "--cask", "local-caffeine" }
+      .to output(/This is a test commit for local-caffeine/).to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
   end
 end

--- a/Library/Homebrew/test/cmd/migrate_spec.rb
+++ b/Library/Homebrew/test/cmd/migrate_spec.rb
@@ -7,14 +7,37 @@ require "cmd/shared_examples/args_parse"
 RSpec.describe Homebrew::Cmd::Migrate do
   it_behaves_like "parseable arguments"
 
-  it "migrates a renamed Formula", :integration_test, :no_api do
-    setup_test_formula "testball1"
+  it "migrates a renamed Formula and Cask", :cask, :integration_test, :no_api do
+    old_formula_path = setup_test_formula "testball1", tab_attributes: { installed_on_request: true }
     setup_test_formula "testball2"
-    install_and_rename_coretap_formula "testball1", "testball2"
+    Keg.new(::Formula["testball1"].prefix).link
+    old_formula_path.unlink
+    (CoreTap.instance.path/"formula_renames.json").write(
+      JSON.pretty_generate("testball1" => "testball2"),
+    )
+    CoreTap.instance.clear_cache
 
-    expect { brew "migrate", "testball1" }
+    expect { brew "migrate", "testball1", "HOMEBREW_TEST_GENERIC_OS" => "1" }
       .to output(/Migrating formula testball1 to testball2/).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
+
+    cask = Cask::CaskLoader.load("local-caffeine")
+    InstallHelper.stub_cask_installation(cask)
+    sourcefile_path = cask.sourcefile_path
+    raise "Cask sourcefile path is unavailable" if sourcefile_path.nil?
+
+    sourcefile_path.unlink
+    (CoreCaskTap.instance.path/"cask_renames.json").write(
+      JSON.pretty_generate("local-caffeine" => "local-transmission-zip"),
+    )
+    CoreCaskTap.instance.clear_cache
+
+    expect { brew "migrate", "--cask", "--dry-run", cask.token }
+      .to output(/Would migrate cask local-caffeine to local-transmission-zip/).to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+    expect(HOMEBREW_CELLAR/"testball1").to be_a_symlink
+    expect((HOMEBREW_CELLAR/"testball1").realpath).to eq(HOMEBREW_CELLAR/"testball2")
   end
 end

--- a/Library/Homebrew/test/cmd/missing_spec.rb
+++ b/Library/Homebrew/test/cmd/missing_spec.rb
@@ -7,7 +7,7 @@ require "cmd/shared_examples/args_parse"
 RSpec.describe Homebrew::Cmd::Missing do
   it_behaves_like "parseable arguments"
 
-  it "prints missing dependencies", :integration_test, :no_api do
+  it "prints missing Formula and Cask dependencies", :cask, :integration_test, :no_api do
     setup_test_formula "foo"
     setup_test_formula "bar"
 
@@ -21,6 +21,14 @@ RSpec.describe Homebrew::Cmd::Missing do
 
     expect { brew "missing" }
       .to output("foo\n").to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_failure
+
+    setup_test_formula "unar"
+    cask = Cask::CaskLoader.load("with-depends-on-everything")
+    InstallHelper.stub_cask_installation(cask)
+    expect { brew "missing", cask.token }
+      .to output(/local-caffeine.*unar/).to_stdout
       .and not_to_output.to_stderr
       .and be_a_failure
   end

--- a/Library/Homebrew/test/cmd/nodenv-sync_spec.rb
+++ b/Library/Homebrew/test/cmd/nodenv-sync_spec.rb
@@ -6,4 +6,5 @@ require "cmd/shared_examples/args_parse"
 
 RSpec.describe Homebrew::Cmd::NodenvSync do
   it_behaves_like "parseable arguments"
+  it_behaves_like "a documented command", "nodenv-sync"
 end

--- a/Library/Homebrew/test/cmd/pin_spec.rb
+++ b/Library/Homebrew/test/cmd/pin_spec.rb
@@ -7,19 +7,16 @@ require "cmd/shared_examples/args_parse"
 RSpec.describe Homebrew::Cmd::Pin do
   it_behaves_like "parseable arguments"
 
-  it "pins a Formula's version", :integration_test do
+  it "pins Formula and Cask versions", :cask, :integration_test do
     setup_test_formula "testball", tab_attributes: { installed_on_request: true }
-
-    expect { brew "pin", "testball" }.to be_a_success
-  end
-
-  it "pins a Cask's version", :cask do
     cask = Cask::CaskLoader.load("local-caffeine")
     InstallHelper.stub_cask_installation(cask)
 
-    expect { described_class.new(["--cask", "local-caffeine"]).run }
+    expect { brew "pin", "testball", "local-caffeine" }
       .to not_to_output.to_stderr
+      .and be_a_success
 
+    expect(Formula["testball"]).to be_pinned
     expect(cask).to be_pinned
     expect(cask.pinned_version).to eq("1.2.3")
     cask.unpin

--- a/Library/Homebrew/test/cmd/postinstall_spec.rb
+++ b/Library/Homebrew/test/cmd/postinstall_spec.rb
@@ -7,6 +7,20 @@ require "cmd/shared_examples/args_parse"
 RSpec.describe Homebrew::Cmd::Postinstall do
   it_behaves_like "parseable arguments"
 
+  it "runs a Formula's post-install steps", :integration_test do
+    setup_test_formula "testball", <<~RUBY, tab_attributes: { installed_on_request: true }
+      def post_install
+        (prefix/"postinstall-ran").write "yes"
+      end
+    RUBY
+
+    expect { brew "postinstall", "testball", "HOMEBREW_TEST_GENERIC_OS" => "1" }
+      .to output(/Postinstalling testball/).to_stdout
+      .and output(/Sandbox unavailable: running post-install without sandboxing!/).to_stderr
+      .and be_a_success
+    expect(Formula["testball"].prefix/"postinstall-ran").to be_a_file
+  end
+
   it "runs post-install steps through `FormulaInstaller`" do
     cmd = described_class.new(["foo"])
     formula = instance_double(Formula, install_etc_var: nil, post_install_steps_defined?: true,

--- a/Library/Homebrew/test/cmd/pyenv-sync_spec.rb
+++ b/Library/Homebrew/test/cmd/pyenv-sync_spec.rb
@@ -6,4 +6,5 @@ require "cmd/shared_examples/args_parse"
 
 RSpec.describe Homebrew::Cmd::PyenvSync do
   it_behaves_like "parseable arguments"
+  it_behaves_like "a documented command", "pyenv-sync"
 end

--- a/Library/Homebrew/test/cmd/rbenv-sync_spec.rb
+++ b/Library/Homebrew/test/cmd/rbenv-sync_spec.rb
@@ -6,4 +6,5 @@ require "cmd/shared_examples/args_parse"
 
 RSpec.describe Homebrew::Cmd::RbenvSync do
   it_behaves_like "parseable arguments"
+  it_behaves_like "a documented command", "rbenv-sync"
 end

--- a/Library/Homebrew/test/cmd/reinstall_spec.rb
+++ b/Library/Homebrew/test/cmd/reinstall_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe Homebrew::Cmd::Reinstall do
     expect { cmd.run }.to output(/Error: one: gzip decompression failed/).to_stderr
   end
 
-  it "reinstalls a Formula", :integration_test do
+  it "reinstalls a Formula and Cask", :cask, :integration_test do
     formula_name = "testball_bottle"
     formula_prefix = HOMEBREW_CELLAR/formula_name/"0.1"
     formula_bin = formula_prefix/"bin"
@@ -236,8 +236,13 @@ RSpec.describe Homebrew::Cmd::Reinstall do
     Keg.new(formula_prefix).link
 
     expect(formula_bin).not_to exist
+    cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
+    InstallHelper.stub_cask_installation(cask)
 
-    expect { brew "reinstall", formula_name }
+    expect do
+      brew "reinstall", "--no-ask", "--appdir=#{Cask::Config::DEFAULT_DIRS_PATHNAMES[:appdir]}", formula_name,
+           cask_path("local-caffeine"), "HOMEBREW_TEST_GENERIC_OS" => "1"
+    end
       .to output(/Reinstalling #{formula_name}/).to_stdout
       .and output(/✔︎.*/m).to_stderr
       .and be_a_success

--- a/Library/Homebrew/test/cmd/sandbox-exec_spec.rb
+++ b/Library/Homebrew/test/cmd/sandbox-exec_spec.rb
@@ -6,6 +6,7 @@ require "cmd/shared_examples/args_parse"
 
 RSpec.describe Homebrew::Cmd::SandboxExec do
   it_behaves_like "parseable arguments"
+  it_behaves_like "a documented command", "sandbox-exec"
 
   it "runs the command in the requested sandbox" do
     expect(Sandbox).to receive(:run_command)

--- a/Library/Homebrew/test/cmd/source_spec.rb
+++ b/Library/Homebrew/test/cmd/source_spec.rb
@@ -7,9 +7,17 @@ require "cmd/shared_examples/args_parse"
 RSpec.describe Homebrew::Cmd::Source do
   it_behaves_like "parseable arguments"
 
-  it "opens the Homebrew repo when no formula is specified", :integration_test do
+  it "opens Homebrew and Formula source repositories", :integration_test do
+    setup_test_formula "testball", <<~RUBY
+      url "https://github.com/Homebrew/testball/archive/refs/tags/v0.1.tar.gz"
+    RUBY
+
     expect { brew "source", "HOMEBREW_BROWSER" => "echo" }
       .to output(%r{https://github\.com/Homebrew/brew}).to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+    expect { brew "source", "testball", "HOMEBREW_BROWSER" => "echo" }
+      .to output(%r{Opening repository for testball.*https://github\.com/Homebrew/testball}m).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
   end

--- a/Library/Homebrew/test/cmd/tab_spec.rb
+++ b/Library/Homebrew/test/cmd/tab_spec.rb
@@ -20,19 +20,28 @@ RSpec.describe Homebrew::Cmd::TabCmd do
 
   it_behaves_like "parseable arguments"
 
-  it "marks a formula as installed on request", :integration_test do
+  it "marks a Formula and Cask as installed on request", :cask, :integration_test do
     setup_test_formula "foo",
                        tab_attributes: { "installed_on_request" => false }
     foo = Formula["foo"]
 
-    expect { brew "tab", "--installed-on-request", "foo" }
-      .to be_a_success
-      .and output(/foo is now marked as installed on request/).to_stdout
+    cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
+    InstallHelper.install_with_caskfile(cask)
+    tab_path = cask.metadata_main_container_path/AbstractTab::FILENAME
+
+    expect(tab_path).not_to exist
+
+    expect { brew "tab", "--installed-on-request", "foo", cask.token }
+      .to output(/foo is now marked as installed on request.*local-caffeine is now marked as installed on request/m)
+      .to_stdout
       .and not_to_output.to_stderr
+      .and be_a_success
     expect(installed_on_request?(foo)).to be true
+    expect(tab_path).to exist
+    expect(cask_installed_on_request?(cask)).to be true
   end
 
-  it "marks or unmarks a cask as installed on request with a missing tab", :cask do
+  it "marks or unmarks a Cask as installed on request with a missing tab", :cask do
     cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
     InstallHelper.install_with_caskfile(cask)
     tab_path = cask.metadata_main_container_path/AbstractTab::FILENAME

--- a/Library/Homebrew/test/cmd/uninstall_spec.rb
+++ b/Library/Homebrew/test/cmd/uninstall_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe Homebrew::Cmd::UninstallCmd do
     cask_file.dirname.mkpath
     FileUtils.cp cask_path("local-caffeine"), cask_file
     tap.clear_cache
-    appdir = mktmpdir
+    cask = Cask::CaskLoader.load(cask_file)
+    InstallHelper.stub_cask_installation(cask)
+    appdir = Pathname(cask.config.appdir)
 
     setup_test_formula "testball", tab_attributes: { installed_on_request: true }
 
@@ -28,14 +30,10 @@ RSpec.describe Homebrew::Cmd::UninstallCmd do
       ENV["HOMEBREW_FORBID_PACKAGES_FROM_PATHS"] = "1"
       ENV["HOMEBREW_REQUIRE_TAP_TRUST"] = "1"
       ENV["HOMEBREW_NO_INSTALL_FROM_API"] = nil
-      brew_env = { "HOMEBREW_SORBET_RUNTIME" => nil, "HOMEBREW_SORBET_RECURSIVE" => nil }
       expect do
-        brew "install", "--cask", "--no-ask", "--appdir=#{appdir}", "./Casks/l/local-caffeine.rb", brew_env
+        brew "uninstall", "--cask", "./Casks/l/local-caffeine.rb",
+             "HOMEBREW_CASK_OPTS" => "--appdir=#{appdir}"
       end
-        .to output(/local-caffeine was successfully installed/).to_stdout
-        .and be_a_success
-
-      expect { brew "uninstall", "--cask", "./Casks/l/local-caffeine.rb", brew_env }
         .to output(/Uninstalling Cask local-caffeine/).to_stdout
         .and not_to_output.to_stderr
         .and be_a_success

--- a/Library/Homebrew/test/cmd/unpin_spec.rb
+++ b/Library/Homebrew/test/cmd/unpin_spec.rb
@@ -7,21 +7,18 @@ require "cmd/unpin"
 RSpec.describe Homebrew::Cmd::Unpin do
   it_behaves_like "parseable arguments"
 
-  it "unpins a Formula's version", :integration_test do
+  it "unpins Formula and Cask versions", :cask, :integration_test do
     setup_test_formula "testball", tab_attributes: { installed_on_request: true }
     Formula["testball"].pin
-
-    expect { brew "unpin", "testball" }.to be_a_success
-  end
-
-  it "unpins a Cask's version", :cask do
     cask = Cask::CaskLoader.load("local-caffeine")
     InstallHelper.stub_cask_installation(cask)
     cask.pin
 
-    expect { described_class.new(["--cask", "local-caffeine"]).run }
+    expect { brew "unpin", "testball", "local-caffeine" }
       .to not_to_output.to_stderr
+      .and be_a_success
 
+    expect(Formula["testball"]).not_to be_pinned
     expect(cask).not_to be_pinned
   end
 

--- a/Library/Homebrew/test/cmd/update-if-needed_spec.rb
+++ b/Library/Homebrew/test/cmd/update-if-needed_spec.rb
@@ -1,0 +1,6 @@
+# typed: true
+# frozen_string_literal: true
+
+RSpec.describe "brew update-if-needed", type: :system do
+  it_behaves_like "a documented command", "update-if-needed", shell: true
+end

--- a/Library/Homebrew/test/cmd/update-reset_spec.rb
+++ b/Library/Homebrew/test/cmd/update-reset_spec.rb
@@ -1,0 +1,6 @@
+# typed: true
+# frozen_string_literal: true
+
+RSpec.describe "brew update-reset", type: :system do
+  it_behaves_like "a documented command", "update-reset", shell: true
+end

--- a/Library/Homebrew/test/cmd/update_spec.rb
+++ b/Library/Homebrew/test/cmd/update_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Homebrew::Cmd::Update do
   end
 
   it_behaves_like "parseable arguments"
+  it_behaves_like "a documented command", "update", shell: true
 
   def run_update_shell(script, env)
     Bundler.with_unbundled_env do

--- a/Library/Homebrew/test/cmd/uses_spec.rb
+++ b/Library/Homebrew/test/cmd/uses_spec.rb
@@ -11,6 +11,16 @@ RSpec.describe Homebrew::Cmd::Uses do
 
   it_behaves_like "parseable arguments"
 
+  it "finds Formulae that use a given Formula", :integration_test, :no_api do
+    setup_test_formula "foo"
+    setup_test_formula "bar"
+
+    expect { brew "uses", "foo", "HOMEBREW_REQUIRE_TAP_TRUST" => "1" }
+      .to output("bar\n").to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+  end
+
   it "uses tap trust configuration to evaluate all formulae" do
     used_formula = instance_double(Formula, full_name: "foo")
     cmd = described_class.new(["--formula", "foo"])

--- a/Library/Homebrew/test/cmd/version-install_spec.rb
+++ b/Library/Homebrew/test/cmd/version-install_spec.rb
@@ -17,13 +17,24 @@ RSpec.describe Homebrew::Cmd::VersionInstall do
   let(:formula) { "foo" }
 
   before do
-    allow(Tap).to receive(:installed).and_return(installed_taps)
-    allow(Formula).to receive(:installed_formula_names).and_return(installed_formula_names)
-    allow(Homebrew::EnvConfig).to receive(:no_github_api?).and_return(true)
-    allow(Formulary).to receive(:factory) { |ref, **opts| formulary_factory.call(ref, **opts) }
+    unless RSpec.current_example&.metadata&.key?(:integration_test)
+      allow(Tap).to receive(:installed).and_return(installed_taps)
+      allow(Formula).to receive(:installed_formula_names).and_return(installed_formula_names)
+      allow(Homebrew::EnvConfig).to receive(:no_github_api?).and_return(true)
+      allow(Formulary).to receive(:factory) { |ref, **opts| formulary_factory.call(ref, **opts) }
+    end
   end
 
   it_behaves_like "parseable arguments"
+
+  it "recognises an installed versioned Formula", :integration_test do
+    setup_test_formula "testball@0.1", tab_attributes: { installed_on_request: true }
+
+    expect { brew "version-install", "testball", "0.1" }
+      .to output(/testball@0\.1 is already installed/).to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+  end
 
   context "when the versioned formula is already installed" do
     let(:installed_formula_names) { [versioned_name] }

--- a/Library/Homebrew/test/cmd/vulns_spec.rb
+++ b/Library/Homebrew/test/cmd/vulns_spec.rb
@@ -8,6 +8,15 @@ require "cmd/shared_examples/args_parse"
 RSpec.describe Homebrew::Cmd::Vulns do
   it_behaves_like "parseable arguments"
 
+  it "scans a Formula", :integration_test do
+    setup_test_formula "testball"
+
+    expect { brew "vulns", "--json", "testball" }
+      .to output(/"skipped_formulae"/).to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+  end
+
   describe "#formulae" do
     let(:installed) { instance_double(Formula, full_name: "curl", recursive_dependencies: []) }
 

--- a/Library/Homebrew/test/cmd/which-formula_spec.rb
+++ b/Library/Homebrew/test/cmd/which-formula_spec.rb
@@ -8,6 +8,7 @@ require "cmd/which-formula"
 
 RSpec.describe Homebrew::Cmd::WhichFormula do
   it_behaves_like "parseable arguments"
+  it_behaves_like "a documented command", "which-formula", shell: true
 
   describe "which_formula" do
     let(:shell_cellar) { HOMEBREW_CELLAR }

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -7,6 +7,13 @@ require "cmd/shared_examples/args_parse"
 RSpec.describe Homebrew::DevCmd::Audit do
   it_behaves_like "parseable arguments"
 
+  it "audits a Formula and Cask", :cask, :integration_test do
+    setup_test_formula "testball"
+
+    expect { brew "audit", "--skip-style", "--only=description", "testball", "local-caffeine" }
+      .to be_a_success
+  end
+
   describe "#run" do
     subject(:audit) { described_class.new(["--tap=homebrew/test"]) }
 

--- a/Library/Homebrew/test/dev-cmd/benchmark_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/benchmark_spec.rb
@@ -7,6 +7,43 @@ require "dev-cmd/benchmark"
 RSpec.describe Homebrew::DevCmd::Benchmark do
   it_behaves_like "parseable arguments"
 
+  it "benchmarks a Formula", :integration_test do
+    formula_file = setup_test_formula "testball"
+    (HOMEBREW_PREFIX/"bin/brew").write <<~SH
+      #!/bin/sh
+      if [ "$1" = "--cache" ]; then
+        printf '/tmp/testball-cache\n'
+      fi
+    SH
+    (HOMEBREW_PREFIX/"bin/brew").chmod(0755)
+    bin = mktmpdir
+    (bin/"hyperfine").write <<~SH
+      #!/bin/sh
+      for argument in "$@"; do
+        if [ "${previous:-}" = "--export-json" ]; then
+          export_json=$argument
+        fi
+        previous=$argument
+      done
+      phase_output=$(printf '%s\n' "$export_json" | sed 's/hyperfine-/phases-/')
+      printf '{"results":[{"mean":0.1}]}' > "$export_json"
+      printf '{"events":[]}' > "$phase_output"
+    SH
+    (bin/"hyperfine").chmod(0755)
+
+    mktmpdir do |directory|
+      directory.cd do
+        expect do
+          brew "benchmark", "--runs=1", formula_file,
+               "PATH" => "#{bin}:#{ENV.fetch("PATH")}"
+        end
+          .to output(/Benchmark results.*Full results written/m).to_stdout
+          .and be_a_success
+      end
+      expect(directory/"benchmark/results.json").to be_a_file
+    end
+  end
+
   it "rotates workloads and records hyperfine and phase timings" do
     directory = mktmpdir
     hyperfine = mktmpdir/"hyperfine"

--- a/Library/Homebrew/test/dev-cmd/bump-cask-pr_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-cask-pr_spec.rb
@@ -75,6 +75,19 @@ RSpec.describe Homebrew::DevCmd::BumpCaskPr do
 
   it_behaves_like "parseable arguments"
 
+  it "updates a Cask without creating a pull request", :cask, :integration_test do
+    CoreCaskTap.instance.path.cd do
+      system "git", "init"
+      system "git", "remote", "add", "origin", "https://github.com/Homebrew/homebrew-cask"
+    end
+
+    expect do
+      brew "bump-cask-pr", "--write-only", "--no-audit", "--no-style",
+           "--version=1.2.4", "--sha256=:no_check", "local-caffeine"
+    end.to be_a_success
+    expect(Cask::CaskLoader.load("local-caffeine").version.to_s).to eq("1.2.4")
+  end
+
   describe "::generate_system_options" do
     # We simulate a macOS version older than the newest, as the method will use
     # the host macOS version instead of the default (the newest macOS version).

--- a/Library/Homebrew/test/dev-cmd/bump-compatibility-version_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-compatibility-version_spec.rb
@@ -7,6 +7,15 @@ require "dev-cmd/bump-compatibility-version"
 RSpec.describe Homebrew::DevCmd::BumpCompatibilityVersion do
   it_behaves_like "parseable arguments"
 
+  it "previews a Formula compatibility version bump", :integration_test do
+    setup_test_formula "testball"
+
+    expect { brew "bump-compatibility-version", "--dry-run", "testball" }
+      .to output(/add "compatibility_version 1"/).to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+  end
+
   describe "#run" do
     before do
       allow(Homebrew).to receive(:install_bundler_gems!)

--- a/Library/Homebrew/test/dev-cmd/bump-formula-pr_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-formula-pr_spec.rb
@@ -17,6 +17,21 @@ RSpec.describe Homebrew::DevCmd::BumpFormulaPr do
 
   it_behaves_like "parseable arguments"
 
+  it "updates a Formula without creating a pull request", :integration_test do
+    formula_path = setup_test_formula "testball"
+    CoreTap.instance.path.cd do
+      system "git", "init"
+      system "git", "remote", "add", "origin", "https://github.com/Homebrew/homebrew-core"
+    end
+    tarball = TEST_FIXTURE_DIR/"tarballs/testball2-0.1.tbz"
+
+    expect do
+      brew "bump-formula-pr", "--write-only", "--no-audit", "--version=0.2",
+           "--url=file://#{tarball}", "--sha256=#{tarball.sha256}", "testball"
+    end.to be_a_success
+    expect(formula_path.read).to include("version \"0.2\"")
+  end
+
   describe "#run" do
     it "adds updated mirrors as string literals" do
       formula_path = CoreTap.instance.new_formula_path("couchdb")

--- a/Library/Homebrew/test/dev-cmd/bump-revision_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-revision_spec.rb
@@ -6,4 +6,13 @@ require "dev-cmd/bump-revision"
 
 RSpec.describe Homebrew::DevCmd::BumpRevision do
   it_behaves_like "parseable arguments"
+
+  it "previews a Formula revision bump", :integration_test do
+    setup_test_formula "testball"
+
+    expect { brew "bump-revision", "--dry-run", "testball" }
+      .to output(/add "revision 1"/).to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+  end
 end

--- a/Library/Homebrew/test/dev-cmd/bump-unversioned-casks_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-unversioned-casks_spec.rb
@@ -6,4 +6,21 @@ require "dev-cmd/bump-unversioned-casks"
 
 RSpec.describe Homebrew::DevCmd::BumpUnversionedCasks do
   it_behaves_like "parseable arguments"
+
+  it "skips an unsuitable Cask", :cask, :integration_test do
+    caskfile = CoreCaskTap.instance.cask_dir/"versioned-test.rb"
+    caskfile.write <<~RUBY
+      cask "versioned-test" do
+        version "1.0"
+        sha256 :no_check
+        url "https://brew.sh/versioned-test-1.0.zip"
+      end
+    RUBY
+    CoreCaskTap.instance.clear_cache
+
+    expect { brew "bump-unversioned-casks", "--dry-run", caskfile }
+      .to output(/Unversioned Casks: 1.*Checking versioned-test/m).to_stdout
+      .and output(/Skipping, not a single-app or PKG cask/).to_stderr
+      .and be_a_success
+  end
 end

--- a/Library/Homebrew/test/dev-cmd/bump_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe Homebrew::DevCmd::Bump do
 
   it_behaves_like "parseable arguments"
 
-  describe "formula", :integration_test, :needs_homebrew_curl, :needs_network do
-    it "returns no data and prints a message for HEAD-only formulae" do
+  describe "formula and cask", :cask, :integration_test do
+    it "prints messages for HEAD-only Formulae and latest Casks" do
       content = <<~RUBY
         desc "HEAD-only test formula"
         homepage "https://brew.sh"
@@ -50,8 +50,8 @@ RSpec.describe Homebrew::DevCmd::Bump do
       RUBY
       setup_test_formula("headonly", content)
 
-      expect { brew "bump", "headonly" }
-        .to output(/Formula is HEAD-only./).to_stdout
+      expect { brew "bump", "--no-pull-requests", "headonly", "version-latest" }
+        .to output(/Formula is HEAD-only.*Cask uses `version :latest`/m).to_stdout
         .and not_to_output.to_stderr
         .and be_a_success
     end

--- a/Library/Homebrew/test/dev-cmd/cat_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/cat_spec.rb
@@ -33,12 +33,11 @@ RSpec.describe Homebrew::DevCmd::Cat do
     cat.run
   end
 
-  it "prints the content of a given Formula", :integration_test do
+  it "prints the content of a given Formula and Cask", :cask, :integration_test do
     formula_file = setup_test_formula "testball"
-    content = formula_file.read
 
-    expect { brew "cat", "testball" }
-      .to output(content).to_stdout
+    expect { brew "cat", "testball", "local-caffeine" }
+      .to output(/#{Regexp.escape(formula_file.read)}.*#{Regexp.escape(cask_path("local-caffeine").read)}/m).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
   end

--- a/Library/Homebrew/test/dev-cmd/contributions_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/contributions_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Homebrew::DevCmd::Contributions do
   before { stub_const("HOMEBREW_CACHE", mktmpdir) }
 
   it_behaves_like "parseable arguments"
+  it_behaves_like "a documented command", "contributions"
 
   it "documents the governance reporting quarters" do
     help_text = described_class.parser.generate_help_text.gsub(/\s+/, " ")

--- a/Library/Homebrew/test/dev-cmd/debugger_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/debugger_spec.rb
@@ -1,0 +1,6 @@
+# typed: true
+# frozen_string_literal: true
+
+RSpec.describe "brew debugger", type: :system do
+  it_behaves_like "a documented command", "debugger"
+end

--- a/Library/Homebrew/test/dev-cmd/edit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/edit_spec.rb
@@ -7,7 +7,7 @@ require "dev-cmd/edit"
 RSpec.describe Homebrew::DevCmd::Edit do
   it_behaves_like "parseable arguments"
 
-  it "opens a given Formula in an editor", :integration_test do
+  it "opens a given Formula and prints a Cask's path", :cask, :integration_test do
     HOMEBREW_REPOSITORY.cd do
       system "git", "init"
     end
@@ -16,6 +16,10 @@ RSpec.describe Homebrew::DevCmd::Edit do
 
     expect { brew "edit", "testball", "HOMEBREW_EDITOR" => "/bin/cat", "HOMEBREW_NO_ENV_HINTS" => "1" }
       .to output(/# something here/).to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+    expect { brew "edit", "--print-path", "--cask", cask_path("local-caffeine") }
+      .to output("#{cask_path("local-caffeine")}\n").to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
   end

--- a/Library/Homebrew/test/dev-cmd/generate-man-completions_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-man-completions_spec.rb
@@ -6,4 +6,5 @@ require "dev-cmd/generate-man-completions"
 
 RSpec.describe Homebrew::DevCmd::GenerateManCompletions do
   it_behaves_like "parseable arguments"
+  it_behaves_like "a documented command", "generate-man-completions"
 end

--- a/Library/Homebrew/test/dev-cmd/generate-zap_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-zap_spec.rb
@@ -9,6 +9,24 @@ RSpec.describe Homebrew::DevCmd::GenerateZap do
 
   it_behaves_like "parseable arguments"
 
+  it "generates a zap stanza for a Cask", :cask, :integration_test do
+    caskfile = CoreCaskTap.instance.cask_dir/"zap-integration.rb"
+    caskfile.write <<~RUBY
+      cask "zap-integration" do
+        version "1.0"
+        sha256 :no_check
+        url "https://brew.sh/zap-integration-1.0.zip"
+        app "CodexZapCoverageRandom.app"
+      end
+    RUBY
+    CoreCaskTap.instance.clear_cache
+
+    expect { brew "generate-zap", caskfile }
+      .to output(/Scanning for files matching.*No zap stanza required/m).to_stdout
+      .and output(/No files found matching/).to_stderr
+      .and be_a_success
+  end
+
   describe "#run" do
     it "surfaces Full Disk Access guidance when scanning raises a permission error" do
       generate_zap = described_class.new(["--name", "Test"])

--- a/Library/Homebrew/test/dev-cmd/install-bundler-gems_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/install-bundler-gems_spec.rb
@@ -6,6 +6,7 @@ require "dev-cmd/install-bundler-gems"
 
 RSpec.describe Homebrew::DevCmd::InstallBundlerGems do
   it_behaves_like "parseable arguments"
+  it_behaves_like "a documented command", "install-bundler-gems"
 
   it "resets Bootsnap after cleaning gems" do
     bundle = "/tmp/bundle"

--- a/Library/Homebrew/test/dev-cmd/lgtm_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/lgtm_spec.rb
@@ -9,6 +9,7 @@ require "utils/tty"
 
 RSpec.describe Homebrew::DevCmd::Lgtm do
   it_behaves_like "parseable arguments"
+  it_behaves_like "a documented command", "lgtm"
 
   describe "#run" do
     subject(:lgtm) { described_class.new(args) }

--- a/Library/Homebrew/test/dev-cmd/linkage_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/linkage_spec.rb
@@ -7,8 +7,14 @@ require "dev-cmd/linkage"
 RSpec.describe Homebrew::DevCmd::Linkage do
   it_behaves_like "parseable arguments"
 
-  it "works when no arguments are provided", :integration_test do
+  it "checks installed Formulae", :integration_test do
+    setup_test_formula "testball", tab_attributes: { installed_on_request: true }
+
     expect { brew "linkage" }
+      .to be_a_success
+      .and not_to_output.to_stdout
+      .and not_to_output.to_stderr
+    expect { brew "linkage", "testball" }
       .to be_a_success
       .and not_to_output.to_stdout
       .and not_to_output.to_stderr

--- a/Library/Homebrew/test/dev-cmd/livecheck_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/livecheck_spec.rb
@@ -7,16 +7,20 @@ require "dev-cmd/livecheck"
 RSpec.describe Homebrew::DevCmd::LivecheckCmd do
   it_behaves_like "parseable arguments"
 
-  it "reports the latest version of a Formula", :integration_test, :needs_network do
+  it "skips a Formula and Cask with disabled livechecks", :cask, :integration_test do
     content = <<~RUBY
       desc "Some test"
       homepage "https://github.com/Homebrew/brew"
       url "https://brew.sh/test-1.0.0.tgz"
+
+      livecheck do
+        skip "integration test"
+      end
     RUBY
     setup_test_formula("test", content)
 
-    expect { brew "livecheck", "test" }
-      .to output(/test: /).to_stdout
+    expect { brew "livecheck", "test", "latest-with-livecheck-skip" }
+      .to output(/latest-with-livecheck-skip: skipped.*test: skipped - integration test/m).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
   end

--- a/Library/Homebrew/test/dev-cmd/rubocop_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/rubocop_spec.rb
@@ -1,0 +1,6 @@
+# typed: true
+# frozen_string_literal: true
+
+RSpec.describe "brew rubocop", type: :system do
+  it_behaves_like "a documented command", "rubocop", shell: true
+end

--- a/Library/Homebrew/test/dev-cmd/rubydoc_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/rubydoc_spec.rb
@@ -1,0 +1,6 @@
+# typed: true
+# frozen_string_literal: true
+
+RSpec.describe "brew rubydoc", type: :system do
+  it_behaves_like "a documented command", "rubydoc"
+end

--- a/Library/Homebrew/test/dev-cmd/style_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/style_spec.rb
@@ -6,4 +6,20 @@ require "dev-cmd/style"
 
 RSpec.describe Homebrew::DevCmd::StyleCmd do
   it_behaves_like "parseable arguments"
+
+  it "checks a Formula and Cask", :cask, :integration_test do
+    formula_file = setup_test_formula "testball"
+    HOMEBREW_LIBRARY.mkpath
+    FileUtils.ln_s HOMEBREW_LIBRARY_PATH.parent/".rubocop.yml", HOMEBREW_LIBRARY/".rubocop.yml"
+    FileUtils.ln_s HOMEBREW_LIBRARY_PATH, HOMEBREW_LIBRARY/"Homebrew"
+
+    begin
+      expect do
+        brew "style", "--only-cops=Layout/TrailingWhitespace", formula_file, cask_path("local-caffeine")
+      end.to be_a_success
+    ensure
+      FileUtils.rm_f HOMEBREW_LIBRARY/".rubocop.yml"
+      FileUtils.rm_f HOMEBREW_LIBRARY/"Homebrew"
+    end
+  end
 end

--- a/Library/Homebrew/test/dev-cmd/test-bot_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/test-bot_spec.rb
@@ -1,0 +1,6 @@
+# typed: true
+# frozen_string_literal: true
+
+RSpec.describe "brew test-bot", type: :system do
+  it_behaves_like "a documented command", "test-bot"
+end

--- a/Library/Homebrew/test/dev-cmd/tests_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tests_spec.rb
@@ -7,6 +7,7 @@ require "parallel_tests/rspec/runner"
 
 RSpec.describe Homebrew::DevCmd::Tests do
   it_behaves_like "parseable arguments"
+  it_behaves_like "a documented command", "tests"
 
   describe "#run" do
     subject(:tests) { described_class.new(args) }

--- a/Library/Homebrew/test/dev-cmd/typecheck_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/typecheck_spec.rb
@@ -6,6 +6,7 @@ require "dev-cmd/typecheck"
 
 RSpec.describe Homebrew::DevCmd::Typecheck do
   it_behaves_like "parseable arguments"
+  it_behaves_like "a documented command", "typecheck"
 
   describe "#trim_rubocop_rbi" do
     let(:rbi_file) { Pathname.new("#{TEST_FIXTURE_DIR}/rubocop@x.x.x.rbi") }

--- a/Library/Homebrew/test/dev-cmd/unpack_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/unpack_spec.rb
@@ -7,7 +7,7 @@ require "dev-cmd/unpack"
 RSpec.describe Homebrew::DevCmd::Unpack do
   it_behaves_like "parseable arguments"
 
-  it "unpacks a given Formula's archive", :integration_test do
+  it "unpacks a given Formula and Cask archive", :cask, :integration_test do
     setup_test_formula "testball"
 
     mktmpdir do |path|
@@ -16,16 +16,12 @@ RSpec.describe Homebrew::DevCmd::Unpack do
 
       expect(path/"testball-0.1").to be_a_directory
     end
-  end
-
-  it "unpacks a given Cask's archive" do
-    caffeine_cask = Cask::CaskLoader.load(cask_path("local-caffeine"))
 
     mktmpdir do |path|
-      expect { described_class.new([cask_path("local-caffeine").to_s, "--destdir=#{path}"]).run }
-        .not_to raise_error
+      expect { brew "unpack", "--cask", cask_path("local-caffeine"), "--destdir=#{path}" }
+        .to be_a_success
 
-      expect(path/"local-caffeine-#{caffeine_cask.version}").to be_a_directory
+      expect(path/"local-caffeine-1.2.3").to be_a_directory
     end
   end
 end

--- a/Library/Homebrew/test/dev-cmd/update-perl-resources_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/update-perl-resources_spec.rb
@@ -6,4 +6,12 @@ require "dev-cmd/update-perl-resources"
 
 RSpec.describe Homebrew::DevCmd::UpdatePerlResources do
   it_behaves_like "parseable arguments"
+
+  it "loads a Formula's Perl resources", :integration_test do
+    setup_test_formula "testball"
+
+    expect { brew "update-perl-resources", "--print-only", "testball" }
+      .to output(/"testball" has no CPAN resources to update/).to_stderr
+      .and be_a_failure
+  end
 end

--- a/Library/Homebrew/test/dev-cmd/update-python-resources_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/update-python-resources_spec.rb
@@ -6,4 +6,15 @@ require "dev-cmd/update-python-resources"
 
 RSpec.describe Homebrew::DevCmd::UpdatePythonResources do
   it_behaves_like "parseable arguments"
+
+  it "loads a Formula's Python resources", :integration_test do
+    setup_test_formula "testball"
+
+    expect do
+      brew "update-python-resources", "--print-only", "--version=0.2",
+           "--ignore-non-pypi-packages", "testball"
+    end
+      .to not_to_output.to_stderr
+      .and be_a_success
+  end
 end

--- a/Library/Homebrew/test/dev-cmd/update-test_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/update-test_spec.rb
@@ -6,4 +6,5 @@ require "dev-cmd/update-test"
 
 RSpec.describe Homebrew::DevCmd::UpdateTest do
   it_behaves_like "parseable arguments"
+  it_behaves_like "a documented command", "update-test"
 end

--- a/Library/Homebrew/test/dev-cmd/vendor-gems_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/vendor-gems_spec.rb
@@ -6,6 +6,7 @@ require "dev-cmd/vendor-gems"
 
 RSpec.describe Homebrew::DevCmd::VendorGems do
   it_behaves_like "parseable arguments"
+  it_behaves_like "a documented command", "vendor-gems"
 
   sig { returns(Homebrew::DevCmd::VendorGems) }
   def vendor_gems_command

--- a/Library/Homebrew/test/dev-cmd/verify_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/verify_spec.rb
@@ -6,4 +6,12 @@ require "dev-cmd/verify"
 
 RSpec.describe Homebrew::DevCmd::Verify do
   it_behaves_like "parseable arguments"
+
+  it "checks whether a Formula has a bottle to verify", :integration_test do
+    setup_test_formula "testball"
+
+    expect { brew "verify", "testball" }
+      .to output(/Bottle for tag .* is unavailable\./).to_stderr
+      .and be_a_success
+  end
 end

--- a/Library/Homebrew/test/manpages_spec.rb
+++ b/Library/Homebrew/test/manpages_spec.rb
@@ -72,4 +72,18 @@ RSpec.describe Homebrew::Manpages do
 
     expect(manpage).not_to include(*hidden_commands)
   end
+
+  it "has integration test coverage for every documented command" do
+    missing_commands = {
+      "cmd"     => Commands.internal_commands,
+      "dev-cmd" => Commands.internal_developer_commands,
+    }.flat_map do |directory, commands|
+      commands.reject do |command|
+        spec = HOMEBREW_LIBRARY_PATH/"test/#{directory}/#{command}_spec.rb"
+        spec.exist? && spec.read.match?(/:integration_test|a documented command/)
+      end
+    end
+
+    expect(missing_commands).to be_empty
+  end
 end

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -5,6 +5,8 @@ if ENV["HOMEBREW_TESTS_COVERAGE"]
   require "simplecov"
   require "simplecov-cobertura"
   SimpleCov.start
+  require_relative "support/helper/integration_coverage"
+  Homebrew::TestIntegrationCoverage.prepare!
 
   formatters = [
     SimpleCov::Formatter::HTMLFormatter,

--- a/Library/Homebrew/test/support/helper/integration_coverage.rb
+++ b/Library/Homebrew/test/support/helper/integration_coverage.rb
@@ -1,0 +1,63 @@
+# typed: false
+# frozen_string_literal: true
+
+require "coverage"
+require "json"
+
+module Homebrew
+  module TestIntegrationCoverage
+    DIRECTORY_ENV = "HOMEBREW_INTEGRATION_COVERAGE_DIR"
+    private_constant :DIRECTORY_ENV
+
+    class << self
+      def prepare!
+        require "fileutils"
+
+        directory = File.join(
+          SimpleCov.coverage_path,
+          ".integration#{ENV.fetch("TEST_ENV_NUMBER", "")}",
+        )
+        FileUtils.rm_rf directory
+        FileUtils.mkdir_p directory
+        ENV[DIRECTORY_ENV] = directory
+        Kernel.at_exit { store_results!(directory) }
+      end
+
+      def start!
+        Coverage.start(lines: true, branches: true, eval: true)
+        Kernel.at_exit { dump! }
+      end
+
+      def dump!
+        return unless Coverage.running?
+
+        directory = ENV.fetch(DIRECTORY_ENV)
+        result_path = File.join(directory, "#{ENV.fetch("HOMEBREW_INTEGRATION_TEST")}.json")
+        temporary_path = "#{result_path}.#{Process.pid}.tmp"
+        File.write(temporary_path, JSON.generate(Coverage.result))
+        File.rename(temporary_path, result_path)
+      end
+
+      def store_results!(directory)
+        accumulator = SimpleCov::Combine::CoverageAccumulator.new
+        Dir.glob(File.join(directory, "*.json")).each do |path|
+          coverage = JSON.parse(File.read(path))
+          coverage = SimpleCov::UselessResultsRemover.call(coverage)
+          accumulator.absorb(coverage)
+        end
+        result = accumulator.result
+        return if result.nil?
+
+        command_name = "brew_i:#{Process.pid}:#{ENV.fetch("TEST_ENV_NUMBER", "")}"
+        SimpleCov::ResultMerger.store_result(SimpleCov::Result.new(result, command_name:))
+      ensure
+        require "fileutils"
+
+        FileUtils.rm_rf directory
+        ENV.delete(DIRECTORY_ENV) if ENV[DIRECTORY_ENV] == directory
+      end
+    end
+  end
+end
+
+Homebrew::TestIntegrationCoverage.start! if ENV["HOMEBREW_INTEGRATION_TEST"]

--- a/Library/Homebrew/test/support/helper/integration_coverage_spec.rb
+++ b/Library/Homebrew/test/support/helper/integration_coverage_spec.rb
@@ -1,0 +1,55 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test/support/helper/integration_coverage"
+
+RSpec.describe Homebrew::TestIntegrationCoverage do
+  it "records coverage before an integration command execs" do
+    mktmpdir do |directory|
+      env = {
+        "HOMEBREW_INTEGRATION_COVERAGE_DIR" => directory.to_s,
+        "HOMEBREW_INTEGRATION_TEST"         => "integration-command",
+        "HOMEBREW_TESTS_COVERAGE"           => "1",
+      }
+      coverage_helper = HOMEBREW_LIBRARY_PATH/"test/support/helper/integration_coverage"
+      integration_mocks = HOMEBREW_LIBRARY_PATH/"test/support/helper/integration_mocks"
+      script = "abort if defined?(SimpleCov); Object.new.extend(Homebrew).exec('/usr/bin/true')"
+
+      _, _, status = Open3.capture3(
+        env,
+        *HOMEBREW_RUBY_EXEC_ARGS,
+        "-r#{coverage_helper}",
+        "-r#{integration_mocks}",
+        "-e", script
+      )
+      result_path = directory/"integration-command.json"
+      coverage = result_path.exist? ? JSON.parse(result_path.read) : {}
+
+      expect([status.success?, coverage.key?(integration_mocks.sub_ext(".rb").to_s)]).to eq([true, true])
+    end
+  end
+
+  it "merges child results before storing them with SimpleCov" do
+    require "simplecov"
+
+    mktmpdir do |directory|
+      source = (HOMEBREW_LIBRARY_PATH/"brew.rb").to_s
+      branches = {
+        [:if, 0, 1, 0, 1, 1] => {
+          [:then, 1, 1, 0, 1, 1] => 1,
+        },
+      }
+      File.write(directory/"one.json", JSON.generate(source => { lines: [1], branches: }))
+      File.write(directory/"two.json", JSON.generate(source => { lines: [2], branches: }))
+      stored_results = []
+      allow(SimpleCov::ResultMerger).to receive(:store_result) { |result| stored_results << result }
+
+      described_class.store_results!(directory)
+
+      stored_result = stored_results.fetch(0)
+      coverage = stored_result.original_result.fetch(source)
+      expect([coverage.fetch("lines"), coverage.fetch("branches").values.first.values])
+        .to eq([[3], [2]])
+    end
+  end
+end

--- a/Library/Homebrew/test/support/helper/integration_mocks.rb
+++ b/Library/Homebrew/test/support/helper/integration_mocks.rb
@@ -13,7 +13,7 @@ module Homebrew
   def exec(*args)
     if ENV["HOMEBREW_TESTS_COVERAGE"] && ENV["HOMEBREW_INTEGRATION_TEST"]
       # Ensure we get coverage results before replacing the current process.
-      SimpleCov.result
+      Homebrew::TestIntegrationCoverage.dump!
     end
     Kernel.exec(*args)
   end

--- a/Library/Homebrew/test/support/helper/simplecov_start.rb
+++ b/Library/Homebrew/test/support/helper/simplecov_start.rb
@@ -1,9 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "rubygems/version"
-
-simplecov_root = File.expand_path("../../..", __dir__)
-Dir.chdir(simplecov_root) { require "simplecov" }
-
-SimpleCov.start

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -44,6 +44,28 @@ end
 
 RSpec::Matchers.define_negated_matcher :be_a_failure, :be_a_success
 
+RSpec.shared_examples "a documented command" do |command, shell: false|
+  T.bind(self, T.class_of(RSpec::Core::ExampleGroup))
+
+  it "shows its help", :integration_test,
+     documented_command: T.cast(command, String), documented_command_shell: T.cast(shell, T::Boolean) do
+    T.bind(self, RSpec::Core::ExampleGroup)
+    example = RSpec.current_example
+    raise "Current RSpec example is unavailable" if example.nil?
+
+    documented_command = T.cast(example.metadata.fetch(:documented_command), String)
+    documented_command_shell = T.cast(example.metadata.fetch(:documented_command_shell), T::Boolean)
+
+    expect do
+      if documented_command_shell
+        T.unsafe(self).brew_sh("help", documented_command)
+      else
+        T.unsafe(self).brew("help", documented_command)
+      end
+    end.to be_a_success
+  end
+end
+
 module Test
   module Helper
     module IntegrationTest
@@ -75,6 +97,7 @@ module Test
         ].compact.join(File::PATH_SEPARATOR)
 
         env["HOMEBREW_AVOID_NESTED_SANDBOXING"] = "1"
+        env["HOMEBREW_INTEGRATION_COVERAGE_DIR"] = ENV.fetch("HOMEBREW_INTEGRATION_COVERAGE_DIR", nil)
         env.merge!(
           "PATH"                         => path,
           "HOMEBREW_PATH"                => path,
@@ -85,26 +108,15 @@ module Test
           "HOMEBREW_ASK"                 => nil,
           "HOMEBREW_USE_RUBY_FROM_PATH"  => ENV.fetch("HOMEBREW_USE_RUBY_FROM_PATH", nil),
           "HOMEBREW_NO_INSTALL_FROM_API" => ENV.fetch("HOMEBREW_NO_INSTALL_FROM_API", nil),
+          "HOMEBREW_SORBET_RUNTIME"      => nil,
+          "HOMEBREW_SORBET_RECURSIVE"    => nil,
           "GEM_HOME"                     => nil,
         )
 
         @ruby_args ||= begin
           ruby_args = HOMEBREW_RUBY_EXEC_ARGS.dup
           if ENV["HOMEBREW_TESTS_COVERAGE"]
-            simplecov_spec = Gem.loaded_specs["simplecov"]
-            parallel_tests_spec = Gem.loaded_specs["parallel_tests"]
-            specs = T.let([], T::Array[Gem::Specification])
-            [simplecov_spec, parallel_tests_spec].each do |spec|
-              specs << spec
-              spec.runtime_dependencies.each do |dep|
-                specs += dep.to_specs
-              rescue Gem::LoadError => e
-                T.bind(self, Utils::Output::Mixin)
-                onoe e
-              end
-            end
-            specs.flat_map(&:full_require_paths).each { |lib| ruby_args << "-I" << lib }
-            ruby_args << "-r#{HOMEBREW_LIBRARY_PATH}/test/support/helper/simplecov_start"
+            ruby_args << "-r#{HOMEBREW_LIBRARY_PATH}/test/support/helper/integration_coverage"
           end
           ruby_args << "-r#{HOMEBREW_LIBRARY_PATH}/test/support/helper/integration_mocks"
           ruby_args << "-e" << "$0 = ARGV.shift; load($0)"
@@ -216,11 +228,11 @@ module Test
 
         return formula_path if tab_attributes.nil?
 
-        keg = ::Formula[name].prefix
+        formula = ::Formula[name]
+        keg = formula.prefix
         keg.mkpath
 
-        tab = Tab.for_name(name)
-        tab.tabfile ||= keg/AbstractTab::FILENAME
+        tab = Tab.create(formula)
         tab_attributes.each do |key, value|
           tab.public_send(:"#{key}=", value)
         end
@@ -261,25 +273,6 @@ module Test
           system "git", "commit", "-m", "init"
         end
         path
-      end
-
-      sig { params(old_name: String, new_name: String).void }
-      def install_and_rename_coretap_formula(old_name, new_name)
-        CoreTap.instance.path.cd do |tap_path|
-          system "git", "init"
-          system "git", "add", "--all"
-          system "git", "commit", "-m",
-                 "#{old_name.capitalize} has not yet been renamed"
-
-          brew "install", old_name
-
-          (tap_path/"Formula/#{old_name}.rb").unlink
-          (tap_path/"formula_renames.json").write JSON.pretty_generate(old_name => new_name)
-
-          system "git", "add", "--all"
-          system "git", "commit", "-m",
-                 "#{old_name.capitalize} has been renamed to #{new_name.capitalize}"
-        end
       end
 
       sig { returns(String) }

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test_spec.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test_spec.rb
@@ -1,0 +1,50 @@
+# typed: true
+# frozen_string_literal: true
+
+RSpec.describe Test::Helper::IntegrationTest do
+  subject(:helper) { Object.new.extend(described_class) }
+
+  let(:status) { instance_double(Process::Status) }
+
+  before do
+    allow(helper).to receive(:command_id).and_return("integration-command")
+  end
+
+  around do |example|
+    (HOMEBREW_PREFIX/"bin").mkpath
+    example.run
+  ensure
+    FileUtils.rm_rf HOMEBREW_PREFIX/"bin"
+  end
+
+  it "disables Sorbet checking in Ruby integration commands" do
+    captured_env = {}
+    allow(Open3).to receive(:capture3) do |env, *_args|
+      captured_env.replace(env)
+      ["", "", status]
+    end
+
+    helper.brew "help"
+
+    expect(captured_env.slice("HOMEBREW_SORBET_RUNTIME", "HOMEBREW_SORBET_RECURSIVE")).to eq(
+      "HOMEBREW_SORBET_RUNTIME"   => nil,
+      "HOMEBREW_SORBET_RECURSIVE" => nil,
+    )
+  end
+
+  it "uses the lightweight integration coverage recorder" do
+    ENV["HOMEBREW_TESTS_COVERAGE"] = "1"
+    captured_command = []
+    allow(Open3).to receive(:capture3) do |_env, *command|
+      captured_command.replace(command.map(&:to_s))
+      ["", "", status]
+    end
+
+    helper.brew "help"
+
+    expect([
+      captured_command.any? { |arg| arg.include?("integration_coverage") },
+      captured_command.any? { |arg| arg.include?("simplecov_start") },
+    ]).to eq([true, false])
+  end
+end


### PR DESCRIPTION
- Test every documented command through an outside-in smoke path.
- Record child coverage with Ruby `Coverage` and skip Sorbet loading.
- Build installed fixtures directly and combine Formula and Cask paths.
- Roughly 35% local integration speedup (before new ones added) but will see how it does in actual CI.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Codex with GPT 5.6-sol at Extra High effort, with local review and testing.

-----