### PR TITLE
advisory-match: sync alias families and reopen reviewed ranges

### DIFF
--- a/Library/Homebrew/dev-cmd/advisory-match.rb
+++ b/Library/Homebrew/dev-cmd/advisory-match.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "abstract_command"
+require "extend/object/deep_dup"
 require "fileutils"
 require "formula"
 require "vulns/match"
@@ -62,22 +63,69 @@ module Homebrew
             begin
               matcher.each_advisory_batch(each_formula) do |formula, hits|
                 report(matcher, formula, hits) if text_mode?
-                hits.each do |hit|
-                  # A `:not_applicable` hit (below every `introduced`) emitted
-                  # as `{introduced: 0}` with no `fixed` reads to OSV consumers
-                  # as currently affected; drop it instead.
+                # A below-introduced hit would otherwise look open to OSV
+                # consumers; it must not participate in alias maintenance.
+                actionable = hits.filter_map do |hit|
                   status, = matcher.range_status(hit)
-                  next if status&.state == :not_applicable
+                  [hit, status] if status&.state != :not_applicable
+                end
+                record_ids_by_canonical = actionable.to_h do |hit, _status|
+                  ids = matcher.record_ids(formula, hit)
+                  [ids.fetch(0), ids]
+                end
+                alias_errors = emitter.prepare_aliases(formula.name, record_ids_by_canonical)
+                if alias_errors.any?
+                  alias_errors.each { |error| onoe error }
+                  Homebrew.failed = true
+                  next
+                end
 
+                actionable.each do |hit, status|
                   record_id = matcher.record_id(formula, hit)
+                  next if emitter.alias_protected?(record_id)
+
+                  reviewed_state = emitter.reviewed_range_state(record_id)
+                  has_open_range = [:open, :mixed].include?(reviewed_state)
+                  has_terminal_range = [:terminal, :mixed].include?(reviewed_state)
+                  transition = (status&.fixed? && has_open_range) ||
+                               (status&.affected? && has_terminal_range)
+                  if args.no_history? && transition
+                    opoo "#{record_id}: reviewed range transition needs history; leaving it unchanged"
+                    next
+                  end
+
                   walk_history = !args.no_history? && status&.fixed?
                   walk_history &&= emitter.history_required?(record_id) if args.new_history?
                   emitter.record_history_walk if walk_history
                   first_fixed = matcher.first_fixed_version(formula, hit) if walk_history
                   next if first_fixed == :never_affected
 
-                  boundary = first_fixed if first_fixed.is_a?(String)
-                  emitter << matcher.to_brew_record(formula, hit, first_fixed: boundary)
+                  fixed_boundary = first_fixed if first_fixed.is_a?(String)
+                  if fixed_boundary && !emitter.fixed_boundary_valid?(record_id, fixed_boundary)
+                    onoe "#{record_id}: fixed #{fixed_boundary} does not follow its reviewed range"
+                    Homebrew.failed = true
+                    next
+                  end
+
+                  first_reintroduced = T.let(nil, T.nilable(String))
+                  if status&.affected? && has_terminal_range
+                    emitter.record_history_walk
+                    reintroduced = matcher.first_reintroduced_version(formula, hit)
+                    unless reintroduced.is_a?(String)
+                      onoe "#{record_id}: could not find a prior non-affected version for its reviewed fixed range"
+                      Homebrew.failed = true
+                      next
+                    end
+                    unless emitter.reintroduction_boundary_valid?(record_id, reintroduced)
+                      onoe "#{record_id}: reintroduction #{reintroduced} does not follow its reviewed range"
+                      Homebrew.failed = true
+                      next
+                    end
+                    first_reintroduced = reintroduced
+                  end
+
+                  emitter << matcher.to_brew_record(formula, hit, first_fixed:        fixed_boundary,
+                                                                  first_reintroduced:)
                 end
               end
             rescue Homebrew::Vulns::OSV::Error => e
@@ -151,11 +199,26 @@ module Homebrew
       # `--output` and text mode write per-record and only accumulate counts;
       # `--json` accumulates the array (single-formula / PR-bot use, so bounded).
       class Emitter
+        sig { params(_formula_name: String, _groups: T::Hash[String, T::Array[String]]).returns(T::Array[String]) }
+        def prepare_aliases(_formula_name, _groups) = []
+
+        sig { params(_record_id: String).returns(T::Boolean) }
+        def alias_protected?(_record_id) = false
+
         sig { params(_record_id: String).returns(T::Boolean) }
         def history_required?(_record_id) = true
 
+        sig { params(_record_id: String, _boundary: String).returns(T::Boolean) }
+        def fixed_boundary_valid?(_record_id, _boundary) = true
+
         sig { void }
         def record_history_walk; end
+
+        sig { params(_record_id: String).returns(T.nilable(Symbol)) }
+        def reviewed_range_state(_record_id); end
+
+        sig { params(_record_id: String, _boundary: String).returns(T::Boolean) }
+        def reintroduction_boundary_valid?(_record_id, _boundary) = true
 
         sig { params(record: T::Hash[Symbol, T.untyped]).void }
         def <<(record); end
@@ -176,48 +239,199 @@ module Homebrew
           @unchanged = T.let(0, Integer)
           @skipped_generated = T.let(0, Integer)
           @history_walks = T.let(0, Integer)
+          @alias_targets = T.let({}, T::Hash[String, T::Array[String]])
+          @protected_aliases = T.let({}, T::Hash[String, T::Boolean])
+          @alias_records = T.let({}, T::Hash[String, T.untyped])
+          @identity_paths = T.let({}, T::Hash[String, T::Array[String]])
+          @path_identities = T.let({}, T::Hash[String, T::Array[String]])
+          @alias_index_loaded = T.let(false, T::Boolean)
+        end
+
+        sig {
+          override.params(formula_name: String, groups: T::Hash[String, T::Array[String]])
+                  .returns(T::Array[String])
+        }
+        def prepare_aliases(formula_name, groups)
+          ensure_alias_index
+          errors = T.let([], T::Array[String])
+          targets = T.let({}, T::Hash[String, T::Array[String]])
+          protected = T.let({}, T::Hash[String, T::Boolean])
+          owners = T.let({}, T::Hash[String, String])
+          identity_owners = T.let({}, T::Hash[String, String])
+          generated_paths = T.let([], T::Array[String])
+
+          groups.each do |canonical_id, record_ids|
+            record_ids.each do |record_id|
+              if (owner = identity_owners[record_id]) && owner != canonical_id
+                errors << "#{canonical_id}: identity also belongs to #{owner}; leaving both unchanged"
+              else
+                identity_owners[record_id] = canonical_id
+              end
+            end
+            paths = matching_alias_paths(record_ids)
+            paths.each do |path|
+              if (owner = owners[path]) && owner != canonical_id
+                errors << "#{canonical_id}: alias family also belongs to #{owner}; leaving both unchanged"
+              else
+                owners[path] = canonical_id
+              end
+            end
+
+            writable = T.let([], T::Array[String])
+            paths.each do |path|
+              existing = alias_record(path)
+              if existing == :malformed
+                errors << "#{canonical_id}: malformed alias #{path}; leaving family unchanged"
+                next
+              end
+              unless existing.is_a?(Hash)
+                errors << "#{canonical_id}: invalid alias #{path}; leaving family unchanged"
+                next
+              end
+              if existing["id"] != File.basename(path, ".json")
+                errors << "#{canonical_id}: #{path} has a mismatched id; leaving family unchanged"
+                next
+              end
+
+              database_specific = existing["database_specific"]
+              source = database_specific["source"] if database_specific.is_a?(Hash)
+              if source == "generated"
+                generated_paths << path
+                next
+              end
+              if source != "matched"
+                errors << "#{canonical_id}: #{path} has unsupported source " \
+                          "#{source.inspect}; leaving family unchanged"
+                next
+              end
+
+              affected = existing["affected"]
+              names = affected_formula_names(existing)
+              if !affected.is_a?(Array) || !affected.one? || names != [formula_name]
+                errors << "#{canonical_id}: #{path} has unsupported affected entries for " \
+                          "#{formula_name}; leaving family unchanged"
+                next
+              end
+              writable << path
+            end
+
+            canonical_path = record_path(canonical_id)
+            writable << canonical_path unless File.file?(canonical_path)
+            writable.uniq!
+            targets[canonical_id] = writable
+            protected[canonical_id] = writable.empty?
+          end
+          return errors.uniq if errors.any?
+
+          @alias_targets.merge!(targets)
+          @protected_aliases.merge!(protected)
+          @skipped_generated += generated_paths.uniq.length
+          []
+        end
+
+        sig { override.params(record_id: String).returns(T::Boolean) }
+        def alias_protected?(record_id)
+          @protected_aliases.fetch(record_id, false)
         end
 
         sig { override.params(record: T::Hash[Symbol, T.untyped]).void }
         def <<(record)
-          path = record_path(record.fetch(:id))
-          # A record already emitted by `generate-vulns-advisories` (a formula
-          # `resolves` patch annotation) is more authoritative than a matched
-          # candidate; overwriting it would drop `fix: "patch"` for a derived
-          # `fix: null`/`"bump"`.
-          if File.file?(path) && existing_source(path) == "generated"
-            @skipped_generated += 1
-            return
+          updates = alias_target_paths(record.fetch(:id)).map do |path|
+            candidate = record.deep_dup
+            existing = alias_record(path) if File.file?(path)
+            if existing.is_a?(Hash)
+              candidate[:id] = existing.fetch("id")
+              candidate[:upstream] = (Array(existing["upstream"]) + Array(candidate[:upstream])).uniq
+            elsif File.file?(path)
+              candidate[:id] = File.basename(path, ".json")
+            end
+            merged = Homebrew::Vulns::OsvExport.merge_existing(
+              path, candidate, close_open_ranges: @close_open_ranges
+            )
+            [path, merged]
           end
