### PR TITLE
Add padded bottle build prefixes

### DIFF
--- a/Library/Homebrew/bottle.rb
+++ b/Library/Homebrew/bottle.rb
@@ -200,7 +200,22 @@ class Bottle
 
   sig { returns(T::Boolean) }
   def compatible_locations?
-    @spec.compatible_locations?(tag: @tag)
+    return true if compatible_locations_from_tab?
+
+    fetch_tab(quiet: true)
+    compatible_locations_from_tab?
+  rescue DownloadError, Resource::BottleManifest::Error
+    false
+  end
+
+  sig { returns(T.any(Symbol, String)) }
+  def built_cellar
+    tab = tab_attributes
+    if tab["padded_prefix"] == true && (built_prefix = tab["built_prefix"])
+      "#{built_prefix}/Cellar"
+    else
+      @spec.tag_to_cellar(@tag)
+    end
   end
 
   # Does the bottle need to be relocated?
@@ -372,6 +387,13 @@ class Bottle
   def download_queue_name = "#{name} (#{resource.version})"
 
   private
+
+  sig { returns(T::Boolean) }
+  def compatible_locations_from_tab?
+    tab = tab_attributes
+    @spec.compatible_locations?(tag: @tag, built_prefix: tab["built_prefix"],
+                                padded_prefix: tab["padded_prefix"] == true)
+  end
 
   sig { params(specs: T::Hash[Symbol, T.anything]).returns(T::Hash[Symbol, T.anything]) }
   def select_download_strategy(specs)

--- a/Library/Homebrew/bottle_specification.rb
+++ b/Library/Homebrew/bottle_specification.rb
@@ -80,16 +80,21 @@ class BottleSpecification
     end
   end
 
-  sig { params(tag: Utils::Bottles::Tag).returns(T::Boolean) }
-  def compatible_locations?(tag: Utils::Bottles.tag)
-    cellar = tag_to_cellar(tag)
+  sig {
+    params(tag: Utils::Bottles::Tag, built_prefix: T.nilable(String), padded_prefix: T::Boolean)
+      .returns(T::Boolean)
+  }
+  def compatible_locations?(tag: Utils::Bottles.tag, built_prefix: nil, padded_prefix: false)
+    return false if padded_prefix && built_prefix.nil?
+
+    cellar = padded_prefix ? "#{built_prefix}/Cellar" : tag_to_cellar(tag)
 
     return true if RELOCATABLE_CELLARS.include?(cellar)
 
     prefix = Pathname(cellar.to_s).parent.to_s
 
     # Raw prefix strings are patched in place, so the byte length decides.
-    relocatable = Homebrew::EnvConfig.relocate_build_prefix?
+    relocatable = padded_prefix || Homebrew::EnvConfig.relocate_build_prefix?
     cellar_relocatable = relocatable && cellar.to_s.bytesize >= HOMEBREW_CELLAR.to_s.bytesize
     prefix_relocatable = relocatable && prefix.bytesize >= HOMEBREW_PREFIX.to_s.bytesize
 

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -475,6 +475,7 @@ module Homebrew
 
         prefix = HOMEBREW_PREFIX.to_s
         cellar = HOMEBREW_CELLAR.to_s
+        padded = T.let(prefix == bottle_tag.padded_prefix, T::Boolean)
 
         if local_bottle_json
           bottle_path = formula.local_bottle_path
@@ -492,9 +493,12 @@ module Homebrew
                                           .tag_specification_for(bottle_tag, no_older_versions: true)
           relocatable = BottleSpecification::RELOCATABLE_CELLARS.include?(tag_spec.cellar)
           skip_relocation = tag_spec.cellar == BottleSpecification::ANY_SKIP_RELOCATION_CELLAR
+          padded = tab.padded_prefix == true
 
-          prefix = bottle_tag.default_prefix
-          cellar = bottle_tag.default_cellar
+          unless relocatable
+            cellar = tag_spec.cellar.to_s
+            prefix = tab.built_prefix || Pathname(cellar).parent.to_s
+          end
         else
           tar_filename = filename.to_s.sub(/.gz$/, "")
           tar_path = Pathname.pwd/tar_filename
@@ -600,6 +604,7 @@ module Homebrew
               end
               skip_relocation = relocatable && !keg.require_relocation?
             end
+            tab.padded_prefix = (padded && !relocatable) ? true : nil
             tab.binary_relocation_files = args.skip_relocation? ? nil : binary_relocation_files.sort
 
             if args.only_json_tab?
@@ -660,6 +665,9 @@ module Homebrew
           else
             BottleSpecification::ANY_CELLAR
           end
+        elsif padded
+          # Padded-prefix eligibility belongs in the tab, not formulae.
+          bottle_tag.default_cellar
         else
           cellar
         end
