### PR TITLE
Stream parallel cleanup output

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -20,6 +20,29 @@ module Homebrew
     GH_ACTIONS_ARTIFACT_CLEANUP_DAYS = 3
     private_constant :CLEANUP_DEFAULT_DAYS, :GH_ACTIONS_ARTIFACT_CLEANUP_DAYS
 
+    class InstallCleanupOutput
+      sig { params(output: T.any(IO, StringIO), heading: String).void }
+      def initialize(output, heading)
+        @output = output
+        @heading = heading
+        @mutex = T.let(Thread::Mutex.new, Thread::Mutex)
+        @printed = T.let(false, T::Boolean)
+      end
+
+      sig { params(line: String).void }
+      def puts(line)
+        @mutex.synchronize do
+          @output.puts @heading unless @printed
+          @printed = true
+          @output.puts line
+        end
+      end
+
+      sig { returns(T::Boolean) }
+      def printed? = @printed
+    end
+    private_constant :InstallCleanupOutput
+
     class << self
       sig { params(pathname: Pathname).returns(T::Boolean) }
       def incomplete?(pathname)
@@ -257,7 +280,7 @@ module Homebrew
         scrub:   T::Boolean,
         days:    T.nilable(Integer),
         cache:   Pathname,
-        output:  T.any(IO, StringIO),
+        output:  T.any(IO, StringIO, InstallCleanupOutput),
       ).void
     }
     def initialize(*args, dry_run: false, scrub: false, days: nil, cache: HOMEBREW_CACHE, output: $stdout)
@@ -345,33 +368,24 @@ module Homebrew
       packages = T.let(formulae + casks, T::Array[T.any(Formula, Cask::Cask)])
       return if packages.empty?
 
-      cleanup_output = Utils.parallel_map(packages) do |package|
-        output = StringIO.new
+      output = InstallCleanupOutput.new($stdout, oh1_title("Cleanup"))
+      Utils.parallel_map(packages) do |package|
         cleanup = Cleanup.new(output:)
-        name = case package
+        case package
         when Formula
           cleanup.cleanup_formula(package, quiet: true, cache_db: false, cleanup_unreferenced: false)
-          package.full_specified_name
         when Cask::Cask
           cleanup.cleanup_cask(package, cleanup_unreferenced: false)
-          package.full_name
         else
           T.absurd(package)
         end
-        [name, output.string]
       end
 
       Cleanup.new.cleanup_cache_db if formulae.present?
       Cleanup.new.cleanup_unreferenced_downloads
 
-      cleanup_output.reject! { |_, output| output.empty? }
-      return if cleanup_output.empty?
+      return unless output.printed?
 
-      oh1 "Cleanup"
-      cleanup_output.each do |name, output|
-        ohai name
-        print output
-      end
       puts_no_install_cleanup_disable_message_if_not_already!
     end
 

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Homebrew::Cleanup do
       end
     end
 
-    it "only reports packages that were cleaned", :cask do
+    it "reports cleanup paths in real time without package headings", :cask do
       formula = Testball.new
       cask = Cask::Cask.new("local-caffeine")
       stale_path = mktmpdir/"testball--0.0"
@@ -88,7 +88,10 @@ RSpec.describe Homebrew::Cleanup do
       allow(described_class).to receive(:install_cleanup_formulae).with([formula]).and_return([formula])
       expect_any_instance_of(described_class).to receive(:cleanup_formula) do |cleanup, package, **|
         expect(package).to be(formula)
-        cleanup.cleanup_path(stale_path) { stale_path.unlink }
+        cleanup.cleanup_path(stale_path) do
+          expect($stdout.string).to include("Removing: #{stale_path}...")
+          stale_path.unlink
+        end
       end
       expect_any_instance_of(described_class).to receive(:cleanup_cask)
         .with(cask, cleanup_unreferenced: false)
@@ -98,7 +101,6 @@ RSpec.describe Homebrew::Cleanup do
       with_env(HOMEBREW_NO_ENV_HINTS: "1") do
         expect { described_class.install_clean!(formulae: [formula], casks: [cask]) }.to output(<<~EOS).to_stdout
           ==> Cleanup
-          ==> testball
           Removing: #{stale_path}... (#{stale_path.abv})
         EOS
       end


### PR DESCRIPTION
- Stream `Removing:` lines as package cleanups run instead of buffering every package until all parallel work has completed.
- Use a shared synchronised output sink to prevent worker lines from interleaving. Print the `Cleanup` heading only on the first removal.
- Drop per-package headings because each removal already identifies its path while preserving silent output when there is nothing to clean.
- Test that output is visible before deletion and contains no package heading.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Codex with GPT 5.6-sol at Extra High effort, with local review and testing.

-----