-          merged = Homebrew::Vulns::OsvExport.merge_existing(path, record,
-                                                             close_open_ranges: @close_open_ranges)
-          if merged.nil?
-            @unchanged += 1
-            return
+
+          updates.each do |path, merged|
+            if merged.nil?
+              @unchanged += 1
+              next
+            end
+            File.write(path, "#{JSON.pretty_generate(merged)}\n")
+            puts "  wrote #{path}" if @verbose
+            @written += 1
           end
-          File.write(path, "#{JSON.pretty_generate(merged)}\n")
-          puts "  wrote #{path}" if @verbose
-          @written += 1
         end
 
         sig { override.params(record_id: String).returns(T::Boolean) }
         def history_required?(record_id)
-          path = record_path(record_id)
-          return true unless File.file?(path)
+          alias_target_paths(record_id).any? do |path|
+            next true unless File.file?(path)
 
-          existing = JSON.parse(File.read(path))
-          return true unless existing.is_a?(Hash)
-          return false if existing.dig("database_specific", "source") == "generated"
+            existing = alias_record(path)
+            next true unless existing.is_a?(Hash)
 
-          affected = existing["affected"]
-          return true unless affected.is_a?(Array)
-          return true if affected.empty?
+            affected = existing["affected"]
+            next true unless affected.is_a?(Array)
+            next true if affected.empty?
 
-          affected.any? do |entry|
-            !entry.is_a?(Hash) || !Homebrew::Vulns::OsvExport.ranges_terminal?(entry["ranges"])
+            affected.any? do |entry|
+              !entry.is_a?(Hash) ||
+                !Homebrew::Vulns::OsvExport.ranges_terminal?(homebrew_ranges(entry["ranges"]))
+            end
           end
-        rescue JSON::ParserError
-          true
+        end
+
+        sig { override.params(record_id: String, boundary: String).returns(T::Boolean) }
+        def fixed_boundary_valid?(record_id, boundary)
+          alias_target_paths(record_id).all? do |path|
+            next true unless File.file?(path)
+
+            existing = alias_record(path)
+            next false unless existing.is_a?(Hash)
+
+            affected = existing["affected"]
+            next false unless affected.is_a?(Array)
+
+            affected.all? do |entry|
+              entry.is_a?(Hash) &&
+                Homebrew::Vulns::OsvExport.fixed_follows?(homebrew_ranges(entry["ranges"]), boundary)
+            end
+          end
+        end
+
+        sig { override.params(record_id: String).returns(T.nilable(Symbol)) }
+        def reviewed_range_state(record_id)
+          paths = alias_target_paths(record_id).select { |path| File.file?(path) }
+          states_by_path = paths.map { |path| reviewed_states(path) }
+          return if states_by_path.any?(&:nil?)
+
+          states = states_by_path.flatten
+          return if states.empty?
+
+          unique = states.uniq
+          return :mixed if unique.include?(:open) && unique.include?(:terminal)
+
+          unique.fetch(0)
+        end
+
+        sig { override.params(record_id: String, boundary: String).returns(T::Boolean) }
+        def reintroduction_boundary_valid?(record_id, boundary)
+          alias_target_paths(record_id).all? do |path|
+            next true unless File.file?(path)
+
+            existing = alias_record(path)
+            next false unless existing.is_a?(Hash)
+
+            affected = existing["affected"]
+            next false unless affected.is_a?(Array)
+
+            affected.all? do |entry|
+              next false unless entry.is_a?(Hash)
+
+              ranges = homebrew_ranges(entry["ranges"])
+              Homebrew::Vulns::OsvExport.reintroduction_follows?(ranges, boundary)
+            end
+          end
         end
 
         sig { override.void }
@@ -231,11 +445,105 @@ module Homebrew
           File.join(@dir, "#{record_id}.json")
         end
 
-        sig { params(path: String).returns(T.nilable(String)) }
-        def existing_source(path)
-          JSON.parse(File.read(path)).dig("database_specific", "source")
+        sig { params(record_id: String).returns(T::Array[String]) }
+        def alias_target_paths(record_id)
+          @alias_targets.fetch(record_id) { [record_path(record_id)] }
+        end
+
+        sig { params(path: String).returns(T.untyped) }
+        def alias_record(path)
+          return @alias_records[path] if @alias_records.key?(path)
+
+          @alias_records[path] = JSON.parse(File.read(path))
         rescue JSON::ParserError
-          nil
+          @alias_records[path] = :malformed
+        end
+
+        sig { params(record: T::Hash[String, T.untyped]).returns(T::Array[String]) }
+        def affected_formula_names(record)
+          Array(record["affected"]).filter_map do |entry|
+            next unless entry.is_a?(Hash)
+
+            package = entry["package"]
+            next unless package.is_a?(Hash)
+            next if package["ecosystem"] != Homebrew::Vulns::OsvExport::ECOSYSTEM
+
+            package["name"]
+          end.uniq
+        end
+
+        sig { void }
+        def ensure_alias_index
+          return if @alias_index_loaded
+
+          Dir.glob(File.join(@dir, "BREW-*.json")).each do |path|
+            existing = alias_record(path)
+            next unless existing.is_a?(Hash)
+
+            formula_names = affected_formula_names(existing)
+            next unless formula_names.one?
+
+            identities = Array(existing["upstream"]).grep(String).map do |id|
+              "BREW-#{formula_names.fetch(0)}-#{id}"
+            end.uniq
+            @path_identities[path] = identities
+            identities.each { |identity| (@identity_paths[identity] ||= []) << path }
+          end
+          @alias_index_loaded = true
+        end
+
+        sig { params(record_ids: T::Array[String]).returns(T::Array[String]) }
+        def matching_alias_paths(record_ids)
+          pending = record_ids.dup
+          identities = T.let({}, T::Hash[String, T::Boolean])
+          paths = T.let({}, T::Hash[String, T::Boolean])
+          until pending.empty?
+            identity = pending.shift
+            next if identity.nil? || identities[identity]
+
+            identities[identity] = true
+            direct = record_path(identity)
+            linked = [direct, *@identity_paths.fetch(identity, [])]
+            linked.each do |path|
+              next unless File.file?(path)
+              next if paths[path]
+
+              paths[path] = true
+              pending.concat(@path_identities.fetch(path, []))
+            end
+          end
+          paths.keys.sort
+        end
+
+        sig { params(path: String).returns(T.nilable(T::Array[Symbol])) }
+        def reviewed_states(path)
+          existing = alias_record(path)
+          return unless existing.is_a?(Hash)
+
+          affected = existing["affected"]
+          return unless affected.is_a?(Array)
+          return if affected.empty?
+
+          states = affected.filter_map do |entry|
+            next unless entry.is_a?(Hash)
+
+            ranges = homebrew_ranges(entry["ranges"])
+            if Homebrew::Vulns::OsvExport.ranges_terminal?(ranges)
+              :terminal
+            elsif Homebrew::Vulns::OsvExport.ranges_open?(ranges)
+              :open
+            end
+          end
+          return if states.length != affected.length
+
+          states
+        end
+
+        sig { params(ranges: T.untyped).returns(T::Array[T.untyped]) }
+        def homebrew_ranges(ranges)
+          Array(ranges).select do |range|
+            range.is_a?(Hash) && range["type"] == "ECOSYSTEM"
+          end
         end
 
         sig { override.void }

--- a/Library/Homebrew/test/dev-cmd/advisory-match_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/advisory-match_spec.rb
@@ -32,16 +32,427 @@ RSpec.describe Homebrew::DevCmd::AdvisoryMatch do
     cmd
   end
 