@@ -789,6 +797,7 @@ module Homebrew
           all_bottle = !args.no_all_checks? &&
                        (!old_bottle_spec_matches || bottle.rebuild != old_bottle_spec.rebuild) &&
                        tag_hashes.count > 1 &&
+                       tag_hashes.none? { it.dig("tab", "padded_prefix") == true } &&
                        tag_hashes.uniq { |tag_hash| "#{tag_hash["cellar"]}-#{tag_hash["sha256"]}" }.one?
 
           old_all_bottle = old_bottle_spec.tag?(Utils::Bottles.tag(:all))

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -550,7 +550,8 @@ class Formula
   # The {Bottle} object for the currently active {SoftwareSpec}.
   sig { returns(T.nilable(Bottle)) }
   def bottle
-    @bottle ||= T.let(Bottle.new(self, bottle_specification), T.nilable(Bottle)) if bottled?
+    bottle = @bottle_candidate ||= T.let(bottle_for_tag(Utils::Bottles.tag), T.nilable(Bottle))
+    bottle if bottle && (force_bottle || bottle.compatible_locations?)
   end
 
   # The {Bottle} object for given tag.

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -151,6 +151,7 @@ class FormulaInstaller
     @download_queue = download_queue
     @api_bottle = T.let(nil, T.nilable(Bottle))
     @api_bottle_loaded = T.let(false, T::Boolean)
+    @selected_bottle = T.let(nil, T.nilable(Bottle))
     @enqueued_bottle_download = T.let(nil, T.nilable(Downloadable))
 
     # Take the original formula instance, which might have been swapped from an API instance to a source instance
@@ -274,16 +275,17 @@ class FormulaInstaller
 
     return true if formula.local_bottle_path
 
-    bottle = api_bottle || formula.bottle_for_tag(Utils::Bottles.tag)
+    bottle = selected_bottle
     return false if bottle.nil?
 
     unless bottle.compatible_locations?
       if output_warning
-        prefix = Pathname(bottle.cellar.to_s).parent
+        cellar = bottle.built_cellar.to_s
+        prefix = Pathname(cellar).parent
         # Raw prefix strings can only be replaced in place by an equal-or-shorter
         # byte string, so the byte length difference is the fact that matters.
         excess = [HOMEBREW_PREFIX.to_s.bytesize - prefix.to_s.bytesize,
-                  HOMEBREW_CELLAR.to_s.bytesize - bottle.cellar.to_s.bytesize].max
+                  HOMEBREW_CELLAR.to_s.bytesize - cellar.bytesize].max
         cause = if excess.positive?
           "Your prefix is #{excess} bytes longer than the bottle's build prefix."
         elsif excess.negative?
@@ -293,7 +295,7 @@ class FormulaInstaller
         end
         opoo <<~EOS
           Building #{formula.full_name} from source as the bottle needs:
-          - `HOMEBREW_CELLAR=#{bottle.cellar}` (yours is #{HOMEBREW_CELLAR})
+          - `HOMEBREW_CELLAR=#{cellar}` (yours is #{HOMEBREW_CELLAR})
           - `HOMEBREW_PREFIX=#{prefix}` (yours is #{HOMEBREW_PREFIX})
           #{cause}
         EOS
@@ -386,12 +388,12 @@ class FormulaInstaller
     # Setup bottle_tab_runtime_dependencies for compute_dependencies and
     # bottle_built_os_version for dependency resolution.
     begin
-      bottle_tab_attributes = formula.bottle_tab_attributes
+      bottle = selected_bottle
+      bottle_tab_attributes = bottle&.tab_attributes || {}
       raw_deps = bottle_tab_attributes.fetch("runtime_dependencies", []).then { |deps| deps || [] }
       @bottle_tab_runtime_dependencies = raw_deps.to_h { |dep| [dep["full_name"], dep] }.freeze
 
-      if (bottle_tag = formula.bottle_for_tag(Utils::Bottles.tag)&.tag) &&
-         bottle_tag.system != :all
+      if bottle && bottle.tag.system != :all
         # Extract the OS version the bottle was built on.
         # This ensures that when installing older bottles (e.g. Sonoma bottle on Sequoia),
         # we resolve dependencies according to the bottle's built OS, not the current OS.
@@ -1059,7 +1061,7 @@ on_request: installed_on_request?, options:)
           SBOM.spdxfile(formula),
           homebrew_version: HOMEBREW_VERSION,
           time:             install_time,
-          supplement:       (api_bottle || formula.bottle)&.sbom_supplement,
+          supplement:       selected_bottle&.sbom_supplement,
         )
       end
     elsif Homebrew::EnvConfig.sbom? && !build_bottle?
@@ -1525,15 +1527,22 @@ on_request: installed_on_request?, options:)
     end
   end
 
-  sig { params(quiet: T::Boolean, enqueue: T::Boolean).void }
-  def fetch_bottle_tab(quiet: false, enqueue: false)
+  sig { params(quiet: T::Boolean, enqueue: T::Boolean, bottle: T.nilable(Bottle)).void }
+  def fetch_bottle_tab(quiet: false, enqueue: false, bottle: nil)
     return if @fetch_bottle_tab
     return if formula.local_bottle_path
 
