### PR TITLE
github_runner_matrix: use macos-15-intel for Portable Ruby x86_64

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -96,12 +96,13 @@ class GitHubRunnerMatrix
     # Portable Ruby logic
     if @testing_formulae.any? { |tf| tf.name.start_with?("portable-") }
       x86_64_spec = MacOSRunnerSpec.new(
-        name:    "macOS 10.15-cross x86_64",
-        runner:  "10.15-cross-#{@github_run_id}",
-        timeout: GITHUB_ACTIONS_LONG_TIMEOUT,
-        cleanup: true,
+        name:         "macOS 11-cross x86_64",
+        runner:       "macos-15-intel",
+        timeout:      GITHUB_ACTIONS_RUNNER_TIMEOUT,
+        cleanup:      true,
+        target_macos: "11.7.10",
       )
-      x86_64_macos_version = MacOSVersion.new("10.15")
+      x86_64_macos_version = MacOSVersion.new("11")
       @runners << create_runner(:macos, :x86_64, x86_64_spec, x86_64_macos_version)
 
       # odisabled: remove support for Big Sur September (or later) 2027

--- a/Library/Homebrew/macos_runner_spec.rb
+++ b/Library/Homebrew/macos_runner_spec.rb
@@ -6,6 +6,7 @@ class MacOSRunnerSpec < T::Struct
   const :runner, String
   const :timeout, Integer
   const :cleanup, T::Boolean
+  const :target_macos, T.nilable(String), default: nil
   prop  :testing_formulae, T::Array[String], default: []
 
   sig {
@@ -14,6 +15,7 @@ class MacOSRunnerSpec < T::Struct
       runner:           String,
       timeout:          Integer,
       cleanup:          T::Boolean,
+      target_macos:     T.nilable(String),
       testing_formulae: String,
     })
   }
@@ -23,6 +25,7 @@ class MacOSRunnerSpec < T::Struct
       runner:,
       timeout:,
       cleanup:,
+      target_macos:,
       testing_formulae: testing_formulae.join(","),
     }
   end

--- a/Library/Homebrew/test/github_runner_matrix_spec.rb
+++ b/Library/Homebrew/test/github_runner_matrix_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
     setup_test_runner_formula("testball-depender-intel", ["testball", { arch: :x86_64 }])
   end
   let(:testball_depender_arm) { setup_test_runner_formula("testball-depender-arm", ["testball", { arch: :arm64 }]) }
+  let(:portable_ruby) { setup_test_runner_formula("portable-ruby") }
   let(:testball_depender_newest) do
     symbol, = newest_supported_macos
     setup_test_runner_formula("testball-depender-newest", ["testball", { macos: symbol }])
@@ -61,6 +62,25 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
           options: "--init --user linuxbrew",
         }
       end)
+    end
+
+    it "includes active macOS 11 Portable Ruby runners" do
+      runners = described_class.new([portable_ruby], [], all_supported: false, dependent_matrix: false)
+                               .active_runner_specs_hash
+      intel_runner = runners.find { |runner| runner[:runner] == "macos-15-intel" }
+      arm_runner = runners.find { |runner| runner[:name] == "macOS 11-cross arm64" }
+
+      expect(intel_runner).to include(
+        name:         "macOS 11-cross x86_64",
+        timeout:      360,
+        target_macos: "11.7.10",
+      )
+      expect(arm_runner).to include(
+        name:         "macOS 11-cross arm64",
+        timeout:      2160,
+        target_macos: nil,
+      )
+      expect(T.must(arm_runner).fetch(:runner)).to start_with("11-arm64-cross-")
     end
   end
 

--- a/Library/Homebrew/test/macos_runner_spec_spec.rb
+++ b/Library/Homebrew/test/macos_runner_spec_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe MacOSRunnerSpec do
   let(:spec) { described_class.new(name: "macOS 11-arm64", runner: "11-arm64", timeout: 90, cleanup: true) }
 
   it "has immutable attributes" do
-    [:name, :runner, :timeout, :cleanup].each do |attribute|
+    [:name, :runner, :timeout, :cleanup, :target_macos].each do |attribute|
       expect(spec.respond_to?(:"#{attribute}=")).to be(false)
     end
   end
@@ -15,6 +15,22 @@ RSpec.describe MacOSRunnerSpec do
   describe "#to_h" do
     it "returns an object that responds to `#to_json`" do
       expect(spec.to_h.respond_to?(:to_json)).to be(true)
+    end
+
+    it "includes a nil target for ordinary macOS runners" do
+      expect(spec.to_h).to include(target_macos: nil)
+    end
+
+    it "includes optional cross-compilation targets" do
+      cross_spec = described_class.new(
+        name:         "macOS 11-cross x86_64",
+        runner:       "macos-15-intel",
+        timeout:      360,
+        cleanup:      true,
+        target_macos: "11.7.10",
+      )
+
+      expect(cross_spec.to_h).to include(target_macos: "11.7.10")
     end
   end
 end


### PR DESCRIPTION
This switches the Portable Ruby x86_64 runner from the self-hosted `10.15-cross` MacStadium runner to GitHub's `macos-15-intel`, so we can decommission our self-hosted Intel infrastructure and move macOS 10.15 to fully unsupported. The matrix entry now carries `target_macos: "11.7.10"`, which Homebrew/homebrew-core#301193 turns into `HOMEBREW_FAKE_MACOS` at build time, keeping the bottle floor at macOS 11 and moving the tag from `catalina` to `big_sur`.

`MacOSRunnerSpec` gains an optional `target_macos` field serialized for every macOS runner (`null` for ordinary ones, so the gated workflow steps skip), the runner timeout drops to the hosted 360-minute cap, and the self-hosted ARM runner is unchanged. This should land after Homebrew/homebrew-core#301193; with current homebrew-core the new runner would fail closed rather than build a wrong-target bottle.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Fable 5) drafted the implementation and tests; I reviewed the diff, probed the matrix serialization, and ran `brew lgtm` plus the changed specs.

-----