-  def stub_osv_hit(cve, fixed:)
+  def stub_osv_hit(cve, fixed:, aliases: [])
     allow(Homebrew::Vulns::OSV).to receive(:query_batch).and_return([[{ "id" => cve }], []])
     allow(Homebrew::Vulns::OSV).to receive(:vulnerability).with(cve).and_return(
-      { "id" => cve, "summary" => "s",
+      { "id" => cve, "aliases" => aliases, "summary" => "s",
         "affected" => [{
           "package" => { "ecosystem" => "GIT", "name" => "https://github.com/psf/requests" },
           "ranges"  => [{ "type"   => "ECOSYSTEM",
                           "events" => [{ "introduced" => "0" }, { "fixed" => fixed }] }],
         }] },
     )
+  end
+
+  it "synchronizes an existing matched alias while preserving its identity and reviewed history" do
+    stub_osv_hit("GHSA-old", aliases: ["CVE-2024-1234"], fixed: "2.28.1")
+
+    Dir.mktmpdir do |dir|
+      alias_path = File.join(dir, "BREW-requests-GHSA-old.json")
+      legacy_path = File.join(dir, "BREW-requests-PYSEC-old.json")
+      File.write(alias_path, JSON.generate({
+        "id"                => "BREW-requests-GHSA-old",
+        "published"         => "2025-01-01T00:00:00Z",
+        "summary"           => "stale",
+        "upstream"          => ["GHSA-old"],
+        "affected"          => [{
+          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [
+            { "introduced" => "0" }, { "fixed" => "2.28.1" }
+          ] }],
+        }],
+        "database_specific" => { "source" => "matched" },
+      }))
+      File.write(legacy_path, JSON.generate({
+        "id"                => "BREW-requests-PYSEC-old",
+        "published"         => "2024-01-01T00:00:00Z",
+        "summary"           => "older",
+        "upstream"          => ["PYSEC-old", "GHSA-old"],
+        "affected"          => [{
+          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [
+            { "introduced" => "0" }, { "fixed" => "2.27.0" }
+          ] }],
+        }],
+        "database_specific" => { "source" => "matched" },
+      }))
+
+      cmd_for("requests", "--output", dir, "--no-history").run
+
+      refreshed = JSON.parse(File.read(alias_path))
+      expect(refreshed.values_at("id", "published", "summary", "upstream")).to eq([
+        "BREW-requests-GHSA-old",
+        "2025-01-01T00:00:00Z",
+        "s",
+        ["GHSA-old", "CVE-2024-1234"],
+      ])
+      expect(refreshed.dig("affected", 0, "ranges", 0, "events")).to eq([
+        { "introduced" => "0" }, { "fixed" => "2.28.1" }
+      ])
+      legacy = JSON.parse(File.read(legacy_path))
+      expect(legacy.values_at("id", "published", "summary", "upstream")).to eq([
+        "BREW-requests-PYSEC-old",
+        "2024-01-01T00:00:00Z",
+        "s",
+        ["PYSEC-old", "GHSA-old", "CVE-2024-1234"],
+      ])
+      expect(legacy.dig("affected", 0, "ranges", 0, "events")).to eq([
+        { "introduced" => "0" }, { "fixed" => "2.27.0" }
+      ])
+      expect(File).to exist(File.join(dir, "BREW-requests-CVE-2024-1234.json"))
+    end
+  end
+
+  it "uses a terminal alias to decide whether reintroduction history is required" do
+    stub_osv_hit("GHSA-old", aliases: ["CVE-2024-1234"], fixed: "2.32.0")
+    matcher = Homebrew::Vulns::Match.new
+    expect(matcher).to receive(:first_reintroduced_version).and_return("2.31.0")
+    allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
+
+    Dir.mktmpdir do |dir|
+      alias_path = File.join(dir, "BREW-requests-GHSA-old.json")
+      File.write(alias_path, JSON.generate({
+        "id"                => "BREW-requests-GHSA-old",
+        "upstream"          => ["GHSA-old"],
+        "affected"          => [{
+          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [
+            { "introduced" => "0" }, { "fixed" => "2.30.0" }
+          ] }],
+        }],
+        "database_specific" => { "source" => "matched" },
+      }))
+
+      expect { cmd_for("requests", "--output", dir, "--new-history").run }
+        .to output(/1 history walks/).to_stdout
+      expect(JSON.parse(File.read(alias_path)).dig("affected", 0, "ranges", 0, "events")).to eq([
+        { "introduced" => "0" }, { "fixed" => "2.30.0" }, { "introduced" => "2.31.0" }
+      ])
+    end
+  end
+
+  it "protects a generated alias while still emitting the canonical matched record" do
+    stub_osv_hit("GHSA-old", aliases: ["CVE-2024-1234"], fixed: "2.28.1")
+
+    Dir.mktmpdir do |dir|
+      generated_path = File.join(dir, "BREW-requests-GHSA-old.json")
+      generated = {
+        "id"                => "BREW-requests-GHSA-old",
+        "upstream"          => ["GHSA-old"],
+        "affected"          => [{
+          "package"            => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ecosystem_specific" => { "fix" => "patch" },
+        }],
+        "database_specific" => { "source" => "generated" },
+      }
+      File.write(generated_path, JSON.generate(generated))
+
+      expect { cmd_for("requests", "--output", dir, "--no-history").run }
+        .to output(/1 generated left as-is/).to_stdout
+      expect(JSON.parse(File.read(generated_path))).to eq generated
+      expect(File).to exist(File.join(dir, "BREW-requests-CVE-2024-1234.json"))
+    end
+  end
+
+  it "leaves every alias unchanged with --no-history when one needs a transition" do
+    stub_osv_hit("GHSA-old", aliases: ["CVE-2024-1234"], fixed: "2.28.1")
+
+    Dir.mktmpdir do |dir|
+      canonical_path = File.join(dir, "BREW-requests-CVE-2024-1234.json")
+      alias_path = File.join(dir, "BREW-requests-GHSA-old.json")
+      canonical = {
+        "id"                => "BREW-requests-CVE-2024-1234",
+        "upstream"          => ["CVE-2024-1234", "GHSA-old"],
+        "affected"          => [{
+          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [
+            { "introduced" => "0" }, { "fixed" => "2.28.1" }
+          ] }],
+        }],
+        "database_specific" => { "source" => "matched" },
+      }
+      alias_record = {
+        "id"                => "BREW-requests-GHSA-old",
+        "upstream"          => ["GHSA-old", "CVE-2024-1234"],
+        "affected"          => [{
+          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [{ "introduced" => "1.0" }] }],
+        }],
+        "database_specific" => { "source" => "matched" },
+      }
+      File.write(canonical_path, JSON.generate(canonical))
+      File.write(alias_path, JSON.generate(alias_record))
+
+      cmd_for("requests", "--output", dir, "--no-history").run
+
+      expect(JSON.parse(File.read(canonical_path))).to eq canonical
+      expect(JSON.parse(File.read(alias_path))).to eq alias_record
+    end
+  end
+
+  it "closes an open alias without changing a terminal alias in the same family" do
+    stub_osv_hit("GHSA-old", aliases: ["CVE-2024-1234"], fixed: "2.28.1")
+    matcher = Homebrew::Vulns::Match.new
+    expect(matcher).to receive(:first_fixed_version).and_return("2.28.1")
+    allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
+
+    Dir.mktmpdir do |dir|
+      canonical_path = File.join(dir, "BREW-requests-CVE-2024-1234.json")
+      alias_path = File.join(dir, "BREW-requests-GHSA-old.json")
+      common = {
+        "affected"          => [{
+          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
+        }],
+        "database_specific" => { "source" => "matched" },
+      }
+      File.write(canonical_path, JSON.generate(common.merge(
+                                                 "id"       => "BREW-requests-CVE-2024-1234",
+                                                 "upstream" => ["CVE-2024-1234", "GHSA-old"],
+                                                 "affected" => [{
+                                                   "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
+                                                   "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [
+                                                     { "introduced" => "0" }, { "fixed" => "2.27.0" }
+                                                   ] }],
+                                                 }],
+                                               )))
+      File.write(alias_path, JSON.generate(common.merge(
+                                             "id"       => "BREW-requests-GHSA-old",
+                                             "upstream" => ["GHSA-old", "CVE-2024-1234"],
+                                             "affected" => [{
+                                               "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
+                                               "ranges"  => [{ "type"   => "ECOSYSTEM",
+                                                               "events" => [{ "introduced" => "2.27.1" }] }],
+                                             }],
+                                           )))
+
+      expect { cmd_for("requests", "--output", dir, "--new-history").run }
+        .to output(/1 history walks/).to_stdout
+      expect(JSON.parse(File.read(canonical_path)).dig("affected", 0, "ranges", 0, "events")).to eq([
+        { "introduced" => "0" }, { "fixed" => "2.27.0" }
+      ])
+      expect(JSON.parse(File.read(alias_path)).dig("affected", 0, "ranges", 0, "events")).to eq([
+        { "introduced" => "2.27.1" }, { "fixed" => "2.28.1" }
+      ])
+    end
+  end
+
+  it "leaves an alias family unchanged when fixed does not follow every open range" do
+    stub_osv_hit("GHSA-old", aliases: ["CVE-2024-1234"], fixed: "2.28.1")
+    matcher = Homebrew::Vulns::Match.new
+    expect(matcher).to receive(:first_fixed_version).and_return("2.28.1")
+    allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
+
+    Dir.mktmpdir do |dir|
+      canonical_path = File.join(dir, "BREW-requests-CVE-2024-1234.json")
+      alias_path = File.join(dir, "BREW-requests-GHSA-old.json")
+      canonical = {
+        "id"                => "BREW-requests-CVE-2024-1234",
+        "upstream"          => ["CVE-2024-1234", "GHSA-old"],
+        "affected"          => [{
+          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [{ "introduced" => "2.27.0" }] }],
+        }],
+        "database_specific" => { "source" => "matched" },
+      }
+      alias_record = {
+        "id"                => "BREW-requests-GHSA-old",
+        "upstream"          => ["GHSA-old", "CVE-2024-1234"],
+        "affected"          => [{
+          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [{ "introduced" => "2.29.0" }] }],
+        }],
+        "database_specific" => { "source" => "matched" },
+      }
+      File.write(canonical_path, JSON.generate(canonical))
+      File.write(alias_path, JSON.generate(alias_record))
+
+      expect { cmd_for("requests", "--output", dir, "--new-history").run }
+        .to output(/fixed 2\.28\.1 does not follow its reviewed range/).to_stderr
+      expect([
+        JSON.parse(File.read(canonical_path)),
+        JSON.parse(File.read(alias_path)),
+        Homebrew.failed?,
+      ]).to eq [canonical, alias_record, true]
+    end
+  end
+
+  it "refreshes an open alias while reopening terminal siblings" do
+    stub_osv_hit("GHSA-old", aliases: ["CVE-2024-1234"], fixed: "2.32.0")
+    matcher = Homebrew::Vulns::Match.new
+    expect(matcher).to receive(:first_reintroduced_version).and_return("2.31.0")
+    allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
+
+    Dir.mktmpdir do |dir|
+      canonical_path = File.join(dir, "BREW-requests-CVE-2024-1234.json")
+      alias_path = File.join(dir, "BREW-requests-GHSA-old.json")
+      File.write(canonical_path, JSON.generate({
+        "id"                => "BREW-requests-CVE-2024-1234",
+        "summary"           => "stale",
+        "upstream"          => ["CVE-2024-1234", "GHSA-old"],
+        "affected"          => [{
+          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [
+            { "introduced" => "0" }, { "fixed" => "2.30.0" }
+          ] }],
+        }],
+        "database_specific" => { "source" => "matched" },
+      }))
+      File.write(alias_path, JSON.generate({
+        "id"                => "BREW-requests-GHSA-old",
+        "summary"           => "stale",
+        "upstream"          => ["GHSA-old"],
+        "affected"          => [{
+          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [{ "introduced" => "2.31.0" }] }],
+        }],
+        "database_specific" => { "source" => "matched" },
+      }))
+
+      cmd_for("requests", "--output", dir, "--new-history").run
+
+      canonical = JSON.parse(File.read(canonical_path))
+      alias_record = JSON.parse(File.read(alias_path))
+      expect([
+        canonical.dig("affected", 0, "ranges", 0, "events"),
+        alias_record.values_at("summary", "upstream"),
+        alias_record.dig("affected", 0, "ranges", 0, "events"),
+      ]).to eq [
+        [{ "introduced" => "0" }, { "fixed" => "2.30.0" }, { "introduced" => "2.31.0" }],
+        ["s", ["GHSA-old", "CVE-2024-1234"]],
+        [{ "introduced" => "2.31.0" }],
+      ]
+    end
+  end
+
+  it "rejects overlapping alias groups before writing either family" do
+    Dir.mktmpdir do |dir|
+      shared_path = File.join(dir, "BREW-requests-GHSA-shared.json")
+      File.write(shared_path, JSON.generate({
+        "id"                => "BREW-requests-GHSA-shared",
+        "upstream"          => ["GHSA-shared"],
+        "affected"          => [{
+          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [{ "introduced" => "0" }] }],
+        }],
+        "database_specific" => { "source" => "matched" },
+      }))
+      emitter = Homebrew::DevCmd::AdvisoryMatch::DirEmitter.new(dir, verbose: false, close_open_ranges: false)
+
+      errors = emitter.prepare_aliases("requests", {
+        "BREW-requests-CVE-one" => ["BREW-requests-CVE-one", "BREW-requests-GHSA-shared"],
+        "BREW-requests-CVE-two" => ["BREW-requests-CVE-two", "BREW-requests-GHSA-shared"],
+      })
+
+      expect(errors.join("\n")).to include("identity also belongs")
+      expect(File).not_to exist(File.join(dir, "BREW-requests-CVE-one.json"))
+      expect(File).not_to exist(File.join(dir, "BREW-requests-CVE-two.json"))
+    end
+  end
+
+  it "fails closed when an alias filename and record id disagree" do
+    stub_osv_hit("GHSA-old", aliases: ["CVE-2024-1234"], fixed: "2.28.1")
+
+    Dir.mktmpdir do |dir|
+      alias_path = File.join(dir, "BREW-requests-GHSA-old.json")
+      conflicting = {
+        "id"                => "BREW-requests-GHSA-other",
+        "upstream"          => ["GHSA-old"],
+        "affected"          => [{
+          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [{ "introduced" => "0" }] }],
+        }],
+        "database_specific" => { "source" => "matched" },
+      }
+      File.write(alias_path, JSON.generate(conflicting))
+
+      expect { cmd_for("requests", "--output", dir, "--no-history").run }
+        .to output(/mismatched id/).to_stderr
+      expect(JSON.parse(File.read(alias_path))).to eq conflicting
+      expect(File).not_to exist(File.join(dir, "BREW-requests-CVE-2024-1234.json"))
+      expect(Homebrew.failed?).to be true
+    end
+  end
+
+  it "fails closed when an alias database_specific value is not an object" do
+    stub_osv_hit("GHSA-old", aliases: ["CVE-2024-1234"], fixed: "2.28.1")
+
+    Dir.mktmpdir do |dir|
+      alias_path = File.join(dir, "BREW-requests-GHSA-old.json")
+      existing = {
+        "id"                => "BREW-requests-GHSA-old",
+        "upstream"          => ["GHSA-old", "CVE-2024-1234"],
+        "affected"          => [{
+          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [{ "introduced" => "0" }] }],
+        }],
+        "database_specific" => "bad",
+      }
+      File.write(alias_path, JSON.generate(existing))
+
+      expect { cmd_for("requests", "--output", dir, "--no-history").run }
+        .to output(/unsupported source/).to_stderr
+      expect(JSON.parse(File.read(alias_path))).to eq existing
+      expect(File).not_to exist(File.join(dir, "BREW-requests-CVE-2024-1234.json"))
+      expect(Homebrew.failed?).to be true
+    end
+  end
+
+  it "fails closed when an alias package value is not an object" do
+    stub_osv_hit("GHSA-old", aliases: ["CVE-2024-1234"], fixed: "2.28.1")
+
+    Dir.mktmpdir do |dir|
+      alias_path = File.join(dir, "BREW-requests-GHSA-old.json")
+      existing = {
+        "id"                => "BREW-requests-GHSA-old",
+        "upstream"          => ["GHSA-old", "CVE-2024-1234"],
+        "affected"          => [{
+          "package" => "bad",
+          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [{ "introduced" => "0" }] }],
+        }],
+        "database_specific" => { "source" => "matched" },
+      }
+      File.write(alias_path, JSON.generate(existing))
+
+      expect { cmd_for("requests", "--output", dir, "--no-history").run }
+        .to output(/unsupported affected entries/).to_stderr
+      expect(JSON.parse(File.read(alias_path))).to eq existing
+      expect(File).not_to exist(File.join(dir, "BREW-requests-CVE-2024-1234.json"))
+      expect(Homebrew.failed?).to be true
+    end
+  end
+
+  it "fails closed when an alias has multiple affected entries" do
+    stub_osv_hit("GHSA-old", aliases: ["CVE-2024-1234"], fixed: "2.28.1")
+
+    Dir.mktmpdir do |dir|
+      alias_path = File.join(dir, "BREW-requests-GHSA-old.json")
+      existing = {
+        "id"                => "BREW-requests-GHSA-old",
+        "upstream"          => ["GHSA-old", "CVE-2024-1234"],
+        "affected"          => [
+          {
+            "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
+            "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [
+              { "introduced" => "0" }, { "fixed" => "2.27.0" }
+            ] }],
+          },
+          {
+            "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
+            "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [
+              { "introduced" => "2.27.1" }, { "fixed" => "2.28.0" }
+            ] }],
+          },
+        ],
+        "database_specific" => { "source" => "matched" },
+      }
+      File.write(alias_path, JSON.generate(existing))
+
+      expect { cmd_for("requests", "--output", dir, "--no-history").run }
+        .to output(/unsupported affected entries/).to_stderr
+      expect(JSON.parse(File.read(alias_path))).to eq existing
+      expect(File).not_to exist(File.join(dir, "BREW-requests-CVE-2024-1234.json"))
+      expect(Homebrew.failed?).to be true
+    end
   end
 
   it "writes matched records to --output=<dir> with merge_existing semantics" do