-    if (bottle = api_bottle || formula.bottle) &&
-       (manifest_resource = bottle.github_packages_manifest_resource) &&
-       enqueue
-      download_queue.enqueue(manifest_resource) unless manifest_resource.downloaded_and_valid?
+    bottle ||= selected_bottle
+    if bottle && (manifest_resource = bottle.github_packages_manifest_resource)
+      if enqueue
+        download_queue.enqueue(manifest_resource) unless manifest_resource.downloaded_and_valid?
+      else
+        begin
+          bottle.fetch_tab(quiet:)
+        rescue DownloadError, Resource::BottleManifest::Error
+          # do nothing
+        end
+      end
     else
       begin
         formula.fetch_bottle_tab(quiet: quiet)
@@ -1625,7 +1634,7 @@ on_request: installed_on_request?, options:)
     if (bottle_path = formula.local_bottle_path)
       Resource::Local.new(bottle_path.to_s)
     elsif pour_bottle?
-      bottle = api_bottle || formula.bottle
+      bottle = selected_bottle
       odie "Bottle for #{formula.full_name} is unavailable." if bottle.nil?
 
       bottle
@@ -1635,6 +1644,11 @@ on_request: installed_on_request?, options:)
 
       resource
     end
+  end
+
+  sig { returns(T.nilable(Bottle)) }
+  def selected_bottle
+    @selected_bottle ||= api_bottle || formula.bottle || formula.bottle_for_tag(Utils::Bottles.tag)
   end
 
   sig { returns(T.nilable(Bottle)) }
@@ -1725,13 +1739,16 @@ on_request: installed_on_request?, options:)
                                       cellar: build_cellar)
     end
 
-    cellar = formula.bottle_specification.tag_to_cellar(Utils::Bottles.tag)
+    bottle_specification = formula.bottle_specification
+    tag = Utils::Bottles.tag
+    cellar = bottle_specification.tag_to_cellar(tag)
     return if BottleSpecification::RELOCATABLE_CELLARS.include?(cellar)
 
-    prefix = Pathname(cellar).parent.to_s
-    return if cellar == HOMEBREW_CELLAR.to_s && prefix == HOMEBREW_PREFIX.to_s
+    prefix = tab.built_prefix || Pathname(cellar.to_s).parent.to_s
+    build_cellar = tab.built_prefix ? "#{prefix}/Cellar" : cellar.to_s
+    return if build_cellar == HOMEBREW_CELLAR.to_s && prefix == HOMEBREW_PREFIX.to_s
 
