### PR TITLE
tap: normalise Codeberg remote forms

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -52,8 +52,8 @@ class Tap
   # Fetch a {Tap} by name.
   #
   # @api public
-  sig { params(user: String, repository: String).returns(Tap) }
-  def self.fetch(user, repository = T.unsafe(nil))
+  sig { params(user: String, repository: T.nilable(String)).returns(Tap) }
+  def self.fetch(user, repository = nil)
     user, repository = user.split("/", 2) if repository.nil?
 
     if [user, repository].any? { |part| part.nil? || part.include?("/") }
@@ -61,6 +61,7 @@ class Tap
     end
 
     user = T.must(user)
+    repository = T.must(repository)
 
     # We special case homebrew and linuxbrew so that users don't have to shift in a terminal.
     user = user.capitalize if ["homebrew", "linuxbrew"].include?(user)
@@ -141,8 +142,9 @@ class Tap
 
   # Hosts where a `.git` suffix and trailing slashes are known not to change which repository a
   # remote identifies, so we can safely strip them. We don't assume this for arbitrary hosts
-  # (including self-hosted GitLab and GitHub Enterprise) where `repo.git` and `repo` may differ.
-  NORMALIZE_REMOTE_HOSTS = %w[github.com gitlab.com].freeze
+  # (including self-hosted GitLab, Forgejo, and GitHub Enterprise) where `repo.git` and `repo`
+  # may differ.
+  NORMALIZE_REMOTE_HOSTS = %w[codeberg.org github.com gitlab.com].freeze
 
   # An optional RFC 3986-ish `scheme://` (e.g. `https://`, `ssh://` or `git+https://`) followed by
   # optional `user@` userinfo: the part of a remote URL that can precede the host.

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -212,9 +212,19 @@ RSpec.describe Tap do
                                           "https://gitlab.com/other/repo")).to be true
     end
 
+    it "ignores a `.git` suffix on Codeberg remotes" do
+      expect(described_class.same_remote?("https://codeberg.org/other/repo.git",
+                                          "https://codeberg.org/other/repo")).to be true
+    end
+
     it "ignores a trailing slash on GitLab remotes" do
       expect(described_class.same_remote?("https://gitlab.com/other/repo/",
                                           "https://gitlab.com/other/repo")).to be true
+    end
+
+    it "ignores a trailing slash on Codeberg remotes" do
+      expect(described_class.same_remote?("https://codeberg.org/other/repo/",
+                                          "https://codeberg.org/other/repo")).to be true
     end
 
     it "keeps a `.git` suffix and trailing slash significant on a self-hosted remote" do


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Adds Codeberg to the allowlist of remote hosts that can be normalised. Like `github.com` and `gitlab.com`, the `.git` suffix and trailing slashes never change which repository a `codeberg.org` URL identifies.