@@ -155,19 +566,101 @@ RSpec.describe Homebrew::DevCmd::AdvisoryMatch do
     end
   end
 
-  it "walks history when an existing record is malformed" do
+  it "walks history and reopens an existing terminal range with --new-history" do
+    stub_osv_hit("CVE-2024-1234", fixed: "2.32.0")
+    matcher = Homebrew::Vulns::Match.new
+    expect(matcher).to receive(:first_reintroduced_version).and_return("2.31.0")
+    allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
+
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "BREW-requests-CVE-2024-1234.json")
+      File.write(path, JSON.generate({
+        "id"                => "BREW-requests-CVE-2024-1234",
+        "affected"          => [{
+          "package"            => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"             => [{ "type" => "ECOSYSTEM", "events" => [
+            { "introduced" => "0" }, { "fixed" => "2.30.0" }
+          ] }],
+          "ecosystem_specific" => { "range_state" => "fixed" },
+        }],
+        "database_specific" => { "source" => "matched" },
+      }))
+
+      expect { cmd_for("requests", "--output", dir, "--new-history").run }
+        .to output(/1 history walks/).to_stdout
+      expect(JSON.parse(File.read(path)).dig("affected", 0, "ranges", 0, "events"))
+        .to eq([{ "introduced" => "0" }, { "fixed" => "2.30.0" }, { "introduced" => "2.31.0" }])
+    end
+  end
+
+  it "leaves a terminal range unchanged when history cannot prove a reintroduction" do
+    stub_osv_hit("CVE-2024-1234", fixed: "2.32.0")
+    matcher = Homebrew::Vulns::Match.new
+    expect(matcher).to receive(:first_reintroduced_version).and_return(:not_reintroduced)
+    allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
+
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "BREW-requests-CVE-2024-1234.json")
+      existing = {
+        "id"                => "BREW-requests-CVE-2024-1234",
+        "affected"          => [{
+          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [
+            { "introduced" => "0" }, { "fixed" => "2.30.0" }
+          ] }],
+        }],
+        "database_specific" => { "source" => "matched" },
+      }
+      File.write(path, JSON.generate(existing))
+
+      expect { cmd_for("requests", "--output", dir, "--new-history").run }
+        .to output(/could not find a prior non-affected version/).to_stderr
+      expect(JSON.parse(File.read(path))).to eq existing
+      expect(Homebrew.failed?).to be true
+    end
+  end
+
+  it "leaves a terminal range unchanged when the new boundary precedes the reviewed boundary" do
+    stub_osv_hit("CVE-2024-1234", fixed: "2.32.0")
+    matcher = Homebrew::Vulns::Match.new
+    expect(matcher).to receive(:first_reintroduced_version).and_return("2.29.0")
+    allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
+
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "BREW-requests-CVE-2024-1234.json")
+      existing = {
+        "id"                => "BREW-requests-CVE-2024-1234",
+        "affected"          => [{
+          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [
+            { "introduced" => "0" }, { "fixed" => "2.30.0" }
+          ] }],
+        }],
+        "database_specific" => { "source" => "matched" },
+      }
+      File.write(path, JSON.generate(existing))
+
+      expect { cmd_for("requests", "--output", dir, "--new-history").run }
+        .to output(/reintroduction 2\.29\.0 does not follow its reviewed range/).to_stderr
+      expect(JSON.parse(File.read(path))).to eq existing
+      expect(Homebrew.failed?).to be true
+    end
+  end
+
+  it "fails closed when an existing record is malformed" do
     stub_osv_hit("CVE-2024-1234", fixed: "2.28.1")
     matcher = Homebrew::Vulns::Match.new
-    expect(matcher).to receive(:first_fixed_version).and_return("2.28.1")
+    expect(matcher).not_to receive(:first_fixed_version)
     allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
 
     Dir.mktmpdir do |dir|
       path = File.join(dir, "BREW-requests-CVE-2024-1234.json")
       File.write(path, "{")
 
-      cmd_for("requests", "--output", dir, "--new-history").run
-      expect(JSON.parse(File.read(path)).dig("affected", 0, "ranges", 0, "events", 1))
-        .to eq("fixed" => "2.28.1")
+      expect { cmd_for("requests", "--output", dir, "--new-history").run }
+        .to output(/malformed alias/).to_stderr
+      expect(File.read(path)).to eq "{"
+      expect(Homebrew.failed?).to be true
     end
   end
 