-    return unless Homebrew::EnvConfig.relocate_build_prefix?
+    return if !tab.padded_prefix && !Homebrew::EnvConfig.relocate_build_prefix?
 
     tab.relocated_build_prefix = prefix
     tab.relocated_files = keg.relocate_build_prefix(keg, prefix, HOMEBREW_PREFIX,

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -60,6 +60,11 @@ module Homebrew
   DEFAULT_MACOS_ARM_CELLAR = T.let("#{HOMEBREW_MACOS_ARM_DEFAULT_PREFIX}/Cellar".freeze, String)
   DEFAULT_LINUX_CELLAR = T.let("#{HOMEBREW_LINUX_DEFAULT_PREFIX}/Cellar".freeze, String)
 
+  # A pinned bottle built at one of these 64-byte prefixes can be patched for any shorter prefix.
+  MACOS_ARM64_BOTTLE_PREFIX = T.let("/opt/homebrew/.brew-padded-arm64".ljust(64, "_").freeze, String)
+  LINUX_ARM64_BOTTLE_PREFIX = T.let("/home/linuxbrew/.linuxbrew/.brew-padded-arm64".ljust(64, "_").freeze, String)
+  LINUX_X86_64_BOTTLE_PREFIX = T.let("/home/linuxbrew/.linuxbrew/.brew-padded-x86_64".ljust(64, "_").freeze, String)
+
   class << self
     sig { params(failed: T::Boolean).returns(T::Boolean) }
     attr_writer :failed

--- a/Library/Homebrew/plans/relocatable-bottles.md
+++ b/Library/Homebrew/plans/relocatable-bottles.md
@@ -141,14 +141,18 @@ Replaying the exact `keg_contain?` logic over the contents of 17 pinned and
 2. Push logic and metadata generation to bottle time and away from pour time
    whenever possible: bottle time runs once on CI, pour time runs on every
    user's machine.
-3. The patching feature is pour-time only in its effect. Eligibility and
-   patching are entirely client-side, so it works retroactively for
-   published bottles and needs no homebrew/core changes. Bottle time only
-   adds accelerator metadata, always with a scan fallback, so there is no
-   version coupling.
-4. Bottling migrates to a canonical 64-byte padded build prefix per platform.
-   Every embedded C string then carries 64 bytes of patchable material, so
-   bottles patch down to any prefix up to 64 bytes, including the defaults.
+3. Legacy short-built bottle patching is pour-time only in its effect.
+   Eligibility and patching are entirely client-side, so it works
+   retroactively for published bottles and needs no homebrew/core changes.
+   Bottle time only adds accelerator metadata, always with a scan fallback,
+   so there is no version coupling for that stage.
+4. Bottling uses a canonical 64-byte padded build prefix per platform. Its
+   tab records `padded_prefix: true`, while formulae retain the tag's default
+   cellar. Every embedded C string then carries 64 bytes of patchable
+   material, so bottles patch down to any prefix up to 64 bytes, including
+   the defaults. Clients must understand the tab marker before the first
+   padded bottles are published, so the brew release precedes the
+   infrastructure cutover.
    64 rather than conda's 255 because CI runs `brew test` at the padded
    prefix, where Unix socket paths (`sun_path` is 104 bytes) and shebang
    limits punish very long prefixes.
@@ -161,7 +165,8 @@ Replaying the exact `keg_contain?` logic over the contents of 17 pinned and
 6. A bottle built at a non-default prefix records the literal prefix string
    as `built_prefix` in its tab; absence means the tag's default prefix, so
    tabs for today's bottles are unchanged. The literal string, not a
-   name/version pair, so the constant can change without a mapping.
+   name/version pair, so the constant can change without a mapping. A
+   canonical padded build also records `padded_prefix: true` there.
 7. The user contract is global, not per-bottle, for comprehensibility: one
    number (64) once migration completes; until then the interim rule is
    prefix length up to the bottled default (13 for arm64 macOS, 26 for
@@ -226,18 +231,8 @@ builds, test-bot changes, infra cutover, sweeps and validation runs.
 
 ### Phase 3: migrate bottling to the 64-byte prefix (extends to long prefixes)
 
-12. brew: canonical 64-byte padded prefix constants for x86_64 Linux, arm64
-    Linux and arm64 macOS; bottling emits a symbolic cellar for pinned
-    padded-built bottles (never a 64-character literal in formulae); pour
-    patches down whenever `built_prefix` differs from the local prefix and
-    fits. Patching is unconditional once a bottle is padded-built, because
-    the default prefix is then just another shorter prefix; the hidden
-    variable covers only legacy short-built pinned bottles at custom
-    prefixes until they churn out.
 13. Shadow builds: build a pinned plus path-length-sensitive sample at
     the candidate 64-byte prefixes on all three target platforms.
-14. JSON API and formulae.brew.sh: symbolic cellar representation,
-    version-gated for existing consumers.
 15. test-bot: build and test at the padded prefix; relocated-pour smoke test
     for changed formulae (pour the fresh bottle into a scratch short
     prefix), Linux first.
@@ -340,8 +335,6 @@ the reason, so the exceptions list stays short, visible and countable.
 
 ## Open questions
 
-- Symbolic cellar spelling and JSON API versioning for third-party
-  consumers.
 - How many formulae fail to build at all at a 64-byte prefix
   (path-length-sensitive build systems), discovered by the Phase 3 shadow
   builds; these block the sweep rather than staying pinned.

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -170,7 +170,7 @@ class SoftwareSpec
     owner = self.owner
     return false unless owner.is_a?(Formula)
 
-    owner.force_bottle
+    owner.force_bottle || owner.bottle.present?
   end
 
   sig { params(block: T.proc.bind(BottleSpecification).void).void }

--- a/Library/Homebrew/tab/tab.rb
+++ b/Library/Homebrew/tab/tab.rb
@@ -16,6 +16,9 @@ class Tab < AbstractTab
   sig { returns(T.nilable(String)) }
   attr_accessor :built_prefix
 
+  sig { returns(T.nilable(T::Boolean)) }
+  attr_accessor :padded_prefix
+
   sig { returns(T.nilable(T.any(String, Symbol))) }
   attr_accessor :stdlib
 
@@ -57,6 +60,7 @@ class Tab < AbstractTab
     params(poured_from_bottle:      T.nilable(T::Boolean),
            built_as_bottle:         T.nilable(T::Boolean),
            built_prefix:            T.nilable(String),
+           padded_prefix:           T.nilable(T::Boolean),
            changed_files:           T.nilable(T::Array[T.any(Pathname, String)]),
            linkage_files:           T.nilable(T::Array[T.any(Pathname, String)]),
            binary_relocation_files: T.nilable(T::Array[T.any(Pathname, String)]),
@@ -71,13 +75,15 @@ class Tab < AbstractTab
            tapped_from:             T.nilable(String),
            rest:                    T.untyped).void
   }
-  def initialize(poured_from_bottle: nil, built_as_bottle: nil, built_prefix: nil, changed_files: nil,
+  def initialize(poured_from_bottle: nil, built_as_bottle: nil, built_prefix: nil, padded_prefix: nil,
+                 changed_files: nil,
                  linkage_files: nil, binary_relocation_files: nil, relocated_build_prefix: nil,
                  relocated_files: nil, stdlib: nil, aliases: nil, used_options: nil, unused_options: nil,
                  compiler: nil, source_modified_time: nil, tapped_from: nil, **rest)
     @poured_from_bottle = poured_from_bottle
     @built_as_bottle = built_as_bottle
     @built_prefix = built_prefix
+    @padded_prefix = padded_prefix
     @changed_files = T.let(changed_files&.map { |f| Pathname(f) }, T.nilable(T::Array[Pathname]))
     @linkage_files = T.let(linkage_files&.map { |f| Pathname(f) }, T.nilable(T::Array[Pathname]))
     @binary_relocation_files = T.let(
@@ -403,6 +409,7 @@ class Tab < AbstractTab
       "unused_options"           => unused_options.as_flags,
       "built_as_bottle"          => built_as_bottle,
       "built_prefix"             => built_prefix,
+      "padded_prefix"            => padded_prefix,
       "poured_from_bottle"       => poured_from_bottle,
       "loaded_from_api"          => loaded_from_api,
       "loaded_from_internal_api" => loaded_from_internal_api,
@@ -424,6 +431,7 @@ class Tab < AbstractTab
     }
     attributes.delete("stdlib") if attributes["stdlib"].blank?
     attributes.delete("built_prefix") if attributes["built_prefix"].nil?
+    attributes.delete("padded_prefix") if attributes["padded_prefix"].nil?
     attributes.delete("linkage_files") if attributes["linkage_files"].nil?
     attributes.delete("binary_relocation_files") if attributes["binary_relocation_files"].nil?
     attributes.delete("relocated_build_prefix") if attributes["relocated_build_prefix"].nil?
@@ -438,6 +446,7 @@ class Tab < AbstractTab
     attributes = {
       "homebrew_version"        => homebrew_version,
       "built_prefix"            => built_prefix,
+      "padded_prefix"           => padded_prefix,
       "changed_files"           => changed_files&.map(&:to_s),
       "linkage_files"           => linkage_files&.map(&:to_s),
       "binary_relocation_files" => binary_relocation_files&.map(&:to_s),
@@ -451,6 +460,7 @@ class Tab < AbstractTab
     }
     attributes.delete("stdlib") if attributes["stdlib"].blank?
     attributes.delete("built_prefix") if attributes["built_prefix"].nil?
+    attributes.delete("padded_prefix") if attributes["padded_prefix"].nil?
     attributes.delete("linkage_files") if attributes["linkage_files"].nil?
     attributes.delete("binary_relocation_files") if attributes["binary_relocation_files"].nil?
     attributes.delete("source") if attributes["source"].blank?

--- a/Library/Homebrew/test/bottle_spec.rb
+++ b/Library/Homebrew/test/bottle_spec.rb
@@ -5,6 +5,24 @@ require "bottle_specification"
 require "test/support/fixtures/testball_bottle"
 
 RSpec.describe Bottle do
+  describe "#compatible_locations?" do
+    it "fetches tab metadata before rejecting a padded bottle" do
+      tag = Utils::Bottles::Tag.from_symbol(:arm64_tahoe)
+      bottle_spec = BottleSpecification.new
+      bottle_spec.sha256(tag.to_sym => "deadbeef" * 8)
+      bottle = described_class.new(TestballBottle.new, bottle_spec, tag)
+      stub_const("HOMEBREW_PREFIX", Pathname("/short"))
+      stub_const("HOMEBREW_CELLAR", HOMEBREW_PREFIX/"Cellar")
+      allow(bottle).to receive(:tab_attributes).and_return(
+        {},
+        { "built_prefix" => tag.padded_prefix, "padded_prefix" => true },
+      )
+      expect(bottle).to receive(:fetch_tab).with(quiet: true)
+
+      expect(bottle.compatible_locations?).to be true
+    end
+  end
+
   describe "#filename" do
     it "renders the bottle filename" do
       bottle_spec = BottleSpecification.new

--- a/Library/Homebrew/test/bottle_specification_spec.rb
+++ b/Library/Homebrew/test/bottle_specification_spec.rb
@@ -52,6 +52,25 @@ RSpec.describe BottleSpecification do
 
       expect(bottle_spec.compatible_locations?).to be true
     end
+
+    it "accepts a padded bottle from tab metadata without build prefix relocation being enabled" do
+      tag = Utils::Bottles::Tag.from_symbol(:arm64_tahoe)
+      bottle_spec.sha256(tag.to_sym => "deadbeef" * 8)
+      stub_const("HOMEBREW_PREFIX", Pathname("/short"))
+      stub_const("HOMEBREW_CELLAR", HOMEBREW_PREFIX/"Cellar")
+
+      expect(bottle_spec.compatible_locations?(tag:, built_prefix: tag.padded_prefix, padded_prefix: true)).to be true
+    end
+
+    it "rejects a padded bottle when the local prefix is longer than 64 bytes" do
+      tag = Utils::Bottles::Tag.from_symbol(:arm64_tahoe)
+      bottle_spec.sha256(tag.to_sym => "deadbeef" * 8)
+      stub_const("HOMEBREW_PREFIX", Pathname("/#{"p" * 64}"))
+      stub_const("HOMEBREW_CELLAR", HOMEBREW_PREFIX/"Cellar")
+
+      expect(bottle_spec.compatible_locations?(tag:, built_prefix: tag.padded_prefix,
+                                               padded_prefix: true)).to be false
+    end
   end
 
   describe "#tag_to_cellar" do

--- a/Library/Homebrew/test/dev-cmd/bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bottle_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Homebrew::DevCmd::Bottle do
                     "local_filename":"#{parameters[:local_filename]}",
                     "sha256":"#{parameters[:sha256]}"
                     #{",\"sbom\":#{parameters[:sbom].to_json}" if parameters[:sbom]}
+                    #{",\"tab\":#{parameters[:tab].to_json}" if parameters[:tab]}
                  }
               }
            }
