### PR TITLE
Handle absent cask bundle version suffixes

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -827,6 +827,8 @@ module Cask
         end
         return false if combined_version_comparisons.include?(0)
         return false if combined_version_comparisons.present? && combined_version_comparisons.exclude?(-1)
+        return false if combined_version_comparisons.empty? &&
+                        installed_short_version == tap_short_version.rpartition("-").first
       end
 
       return false if [installed_short_version, installed_bundle_version].any? do |installed_plist_version|

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -381,6 +381,15 @@ RSpec.describe Cask::Cask, :cask do
         expect(cask.outdated_version).to be_nil
       end
 
+      it "is not outdated when the tap version has a suffix absent from the app bundle" do
+        tap_version = "3.6.4-28955b81"
+        cask = write_auto_updates_cask(cask_file, version: tap_version, artifacts:)
+        allow(cask).to receive(:installed_version).and_return("3.6.3-931da4a1")
+        write_info_plist(cask.config.appdir/"MyFancyApp.app", short_version: "3.6.4", bundle_version: "3.6.4")
+
+        expect(cask.outdated_version).to be_nil
+      end
+
       it "is not outdated when the combined installed version is higher than the tap version" do
         tap_version = "2.61-2057"
         cask = write_auto_updates_cask(cask_file, version: tap_version, artifacts:)
@@ -388,6 +397,15 @@ RSpec.describe Cask::Cask, :cask do
         write_info_plist(cask.config.appdir/"MyFancyApp.app", short_version: "2.61", bundle_version: "2058")
 
         expect(cask.outdated_version).to be_nil
+      end
+
+      it "is outdated when the combined installed version is lower than the tap version" do
+        tap_version = "2.61-2057"
+        cask = write_auto_updates_cask(cask_file, version: tap_version, artifacts:)
+        allow(cask).to receive(:installed_version).and_return("2.57-2056")
+        write_info_plist(cask.config.appdir/"MyFancyApp.app", short_version: "2.61", bundle_version: "2056")
+
+        expect(cask.outdated_version).to eq("2.57-2056")
       end
 
       it "is not outdated when the installed short version matches a CSV build candidate" do


### PR DESCRIPTION
- Avoid treating a tap suffix as stale when combined plist versions cannot be compared and the leading app version matches.
- Preserve stale detection for lower reconstructable bundle versions.

Fixes #23678

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Codex with GPT 5.6-sol at Extra High effort, with local review and testing.

-----