@@ -202,6 +695,30 @@ RSpec.describe Homebrew::DevCmd::AdvisoryMatch do
       cmd_for("requests", "--output", dir, "--no-history").run
       expect(JSON.parse(File.read(path)).dig("affected", 0, "ranges", 0, "events"))
         .to eq([{ "introduced" => "1.0" }])
+    end
+  end
+
+  it "does not rewrite an existing terminal range as affected with --no-history" do
+    stub_osv_hit("CVE-2024-1234", fixed: "2.32.0")
+
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "BREW-requests-CVE-2024-1234.json")
+      existing = {
+        "id"                => "BREW-requests-CVE-2024-1234",
+        "affected"          => [{
+          "package"            => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"             => [{ "type" => "ECOSYSTEM", "events" => [
+            { "introduced" => "0" }, { "fixed" => "2.30.0" }
+          ] }],
+          "ecosystem_specific" => { "range_state" => "fixed" },
+        }],
+        "database_specific" => { "source" => "matched" },
+      }
+      File.write(path, JSON.generate(existing))
+
+      cmd_for("requests", "--output", dir, "--no-history").run
+
+      expect(JSON.parse(File.read(path))).to eq existing
     end
   end
 
@@ -250,11 +767,12 @@ RSpec.describe Homebrew::DevCmd::AdvisoryMatch do
   end
 
   it "emits records as JSON with --json" do
-    stub_osv_hit("CVE-2024-1234", fixed: "2.28.1")
+    stub_osv_hit("GHSA-old", aliases: ["CVE-2024-1234"], fixed: "2.28.1")
 
     records = JSON.parse(capture_stdout { cmd_for("requests", "--json", "--no-history").run })
     expect(records.length).to eq 1
     expect(records.first["id"]).to eq "BREW-requests-CVE-2024-1234"
+    expect(records.first["upstream"]).to contain_exactly("CVE-2024-1234", "GHSA-old")
   end
 
   it "prints a per-hit summary in text mode" do

--- a/Library/Homebrew/test/vulns/match_spec.rb
+++ b/Library/Homebrew/test/vulns/match_spec.rb
@@ -506,6 +506,7 @@ RSpec.describe Homebrew::Vulns::Match do
       expect(hits.map(&:canonical_id).sort).to eq ["CVE-2021-22204", "CVE-2021-99999"]
       merged = hits.find { |h| h.canonical_id == "CVE-2021-22204" }
       expect(T.must(merged).strategy).to eq :git
+      expect(T.must(merged).identifiers).to include("CVE-2021-22204", "GHSA-xxxx")
       expect(T.must(merged).evidence.map(&:strategy).uniq.sort).to eq [:cpansa, :distro, :git]
       expect(T.must(merged).evidence.find { |e| e.strategy == :cpansa }&.advisory).not_to be_nil
     end
@@ -633,7 +634,7 @@ RSpec.describe Homebrew::Vulns::Match do
     end
   end
 
-  describe "#first_fixed_version" do
+  describe "historical boundary walks" do
     let(:requests) do
       formula("requests") do
         T.bind(self, T.class_of(Formula))
@@ -714,6 +715,46 @@ RSpec.describe Homebrew::Vulns::Match do
     it "returns :never_affected when the formula was already past fixed at its first revision" do
       stub_history(["2.31.0"])
       expect(matcher.first_fixed_version(requests, hit_fixed_at("2.28.1"))).to eq :never_affected
+    end
+
+    it "keeps Git history uncheckable across repository URL changes" do
+      current = formula("requests") do
+        T.bind(self, T.class_of(Formula))
+        url "https://github.com/neworg/requests/archive/refs/tags/2.0.tar.gz"
+      end
+      historical = [
+        formula("requests") do
+          T.bind(self, T.class_of(Formula))
+          url "https://github.com/oldorg/requests/archive/refs/tags/1.1.tar.gz"
+        end,
+        formula("requests") do
+          T.bind(self, T.class_of(Formula))
+          url "https://github.com/oldorg/requests/archive/refs/tags/1.0.tar.gz"
+        end,
+      ]
+      fv = instance_double(FormulaVersions)
+      allow(fv).to receive(:rev_list) do |_, &block|
+        historical.each_index { |index| block.call("r#{index}", "Formula/r/requests.rb") }
+      end
+      historical.each_with_index do |old, index|
+        allow(fv).to receive(:formula_at_revision).with("r#{index}", anything).and_yield(old)
+      end
+      allow(FormulaVersions).to receive(:new).and_return(fv)
+      git_hit = lambda do |fixed|
+        make_hit(
+          vuln("id" => "CVE-1", "affected" => [
+            { "package" => { "ecosystem" => "GIT", "name" => "https://github.com/neworg/requests" },
+              "ranges"  => [{ "type"   => "ECOSYSTEM",
+                              "events" => [{ "introduced" => "0" }, { "fixed" => fixed }] }] },
+          ]),
+          ev(:git, ecosystem: "GIT", name: "https://github.com/neworg/requests", subject_version: "2.0"),
+        )
+      end
+
+      expect([
+        matcher.first_fixed_version(current, git_hit.call("1.1")),
+        matcher.first_reintroduced_version(current, git_hit.call("3.0")),
+      ]).to eq ["2.0", :not_reintroduced]
     end
 
     it "returns :never_affected when a fixed resource was absent from earlier formula revisions" do
@@ -842,6 +883,135 @@ RSpec.describe Homebrew::Vulns::Match do
     it "returns nil when there is no comparable range" do
       hit = make_hit(vuln("id" => "CVE-1"), ev(:distro, ecosystem: "Debian", name: "requests"))
       expect(matcher.first_fixed_version(requests, hit)).to be_nil
+    end
+
+    it "fails closed when a descending reintroduction would cover a known fixed version" do
+      stub_history(["2.31.0", "2.32.0", "2.30.0"])
+      expect(matcher.first_reintroduced_version(requests, hit_fixed_at("2.32.0"))).to eq :not_reintroduced
+    end
+
+    it "uses the lowest representable version when the affected history moves backwards" do
+      stub_history([["3.0", "1.0"], ["4.0", "1.0"], ["2.0", "2.0"]])
+      current = formula("requests") do
+        T.bind(self, T.class_of(Formula))
+        url "https://files.pythonhosted.org/packages/aa/bb/cc/requests-3.0.tar.gz"
+        resource("certifi") do
+          url "https://files.pythonhosted.org/packages/11/22/33/certifi-1.0.tar.gz"
+        end
+      end
+      hit = make_hit(
+        vuln("id" => "CVE-1", "affected" => [
+          { "package" => { "ecosystem" => "PyPI", "name" => "certifi" },
+            "ranges"  => [{ "type"   => "ECOSYSTEM",
+                            "events" => [{ "introduced" => "0" }, { "fixed" => "1.5" }] }] },
+        ]),
+        ev(:registry, ecosystem: "PyPI", name: "certifi", subject_version: "1.0", resource: "certifi"),
+      )
+
+      expect(matcher.first_reintroduced_version(current, hit)).to eq "3.0"
+    end
+
+    it "finds the formula boundary when a bundled resource becomes affected again" do
+      stub_history([["4.0", "1.0"], ["3.0", "1.0"], ["2.0", "1.2"], ["1.0", "0.9"]])
+      current = formula("requests") do
+        T.bind(self, T.class_of(Formula))
+        url "https://files.pythonhosted.org/packages/aa/bb/cc/requests-4.0.tar.gz"
+        resource("certifi") do
+          url "https://files.pythonhosted.org/packages/11/22/33/certifi-1.0.tar.gz"
+        end
+      end
+      hit = make_hit(
+        vuln("id" => "CVE-1", "affected" => [
+          { "package" => { "ecosystem" => "PyPI", "name" => "certifi" },
+            "ranges"  => [{ "type"   => "ECOSYSTEM",
+                            "events" => [{ "introduced" => "0" }, { "fixed" => "1.1" }] }] },
+        ]),
+        ev(:registry, ecosystem: "PyPI", name: "certifi", subject_version: "1.0", resource: "certifi"),
+      )
+
+      expect(matcher.first_reintroduced_version(current, hit)).to eq "3.0"
+    end
+
+    it "treats a historical primary-package identity change as absence" do
+      current = formula("requests") do
+        T.bind(self, T.class_of(Formula))
+        url "https://files.pythonhosted.org/packages/aa/bb/cc/newpkg-1.0.tar.gz"
+        revision 1
+      end
+      previous = formula("requests") do
+        T.bind(self, T.class_of(Formula))
+        url "https://files.pythonhosted.org/packages/aa/bb/cc/oldpkg-1.0.tar.gz"
+      end
+      fv = instance_double(FormulaVersions)
+      allow(fv).to receive(:rev_list) { |_, &b| b.call("r0", "Formula/r/requests.rb") }
+      allow(fv).to receive(:formula_at_revision).with("r0", anything).and_yield(previous)
+      allow(FormulaVersions).to receive(:new).and_return(fv)
+      hit = make_hit(
+        vuln("id" => "CVE-1", "affected" => [
+          { "package" => { "ecosystem" => "PyPI", "name" => "newpkg" },
+            "ranges"  => [{ "type"   => "ECOSYSTEM",
+                            "events" => [{ "introduced" => "0" }, { "fixed" => "2.0" }] }] },
+        ]),
+        ev(:registry, ecosystem: "PyPI", name: "newpkg", subject_version: "1.0"),
+      )
+
+      expect(matcher.first_reintroduced_version(current, hit)).to eq "1.0_1"
+    end
+
+    it "keeps an unidentifiable historical primary package uncheckable" do
+      previous = formula("requests") do
+        T.bind(self, T.class_of(Formula))
+        url "https://example.test/downloads/requests-2.30.0.tar.gz"
+      end
+      fv = instance_double(FormulaVersions)
+      allow(fv).to receive(:rev_list).and_yield("r0", "Formula/r/requests.rb")
+      allow(fv).to receive(:formula_at_revision).with("r0", anything).and_yield(previous)
+      allow(FormulaVersions).to receive(:new).and_return(fv)
+
+      expect(matcher.first_reintroduced_version(requests, hit_fixed_at("2.32.0"))).to eq :not_reintroduced
+      expect(matcher.first_fixed_version(requests, hit_fixed_at("2.28.1"))).to eq "2.31.0"
+    end
+
+    it "does not let fixed evidence mask another uncheckable historical subject" do
+      previous = formula("requests") do
+        T.bind(self, T.class_of(Formula))
+        url "https://files.pythonhosted.org/packages/aa/bb/cc/requests-2.30.0.tar.gz"
+      end
+      hit = make_hit(
+        vuln("id" => "CVE-1", "affected" => [
+          { "package" => { "ecosystem" => "PyPI", "name" => "requests" },
+            "ranges"  => [{ "type"   => "ECOSYSTEM",
+                            "events" => [{ "introduced" => "0" }, { "fixed" => "2.28.1" }] }] },
+          { "package" => { "ecosystem" => "GIT", "name" => "https://github.com/psf/requests" },
+            "ranges"  => [{ "type"   => "GIT",
+                            "events" => [{ "introduced" => "0" }, { "fixed" => "f" * 40 }] }] },
+        ]),
+        ev(:registry, ecosystem: "PyPI", name: "requests", subject_version: "2.31.0"),
+        ev(:git, ecosystem: "GIT", name: "https://github.com/psf/requests", subject_version: "e" * 40),
+      )
+
+      expect(matcher.aggregate_state_at(previous, hit)).to be_nil
+    end
+
+    it "does not invent a boundary when a historical revision cannot be loaded" do
+      stub_history([nil])
+      expect(matcher.first_reintroduced_version(requests, hit_fixed_at("2.32.0"))).to eq :not_reintroduced
+    end
+
+    it "does not invent a boundary when a historical revision cannot be compared" do
+      stub_history(["2.30.0"])
+      allow(matcher).to receive(:aggregate_state_at).and_return(nil)
+      expect(matcher.first_reintroduced_version(requests, hit_fixed_at("2.32.0"))).to eq :not_reintroduced
+    end
+
+    it "does not invent a reintroduction when every historical revision is affected" do
+      stub_history(["2.31.0", "2.30.0"])
+      expect(matcher.first_reintroduced_version(requests, hit_fixed_at("2.32.0"))).to eq :not_reintroduced
+    end
+
+    it "does not walk reintroduction history when the current version is fixed" do
+      expect(FormulaVersions).not_to receive(:new)
+      expect(matcher.first_reintroduced_version(requests, hit_fixed_at("2.28.1"))).to be_nil
     end
   end
 