@@ -161,6 +162,7 @@ RSpec.describe Homebrew::DevCmd::Bottle do
       FileUtils.rm_f "#{TEST_TMPDIR}/testball-1.0.arm64_big_sur.bottle.json"
       FileUtils.rm_f "#{TEST_TMPDIR}/testball-1.0.catalina.bottle.json"
       FileUtils.rm_f "#{TEST_TMPDIR}/testball-1.0.big_sur.bottle.json"
+      FileUtils.rm_f "#{TEST_TMPDIR}/testball-1.0.arm64_monterey.bottle.json"
     end
 
     it "adds the bottle block to a formula that has none" do
@@ -448,6 +450,40 @@ RSpec.describe Homebrew::DevCmd::Bottle do
       expect(formula_contents).to include("big_sur:")
       expect(formula_contents).not_to include("all:")
     end
+
+    it "does not collapse padded bottles into an all bottle" do
+      core_tap.path.cd do
+        system "git", "-c", "init.defaultBranch=master", "init"
+        setup_test_formula "testball"
+        system "git", "add", "--all"
+        system "git", "commit", "-m", "testball 0.1"
+      end
+
+      sha256 = "8f9aecd233463da6a4ea55f5f88fc5841718c013f3e2a7941350d6130f1dc149"
+      bottle_json_paths = ["arm64_big_sur", "arm64_monterey"].map do |tag|
+        Pathname("#{TEST_TMPDIR}/testball-1.0.#{tag}.bottle.json").tap do |path|
+          path.write stub_hash(
+            name:           "testball",
+            version:        "1.0",
+            path:           "#{core_tap.path}/Formula/testball.rb",
+            cellar:         Homebrew::DEFAULT_MACOS_ARM_CELLAR,
+            os:             tag,
+            filename:       "testball-1.0.#{tag}.bottle.tar.gz",
+            local_filename: "testball--1.0.#{tag}.bottle.tar.gz",
+            sha256:,
+            tab:            { "padded_prefix" => true },
+          )
+        end
+      end
+
+      expect do
+        brew "bottle", "--merge", *bottle_json_paths
+      end.to(
+        output(/\A(?!.* all:)(?=.*sha256 arm64_big_sur:)(?=.*sha256 arm64_monterey:)/m).to_stdout
+          .and(not_to_output.to_stderr)
+          .and(be_a_success),
+      )
+    end
   end
 
   describe "bottle_cmd" do
