### PR TITLE
bundle/mac_app_store: Support upcoming mas 8.0.0

### DIFF
--- a/Library/Homebrew/bundle/extensions/mac_app_store.rb
+++ b/Library/Homebrew/bundle/extensions/mac_app_store.rb
@@ -81,7 +81,7 @@ module Homebrew
 
           @apps = if (mas = package_manager_executable)
             `#{mas} list 2>/dev/null`.split("\n").filter_map do |app|
-              app_details = app.match(/\A\s*(?<id>\d+)\s+(?<name>.*?)\s+\((?<version>[\d.]*)\)\Z/)
+              app_details = app.match(/\A\s*(?<id>\d+)\s+(?<name>.*?)\s+\(?(?<version>[\d.]*)\)?\Z/)
               next if app_details.nil?
 
               id = app_details[:id]

--- a/Library/Homebrew/test/bundle/mac_app_store_spec.rb
+++ b/Library/Homebrew/test/bundle/mac_app_store_spec.rb
@@ -175,6 +175,34 @@ RSpec.describe Homebrew::Bundle::MacAppStore do
         expect(dumper.apps).to eql(expected_app_details_array)
       end
     end
+
+    context "with the 8.0.0+ format" do
+      let(:new_mas_output) do
+        <<~HEREDOC
+          1440147259  AdGuard for Safari  1.9.13
+           497799835  Xcode               12.5
+           425424353  The Unarchiver      4.3.1
+        HEREDOC
+      end
+
+      let(:expected_app_details_array) do
+        [
+          ["1440147259", "AdGuard for Safari"],
+          ["497799835", "Xcode"],
+          ["425424353", "The Unarchiver"],
+        ]
+      end
+
+      before do
+        described_class.reset!
+        allow(described_class).to receive_messages(package_manager_executable: Pathname.new("mas"),
+                                                   "`":                        new_mas_output)
+      end
+
+      it "parses the app versions without parentheses" do
+        expect(dumper.apps).to eql(expected_app_details_array)
+      end
+    end
   end
 
   describe "installing" do


### PR DESCRIPTION
mas 7.0.0 & older surround versions in display command output with parentheses; upcoming mas 8.0.0+ will not.

This should only impact `brew` for `mas list` parsing, for which parentheses are now optional.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