--- a/Library/Homebrew/test/vulns/osv_export_spec.rb
+++ b/Library/Homebrew/test/vulns/osv_export_spec.rb
@@ -48,6 +48,9 @@ RSpec.describe Homebrew::Vulns::OsvExport do
       expect(described_class.ranges_terminal?([{ "events" => [{ "introduced" => "0" }] }])).to be false
       expect(described_class.ranges_terminal?([])).to be false
       expect(described_class.ranges_terminal?([{ "events" => [] }])).to be false
+      wildcard = [{ "events" => [{ "introduced" => "1.0" }, { "limit" => "*" }] }]
+      expect(described_class.ranges_terminal?(wildcard)).to be false
+      expect(described_class.ranges_open?(wildcard)).to be true
     end
   end
 
@@ -78,6 +81,197 @@ RSpec.describe Homebrew::Vulns::OsvExport do
           { "type" => "ECOSYSTEM", "events" => [{ "introduced" => "1.0" }, { "fixed" => "2.0" }] },
           { "type" => "ECOSYSTEM", "events" => [{ "introduced" => "0" }, { "fixed" => "2.0" }] },
         ]
+      end
+    end
+
+    it "idempotently reopens every kind of terminal reviewed range from an explicit reintroduction" do
+      %w[fixed last_affected limit].each do |terminal|
+        Dir.mktmpdir do |dir|
+          path = File.join(dir, "BREW-x-CVE-1.json")
+          File.write(path, JSON.generate({
+            "id"       => "BREW-x-CVE-1",
+            "affected" => [{
+              "ranges"             => [{ "type" => "ECOSYSTEM", "events" => [
+                { "introduced" => "0" }, { terminal => "1.0" }
+              ] }],
+              "ecosystem_specific" => { "range_state" => "fixed" },
+            }],
+          }))
+          incoming = lambda do
+            {
+              id:       "BREW-x-CVE-1",
+              affected: [{
+                ranges:             [{ type: "ECOSYSTEM", events: [{ introduced: "2.0" }] }],
+                ecosystem_specific: { range_state: "affected" },
+              }],
+            }
+          end
+
+          merged = described_class.merge_existing(path, incoming.call, close_open_ranges: true)
+          events = [{ "introduced" => "0" }, { terminal => "1.0" }, { "introduced" => "2.0" }]
+          expect(JSON.parse(JSON.generate(merged)).dig("affected", 0, "ranges", 0, "events")).to eq events
+
+          File.write(path, JSON.generate(merged))
+          merged_again = described_class.merge_existing(path, incoming.call, close_open_ranges: true)
+          expect(merged_again).to be_nil
+        end
+      end
+    end
+
+    it "allows a reintroduction at an exclusive limit but not an inclusive boundary" do
+      outcomes = %w[fixed last_affected limit].to_h do |terminal|
+        ranges = [{ "type" => "ECOSYSTEM", "events" => [
+          { "introduced" => "0" }, { terminal => "2.0" }
+        ] }]
+        [terminal, described_class.reintroduction_follows?(ranges, "2.0")]
+      end
+
+      expect(outcomes).to eq("fixed" => false, "last_affected" => false, "limit" => true)
+    end
+
+    it "adds Homebrew version events only to ECOSYSTEM ranges" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "BREW-x-CVE-1.json")
+        git_events = [{ "introduced" => "a" * 40 }, { "fixed" => "b" * 40 }]
+        File.write(path, JSON.generate({
+          "id"       => "BREW-x-CVE-1",
+          "affected" => [{
+            "ranges" => [
+              { "type" => "ECOSYSTEM", "events" => [{ "introduced" => "0" }, { "fixed" => "1.0" }] },
+              { "type" => "GIT", "events" => git_events },
+            ],
+          }],
+        }))
+        incoming = {
+          id:       "BREW-x-CVE-1",
+          affected: [{ ranges: [{ type: "ECOSYSTEM", events: [{ introduced: "2.0" }] }] }],
+        }
+
+        merged = JSON.parse(JSON.generate(
+                              described_class.merge_existing(path, incoming, close_open_ranges: true),
+                            ))
+        expect(merged.dig("affected", 0, "ranges", 0, "events").last).to eq("introduced" => "2.0")
+        expect(merged.dig("affected", 0, "ranges", 1, "events")).to eq git_events
+      end
+    end
+
+    it "rejects a reintroduction that does not follow the reviewed terminal boundary" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "BREW-x-CVE-1.json")
+        existing = {
+          "id"       => "BREW-x-CVE-1",
+          "affected" => [{
+            "ranges" => [{ "type" => "ECOSYSTEM", "events" => [
+              { "introduced" => "0" }, { "fixed" => "2.0" }
+            ] }],
+          }],
+        }
+        File.write(path, JSON.generate(existing))
+        incoming = {
+          id:       "BREW-x-CVE-1",
+          affected: [{ ranges: [{ type: "ECOSYSTEM", events: [{ introduced: "1.5" }] }] }],
+        }
+
+        expect(described_class.merge_existing(path, incoming, close_open_ranges: true)).to be_nil
+        expect(JSON.parse(File.read(path))).to eq existing
+      end
+    end
+
+    it "rejects a fixed boundary that does not follow every open range" do
+      outcomes = ["1.5", "2.0"].map do |introduced|
+        Dir.mktmpdir do |dir|
+          path = File.join(dir, "BREW-x-CVE-1.json")
+          existing = {
+            "id"       => "BREW-x-CVE-1",
+            "affected" => [{
+              "ranges" => [
+                { "type" => "ECOSYSTEM", "events" => [
+                  { "introduced" => "1.0" }, { "limit" => "*" }
+                ] },
+                { "type" => "ECOSYSTEM", "events" => [{ "introduced" => introduced }] },
+              ],
+            }],
+          }
+          File.write(path, JSON.generate(existing))
+          incoming = {
+            id:       "BREW-x-CVE-1",
+            affected: [{ ranges: [{ type: "ECOSYSTEM", events: [
+              { introduced: "0" }, { fixed: "1.5" }
+            ] }] }],
+          }
+
+          merged = described_class.merge_existing(path, incoming, close_open_ranges: true)
+          [merged.nil?, JSON.parse(File.read(path)) == existing]
+        end
+      end
+
+      expect(outcomes).to eq [[true, true], [true, true]]
+    end
+
+    it "refreshes metadata while reopening only terminal ranges in a mixed range set" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "BREW-x-CVE-1.json")
+        File.write(path, JSON.generate({
+          "id"       => "BREW-x-CVE-1",
+          "summary"  => "stale",
+          "upstream" => ["GHSA-a"],
+          "affected" => [{
+            "ranges" => [
+              { "type" => "ECOSYSTEM", "events" => [
+                { "introduced" => "0" }, { "fixed" => "1.0" }
+              ] },
+              { "type" => "ECOSYSTEM", "events" => [
+                { "introduced" => "2.0" }, { "limit" => "*" }
+              ] },
+            ],
+          }],
+        }))
+        incoming = {
+          id:       "BREW-x-CVE-1",
+          summary:  "fresh",
+          upstream: ["GHSA-a", "CVE-1"],
+          affected: [{ ranges: [{ type: "ECOSYSTEM", events: [{ introduced: "3.0" }] }] }],
+        }
+
+        merged = JSON.parse(JSON.generate(
+                              described_class.merge_existing(path, incoming, close_open_ranges: true),
+                            ))
+        expect(merged.values_at("summary", "upstream", "affected")).to eq [
+          "fresh",
+          ["GHSA-a", "CVE-1"],
+          [{ "ranges" => [
+            { "type" => "ECOSYSTEM", "events" => [
+              { "introduced" => "0" }, { "fixed" => "1.0" }, { "introduced" => "3.0" }
+            ] },
+            { "type" => "ECOSYSTEM", "events" => [
+              { "introduced" => "2.0" }, { "limit" => "*" }
+            ] },
+          ] }],
+        ]
+      end
+    end
+
+    it "replaces an unbounded wildcard limit when closing an open range" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "BREW-x-CVE-1.json")
+        File.write(path, JSON.generate({
+          "id"       => "BREW-x-CVE-1",
+          "affected" => [{
+            "ranges" => [{ "type" => "ECOSYSTEM", "events" => [
+              { "introduced" => "1.0" }, { "limit" => "*" }
+            ] }],
+          }],
+        }))
+        incoming = {
+          id:       "BREW-x-CVE-1",
+          affected: [{ ranges: [{ type: "ECOSYSTEM", events: [
+            { introduced: "0" }, { fixed: "2.0" }
+          ] }] }],
+        }
+
+        merged = described_class.merge_existing(path, incoming, close_open_ranges: true)
+        events = JSON.parse(JSON.generate(merged)).dig("affected", 0, "ranges", 0, "events")
+        expect(events).to eq([{ "introduced" => "1.0" }, { "fixed" => "2.0" }])
       end
     end
   end