@@ -673,6 +709,14 @@ RSpec.describe Homebrew::DevCmd::Bottle do
     end
 
     describe "::bottle_output" do
+      it "omits a padded bottle's tag-default cellar" do
+        bottle = BottleSpecification.new
+        bottle.sha256(cellar:      Homebrew::DEFAULT_MACOS_ARM_CELLAR,
+                      arm64_tahoe: "109c0cb581a7b5d84da36d84b221fb9dd0f8a927b3044d82611791c9907e202e")
+
+        expect(homebrew.bottle_output(bottle, nil)).to include("sha256 arm64_tahoe:")
+      end
+
       it "includes a custom root_url" do
         bottle = BottleSpecification.new
         bottle.root_url("https://example.com")

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -295,14 +295,51 @@ RSpec.describe FormulaInstaller do
     end
   end
 
+  describe "#determine_bottle_tab_attributes" do
+    it "uses dependency metadata from the selected API bottle" do
+      f = formula "padded-bottle-metadata" do
+        T.bind(self, T.class_of(Formula))
+        url "padded-bottle-metadata-1.0"
+        depends_on "dependency"
+      end
+      installer = described_class.new(f)
+      runtime_dependency = { "full_name" => "dependency", "version" => "2.0", "revision" => "1" }
+      bottle = instance_double(
+        Bottle,
+        tab_attributes: {
+          "runtime_dependencies" => [runtime_dependency],
+          "built_on"             => { "os_version" => "macOS 15" },
+        },
+        tag:            Utils::Bottles.tag,
+      )
+      allow(installer).to receive(:api_bottle).and_return(bottle)
+      dependency = f.deps.fetch(0)
+      dependency_formula = instance_double(Formula, deps: [], name: "dependency", full_name: "dependency")
+      allow(dependency).to receive(:to_formula).and_return(dependency_formula)
+      build_options = BuildOptions.new(Options.new, Options.new)
+      allow(installer).to receive_messages(effective_build_options_for: build_options, install_bottle_for?: false)
+
+      installer.determine_bottle_tab_attributes
+
+      expect(dependency).to receive(:satisfied?).with(
+        minimum_version:   Version.new("2.0"),
+        minimum_revision:  1,
+        bottle_os_version: "macOS 15",
+      ).and_return(false)
+      installer.expand_dependencies_for_formula(f)
+    end
+  end
+
   describe "#pour" do
+    let(:bottle_cellar) { :any_skip_relocation }
     let(:f) do
+      cellar = bottle_cellar
       formula("missing-bottle-tab") do
         T.bind(self, T.class_of(Formula))
         url "https://brew.sh/missing-bottle-tab-1.0.tar.gz"
 
         bottle do
-          sha256 cellar: :any_skip_relocation,
+          sha256 cellar:,
                  Utils::Bottles.tag.to_sym => "d7b9f4e8bf83608b71fe958a99f19f2e5e68bb2582965d32e41759c24f1aef97"
         end
       end
@@ -310,9 +347,11 @@ RSpec.describe FormulaInstaller do
     let(:installer) { Class.new(described_class).new(f) }
     let(:downloader) { instance_double(AbstractDownloadStrategy, basename: "missing-bottle-tab", stage: nil) }
     let(:downloadable) { instance_double(Resource, downloader:) }
+    let(:built_prefix) { nil }
+    let(:padded_prefix) { nil }
     let(:tab) do
       instance_double(Tab, changed_files: nil, linkage_files: nil, binary_relocation_files: nil,
-                      built_prefix: nil, source: { "versions" => {} }, write: nil).as_null_object
+                      built_prefix:, padded_prefix:, source: { "versions" => {} }, write: nil).as_null_object
     end
     let(:keg) { instance_double(Keg) }
 
@@ -355,6 +394,23 @@ RSpec.describe FormulaInstaller do
           stderr.scan("OCI registry proxy").one? &&
             stderr.include?("sh.brew.tab") && stderr.include?("HOMEBREW_ARTIFACT_DOMAIN")
         end).to_stderr
+    end
+
+    context "with a padded bottle" do
+      let(:bottle_cellar) { Utils::Bottles.tag.default_cellar }
+      let(:built_prefix) { "/#{"p" * 63}" }
+      let(:padded_prefix) { true }
+
+      it "patches the recorded build prefix without the legacy opt-in" do
+        relocated_files = [Pathname("bin/test")]
+        expect(keg).to receive(:relocate_build_prefix)
+          .with(keg, built_prefix, HOMEBREW_PREFIX, files: nil)
+          .and_return(relocated_files)
+        expect(tab).to receive(:relocated_build_prefix=).with(built_prefix)
+        expect(tab).to receive(:relocated_files=).with(relocated_files)
+
+        installer.pour
+      end
     end
   end
 
@@ -449,7 +505,7 @@ RSpec.describe FormulaInstaller do
       end
       installer = described_class.new(formula)
       installer.download_queue = instance_double(Homebrew::DownloadQueue)
-      manifest_resource = formula.bottle&.github_packages_manifest_resource
+      manifest_resource = installer.selected_bottle&.github_packages_manifest_resource
       cached_download = manifest_resource&.cached_download
 
       allow(manifest_resource).to receive(:downloaded?).and_return(true)
@@ -475,7 +531,7 @@ RSpec.describe FormulaInstaller do
       end
       installer = described_class.new(formula)
       installer.download_queue = instance_double(Homebrew::DownloadQueue)
-      manifest_resource = formula.bottle&.github_packages_manifest_resource
+      manifest_resource = installer.selected_bottle&.github_packages_manifest_resource
 
       allow(manifest_resource).to receive(:downloaded?).and_return(true)
       manifest_resource&.manifest_annotations = {}

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -2110,6 +2110,27 @@ RSpec.describe Formula do
     end
   end
 