--- a/Library/Homebrew/vulns/match.rb
+++ b/Library/Homebrew/vulns/match.rb
@@ -106,6 +106,13 @@ module Homebrew
         def canonical_id
           vulnerability.cve_ids.min || vulnerability.id
         end
+
+        sig { returns(T::Array[String]) }
+        def identifiers
+          evidence.flat_map { |item| item.source_record&.identifiers || [] }
+                  .prepend(*vulnerability.identifiers)
+                  .uniq
+        end
       end
 
       sig { params(repology: T.nilable(Repology), cpan_sec: T.nilable(CPANSec), bulk: T::Boolean).void }
@@ -474,7 +481,9 @@ module Homebrew
       # Emit a candidate `BREW-*` OSV record for `hit` against `formula`.
       #
       # `first_fixed` is the {PkgVersion} at which Homebrew first shipped a fix
-      # (from {#first_fixed_version} or a hand-set value). Otherwise
+      # (from {#first_fixed_version} or a hand-set value), and
+      # `first_reintroduced` is the first Homebrew version in a newer affected
+      # interval (from {#first_reintroduced_version}). Otherwise
       # {#range_status} is consulted: `affected? == false` sets
       # `fixed: pkg_version` and `ecosystem_specific.fix: "bump"`;
       # `affected? == true` (or no comparable range) emits no `fixed` event and
@@ -482,17 +491,18 @@ module Homebrew
       # preserves on-disk `ranges` on rewrite so a hand-corrected boundary
       # sticks.
       sig {
-        params(formula: Formula, hit: Hit, first_fixed: T.nilable(String), now: Time)
+        params(formula: Formula, hit: Hit, first_fixed: T.nilable(String),
+               first_reintroduced: T.nilable(String), now: Time)
           .returns(T::Hash[Symbol, T.untyped])
       }
-      def to_brew_record(formula, hit, first_fixed: nil, now: Time.now.utc)
+      def to_brew_record(formula, hit, first_fixed: nil, first_reintroduced: nil, now: Time.now.utc)
         vuln = hit.vulnerability
         timestamp = now.strftime("%Y-%m-%dT%H:%M:%SZ")
         status, status_evidence = range_status(hit)
 
         fixed = first_fixed
         fixed ||= formula.pkg_version.to_s if status&.fixed?