+  describe "#bottle" do
+    it "selects a padded bottle using its tab metadata" do
+      tag = Utils::Bottles.tag
+      f = formula "padded-bottle" do
+        T.bind(self, T.class_of(Formula))
+        url "padded-bottle-1.0"
+
+        bottle do
+          sha256 tag.to_sym => "deadbeef" * 8
+        end
+      end
+      bottle = f.bottle_for_tag(tag)
+      stub_const("HOMEBREW_PREFIX", Pathname("/short"))
+      stub_const("HOMEBREW_CELLAR", HOMEBREW_PREFIX/"Cellar")
+      allow(f).to receive(:bottle_for_tag).with(tag).and_return(bottle)
+      allow(bottle).to receive(:compatible_locations?).and_return(true)
+
+      expect([f.bottle, f.bottled?]).to eq([bottle, true])
+    end
+  end
+
   describe "#pour_bottle?" do
     it "returns false if set to false" do
       f = formula "foo" do

--- a/Library/Homebrew/test/tab_spec.rb
+++ b/Library/Homebrew/test/tab_spec.rb
@@ -577,6 +577,7 @@ RSpec.describe Tab do
 
   specify "#to_json" do
     tab.built_prefix = "/custom/prefix"
+    tab.padded_prefix = true
     tab.relocated_build_prefix = "/custom/prefix"
     tab.relocated_files = [Pathname("bin/foo")]
     json_tab = described_class.new(**JSON.parse(tab.to_json).transform_keys(&:to_sym))
@@ -591,6 +592,7 @@ RSpec.describe Tab do
     expect(json_tab.linkage_files).to eq(tab.linkage_files)
     expect(json_tab.binary_relocation_files).to eq(tab.binary_relocation_files)
     expect(json_tab.built_prefix).to eq(tab.built_prefix)
+    expect(json_tab.padded_prefix).to be true
     expect(json_tab.tap).to eq(tab.tap)
     expect(json_tab.spec).to eq(tab.spec)
     expect(json_tab.time).to eq(tab.time)
@@ -607,6 +609,7 @@ RSpec.describe Tab do
 
   specify "#to_bottle_hash" do
     tab.built_prefix = "/custom/prefix"
+    tab.padded_prefix = true
     tab.relocated_build_prefix = "/custom/prefix"
     json_tab = described_class.new(**JSON.parse(tab.to_bottle_hash.to_json).transform_keys(&:to_sym))
     expect(json_tab.relocated_build_prefix).to be_nil
@@ -615,6 +618,7 @@ RSpec.describe Tab do
     expect(json_tab.linkage_files).to eq(tab.linkage_files)
     expect(json_tab.binary_relocation_files).to eq(tab.binary_relocation_files)
     expect(json_tab.built_prefix).to eq(tab.built_prefix)
+    expect(json_tab.padded_prefix).to be true
     expect(json_tab.source_modified_time).to eq(tab.source_modified_time)
     expect(json_tab.stdlib).to eq(tab.stdlib)
     expect(json_tab.compiler).to eq(tab.compiler)

--- a/Library/Homebrew/test/utils/bottles/tag_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/tag_spec.rb
@@ -94,4 +94,18 @@ RSpec.describe Utils::Bottles::Tag do
       expect(tag.valid_combination?).to be true
     end
   end
+
+  describe "#padded_prefix" do
+    it "returns distinct 64-byte prefixes for supported bottle platforms" do
+      prefixes = [:arm64_tahoe, :arm64_linux, :x86_64_linux].map do |tag|
+        described_class.from_symbol(tag).padded_prefix
+      end
+
+      expect([prefixes.uniq.length, *prefixes.map { |prefix| prefix&.bytesize }]).to eq([3, 64, 64, 64])
+    end
+
+    it "returns nil for Intel macOS" do
+      expect(described_class.from_symbol(:tahoe).padded_prefix).to be_nil
+    end
+  end
 end

--- a/Library/Homebrew/utils/bottles.rb
+++ b/Library/Homebrew/utils/bottles.rb
@@ -295,6 +295,18 @@ module Utils
         end
       end
 
+      sig { returns(T.nilable(String)) }
+      def padded_prefix
+        if linux?
+          case standardized_arch
+          when :arm64 then Homebrew::LINUX_ARM64_BOTTLE_PREFIX
+          when :x86_64 then Homebrew::LINUX_X86_64_BOTTLE_PREFIX
+          end
+        elsif macos? && standardized_arch == :arm64
+          Homebrew::MACOS_ARM64_BOTTLE_PREFIX
+        end
+      end
+
       private
 
       sig { params(arch: Symbol).returns(Symbol) }


### PR DESCRIPTION
- Record padded-prefix eligibility in bottle tab metadata while formulae retain their tag-default cellars.
- Fetch tab metadata before rejecting a location-incompatible bottle and patch marked bottles from their literal `built_prefix`.
- Keep platform-specific padded bottles as separate tags instead of collapsing them into `:all`.

This change is part of [`plans/relocatable-bottles.md`](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/plans/relocatable-bottles.md)

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Codex with GPT 5.6-sol at Extra High effort, with local review and testing.

-----