-        events = T.let([{ introduced: "0" }], T::Array[T::Hash[Symbol, String]])
+        events = T.let([{ introduced: first_reintroduced || "0" }], T::Array[T::Hash[Symbol, String]])
         events << { fixed: } if fixed
 
         record = T.let({
@@ -500,7 +510,7 @@ module Homebrew
           id:                record_id(formula, hit),
           published:         timestamp,
           modified:          timestamp,
-          upstream:          vuln.identifiers,
+          upstream:          hit.identifiers,
           affected:          [affected_entry(formula, hit, events, fixed, status, status_evidence)],
           database_specific: {
             source:            "matched",
@@ -523,6 +533,11 @@ module Homebrew
       sig { params(formula: Formula, hit: Hit).returns(String) }
       def record_id(formula, hit)
         OsvExport.record_id(formula, hit.canonical_id)
+      end
+
+      sig { params(formula: Formula, hit: Hit).returns(T::Array[String]) }
+      def record_ids(formula, hit)
+        ([record_id(formula, hit)] + hit.identifiers.map { |id| OsvExport.record_id(formula, id) }).uniq
       end
 
       sig {
@@ -609,6 +624,54 @@ module Homebrew
         :never_affected
       end
 
+      # Return the lowest representable formula `pkg_version` in the newest
+      # contiguous affected run. This is the `introduced` boundary when a
+      # reviewed fixed range becomes affected again after a formula or resource
+      # regression, including a run whose version strings move backwards after
+      # a `version_scheme` change. After finding the transition, the remaining
+      # history is checked so the new interval cannot cover a known
+      # non-affected formula version.
+      # `:not_reintroduced` means no prior non-affected revision was verified,
+      # either because all loadable history remained affected or because a
+      # revision could not be loaded or compared safely.
+      sig { params(formula: Formula, hit: Hit).returns(T.nilable(T.any(String, Symbol))) }
+      def first_reintroduced_version(formula, hit)
+        return unless range_status(hit)&.first&.affected?
+
+        fv = @formula_versions[formula.name] ||= FormulaVersions.new(formula)
+        revs = @formula_rev_lists[formula.name] ||=
+          [].tap { |a| fv.rev_list("HEAD") { |rev, entry| a << [rev, entry] } }
+
+        first_affected = T.let(formula.pkg_version.to_s, String)
+        transition_found = T.let(false, T::Boolean)
+        revs.each do |rev, entry|
+          state = fv.formula_at_revision(rev, entry) do |old|
+            [aggregate_state_at(old, hit), old.pkg_version.to_s]
+          end
+          return :not_reintroduced if state.nil?
+
+          aggregate, pkg_version = state
+          return :not_reintroduced if aggregate.nil?
+
+          begin
+            historical = PkgVersion.parse(pkg_version)
+            boundary = PkgVersion.parse(first_affected)
+            if transition_found
+              return :not_reintroduced if aggregate != :affected && historical >= boundary
+            elsif aggregate == :affected
+              first_affected = pkg_version if historical < boundary
+            else
+              return :not_reintroduced if historical >= boundary
+
+              transition_found = true
+            end
+          rescue ArgumentError
+            return :not_reintroduced
+          end
+        end
+        transition_found ? first_affected : :not_reintroduced
+      end
+
       sig { params(formula: Formula, hit: Hit).returns(T.nilable(Symbol)) }
       def aggregate_state_at(formula, hit)
         results = hit.evidence.filter_map do |ev|
@@ -625,11 +688,13 @@ module Homebrew
           # removal can be the fix boundary while still allowing the walk to
           # find an older affected revision.
           next :fixed unless present
+          next :unknown if subject.nil?
 
-          evidence_range_status(ev, subject)&.state
+          evidence_range_status(ev, subject)&.state || :unknown
         end
         return if results.empty?
         return :affected if results.include?(:affected)
+        return if results.include?(:unknown)
         return :fixed if results.include?(:fixed)
 
         :not_applicable
@@ -641,7 +706,26 @@ module Homebrew
       # was present but had no comparable version (uncheckable).
       sig { params(formula: Formula, evidence: Evidence).returns([T::Boolean, T.nilable(String)]) }
       def subject_version_at(formula, evidence)
-        return [true, formula.version.to_s] unless evidence.resource
+        unless evidence.resource
+          stable = formula.stable
+          stable_url = stable&.url
+          if evidence.ecosystem == "GIT"
+            repo = Identify.repo_url(stable_url, formula.head&.url, formula.homepage)
+            return [true, nil] if repo.nil?
+            return [true, nil] if repo != evidence.name
+
+            version = Identify.tag(stable_url) || stable&.specs&.dig(:tag) || stable&.version&.to_s
+            return [true, version]
+          end
+
+          primary_package = Identify.registry_package(stable_url)
+          return [true, nil] if primary_package.nil?
+          if primary_package.ecosystem != evidence.ecosystem || primary_package.name != evidence.name
+            return [false, nil]
+          end
+
+          return [true, primary_package.version]
+        end
 
         exact_resource = formula.resources.find { |resource| resource.name == evidence.resource }
         if exact_resource

--- a/Library/Homebrew/vulns/osv_export.rb
+++ b/Library/Homebrew/vulns/osv_export.rb
@@ -3,6 +3,7 @@
 
 require "json"
 require "fileutils"
+require "pkg_version"
 require "uri"
 require "vulns/osv"
 require "vulns/scanner"
@@ -34,7 +35,8 @@ module Homebrew
       ECOSYSTEM = "Homebrew"
       ID_PREFIX = "BREW"
       RANGE_EVENT_KEYS = %w[introduced fixed last_affected limit].freeze
-      private_constant :RANGE_EVENT_KEYS
+      TERMINAL_EVENT_KEYS = %w[fixed last_affected limit].freeze
+      private_constant :RANGE_EVENT_KEYS, :TERMINAL_EVENT_KEYS
 
       # `annotated` is a list of `[formula, serialized_patches]` pairs. The
       # patches are passed in rather than read from the formula so callers can
@@ -84,10 +86,10 @@ module Homebrew
       # If a record already exists at `path`, carry forward its `published`
       # timestamp and `affected[].ranges` (so a terminal boundary does not
       # drift to today's `pkg_version`), and skip the write entirely when
-      # nothing else has changed. `close_open_ranges` lets the matcher append a
-      # newly discovered `fixed` event to an existing open range while
-      # preserving its reviewed introduction events. Records for annotations
-      # no longer in core are simply not visited, so they persist.
+      # nothing else has changed. `close_open_ranges` lets the matcher merge a
+      # newly discovered `fixed` or reintroduced event into an existing range
+      # while preserving its reviewed history. Records for annotations no
+      # longer in core are simply not visited, so they persist.
       sig {
         params(path: String, record: T::Hash[Symbol, T.untyped], close_open_ranges: T::Boolean)
           .returns(T.nilable(T::Hash[Symbol, T.untyped]))
@@ -102,12 +104,25 @@ module Homebrew
         if (existing_published = existing["published"] || existing["modified"])
           record[:published] = existing_published
         end
-        Array(record[:affected]).each_with_index do |affected, index|
+        affected_records = Array(record[:affected])
+        invalid_transition = affected_records.each_with_index.any? do |affected, index|
+          existing_ranges = existing.dig("affected", index, "ranges")
+          next false unless existing_ranges
+
+          close_open_ranges && (
+            ((fixed = explicit_fixed(affected[:ranges])) && !fixed_follows?(existing_ranges, fixed)) ||
+            ((introduced = explicit_reintroduction(affected[:ranges])) &&
+              !reintroduction_follows?(existing_ranges, introduced))
+          )
+        end
+        return if invalid_transition
+
+        affected_records.each_with_index do |affected, index|
           existing_ranges = existing.dig("affected", index, "ranges")
           next unless existing_ranges
 
           affected[:ranges] = if close_open_ranges
-            merge_open_ranges(existing_ranges, affected[:ranges])
+            merge_range_transitions(existing_ranges, affected[:ranges])
           else
             existing_ranges
           end
@@ -134,8 +149,81 @@ module Homebrew
         !!ranges.all? { |range| range_state(range) == :terminal }
       end
 
+      sig { params(ranges: T.untyped).returns(T::Boolean) }
+      def self.ranges_open?(ranges)
+        return false unless ranges.is_a?(Array)
+        return false if ranges.empty?
+
+        states = ranges.map { |range| range_state(range) }
+        states.exclude?(:invalid) && states.include?(:open)
+      end
+
+      # True when `fixed` can close every reviewed open Homebrew ecosystem
+      # range. Terminal ranges are unchanged; invalid ranges remain eligible
+      # for the existing repair path.
+      sig { params(ranges: T.untyped, fixed: String).returns(T::Boolean) }
+      def self.fixed_follows?(ranges, fixed)
+        fixed_version = PkgVersion.parse(fixed)
+        Array(ranges).all? do |range|
+          next true unless range.is_a?(Hash)
+          next true if (range["type"] || range[:type]) != "ECOSYSTEM"
+          next true if range_state(range) != :open
+
+          event = Array(range["events"] || range[:events]).rfind do |item|
+            item.is_a?(Hash) && (item.key?("introduced") || item.key?(:introduced))
+          end
+          introduced = event&.[]("introduced") || event&.[](:introduced)
+          introduced.is_a?(String) && fixed_version > PkgVersion.parse(introduced)
+        rescue ArgumentError
+          false
+        end
+      rescue ArgumentError
+        false
+      end
+
+      # True when `introduced` is compatible with every reviewed Homebrew
+      # ecosystem range. Open ranges are already affected and remain unchanged;
+      # terminal ranges must end before the new boundary. Other OSV range types
+      # (notably GIT commit ranges) are ignored.
+      sig { params(ranges: T.untyped, introduced: String).returns(T::Boolean) }
+      def self.reintroduction_follows?(ranges, introduced)
+        ecosystem_ranges = Array(ranges).select do |range|
+          range.is_a?(Hash) && (range["type"] || range[:type]) == "ECOSYSTEM"
+        end
+        return false if ecosystem_ranges.empty?
+
+        introduced_version = PkgVersion.parse(introduced)
+        ecosystem_ranges.all? do |range|
+          state = range_state(range)
+          next true if state == :open
+          next false if state != :terminal
+
+          terminal = terminal_event(range)
+          next false unless terminal
+
+          terminal_key = TERMINAL_EVENT_KEYS.find do |key|
+            terminal.key?(key) || terminal.key?(key.to_sym)
+          end
+          next false unless terminal_key
+
+          terminal_version = terminal[terminal_key] || terminal[terminal_key.to_sym]
+          next false unless terminal_version.is_a?(String)
+
+          terminal_version = PkgVersion.parse(terminal_version)
+          if terminal_key == "limit"
+            introduced_version >= terminal_version
+          else
+            introduced_version > terminal_version
+          end
+        rescue ArgumentError
+          false
+        end
+      rescue ArgumentError
+        false
+      end
+
       sig { params(existing_ranges: T.untyped, incoming_ranges: T.untyped).returns(T.untyped) }
-      def self.merge_open_ranges(existing_ranges, incoming_ranges)
+      def self.merge_range_transitions(existing_ranges, incoming_ranges)
         return incoming_ranges if !existing_ranges.is_a?(Array) || existing_ranges.empty?
 
         incoming_ranges = Array(incoming_ranges)
@@ -144,9 +232,19 @@ module Homebrew
             event.is_a?(Hash) && (event.key?(:fixed) || event.key?("fixed"))
           end
         end.first
-        return existing_ranges unless fixed
+        fixed_version = fixed&.[](:fixed) || fixed&.[]("fixed")
+        introduced = incoming_ranges.filter_map do |range|
+          Array(range[:events] || range["events"]).rfind do |event|
+            next false unless event.is_a?(Hash)
 
-        fixed_version = fixed[:fixed] || fixed["fixed"]
+            value = event[:introduced] || event["introduced"]
+            value && value != "0"
+          end
+        end.first
+        introduced_version = introduced&.[](:introduced) || introduced&.[]("introduced")
+        has_invalid = existing_ranges.any? { |range| range_state(range) == :invalid }
+        return existing_ranges if fixed_version.nil? && introduced_version.nil? && !has_invalid
+
         existing_ranges.map.with_index do |range, index|
           case range_state(range)
           when :invalid
@@ -160,13 +258,35 @@ module Homebrew
               replacement
             end
           when :open
-            range.merge("events" => [*range["events"], { "fixed" => fixed_version }])
+            next range unless fixed_version
+            next range if (range["type"] || range[:type]) != "ECOSYSTEM"
+
+            events = Array(range["events"])
+            last_event_index = events.rindex do |event|
+              event.is_a?(Hash) && RANGE_EVENT_KEYS.any? do |key|
+                event.key?(key) || event.key?(key.to_sym)
+              end
+            end
+            last_event = events[last_event_index] if last_event_index
+            if last_event && (last_event["limit"] || last_event[:limit]) == "*"
+              events = events.dup
+              events[last_event_index] = { "fixed" => fixed_version }
+            else
+              events << { "fixed" => fixed_version }
+            end
+            range.merge("events" => events)
+          when :terminal
+            next range unless introduced_version
+            next range if (range["type"] || range[:type]) != "ECOSYSTEM"
+
+            events = Array(range["events"])
+            range.merge("events" => [*events, { "introduced" => introduced_version }])
           else
             range
           end
         end
       end
-      private_class_method :merge_open_ranges
+      private_class_method :merge_range_transitions
 
       sig { params(range: T.untyped).returns(Symbol) }
       def self.range_state(range)
@@ -182,9 +302,49 @@ module Homebrew
         end
         return :invalid unless last
 
+        limit = last["limit"] || last[:limit]
+        return :open if limit == "*"
+
         (last.key?("introduced") || last.key?(:introduced)) ? :open : :terminal
       end
       private_class_method :range_state
+
+      sig { params(range: T.untyped).returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+      def self.terminal_event(range)
+        return unless range.is_a?(Hash)
+
+        Array(range["events"] || range[:events]).rfind do |event|
+          event.is_a?(Hash) && TERMINAL_EVENT_KEYS.any? do |key|
+            event.key?(key) || event.key?(key.to_sym)
+          end
+        end
+      end
+      private_class_method :terminal_event
+
+      sig { params(ranges: T.untyped).returns(T.nilable(String)) }
+      def self.explicit_reintroduction(ranges)
+        event = Array(ranges).filter_map do |range|
+          Array(range[:events] || range["events"]).rfind do |event|
+            next false unless event.is_a?(Hash)
+
+            value = event[:introduced] || event["introduced"]
+            value && value != "0"
+          end
+        end.first
+        event && (event[:introduced] || event["introduced"])
+      end
+      private_class_method :explicit_reintroduction
+
+      sig { params(ranges: T.untyped).returns(T.nilable(String)) }
+      def self.explicit_fixed(ranges)
+        event = Array(ranges).filter_map do |range|
+          Array(range[:events] || range["events"]).rfind do |item|
+            item.is_a?(Hash) && (item.key?(:fixed) || item.key?("fixed"))
+          end
+        end.first
+        event && (event[:fixed] || event["fixed"])
+      end
+      private_class_method :explicit_fixed
 
       sig {
         params(formula: Formula, vuln_id: String, patches: T::Array[T::Hash[String, T.untyped]],


### PR DESCRIPTION
`brew advisory-match --output` only wrote the canonical CVE record for a hit, leaving matched records filed under GHSA/PYSEC/other alias ids stale, and rewrote a reviewed terminal range as open when a vulnerability recurred.

The emitter now discovers alias families through existing `upstream` identifiers and updates the canonical record plus every `source: matched` alias, preserving each file's id, `published` timestamp, and reviewed ranges; `source: generated` records stay untouched. A reviewed terminal range that matches as affected again gets a history-verified `introduced` event appended. Malformed records, id/filename mismatches, overlapping families, and boundaries that do not follow reviewed ranges fail closed with a nonzero exit. Historical subjects are resolved by package identity, so upstream URL changes no longer suppress candidates as `:never_affected`. This keeps advisory-database records accurate when a vulnerability recurs or is known under several ids.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Fable 5) drafted the implementation and tests; I reviewed the diff and verified with `brew lgtm --online` plus targeted `dev-cmd/advisory-match`, `vulns/match`, and `vulns/osv_export` specs.

-----
