### PR TITLE
Break out GitHub Packages downloads per tag

### DIFF
--- a/Library/Homebrew/test/utils/analytics_spec.rb
+++ b/Library/Homebrew/test/utils/analytics_spec.rb
@@ -3,6 +3,7 @@
 
 require "utils/analytics"
 require "formula_installer"
+require "cmd/info"
 
 RSpec.describe Utils::Analytics do
   describe "::with_wsl_suffix_if_needed" do
@@ -314,5 +315,52 @@ RSpec.describe Utils::Analytics do
     expect { described_class.table_output("install", "30", results) }
       .to output(/110 |  100.00%/).to_stdout
       .and not_to_output.to_stderr
+  end
+
+  describe "::output_github_packages_downloads" do
+    let(:json) { { "analytics" => { "install" => { "30d" => { "wget" => 750_000, "wget --HEAD" => 500 } } } } }
+    let(:args) { Homebrew::Cmd::Info.new(["--github-packages-downloads", "wget"]).args }
+    let(:wget) { instance_double(Formula, name: "wget", core_formula?: true) }
+
+    def stub_github_packages_pages(downloads_by_tag)
+      index_html = <<~HTML
+        <a href="/orgs/Homebrew/packages/container/core%2Fwget/2?tag=1.25.0-2">1.25.0-2</a>
+        <a href="/orgs/Homebrew/packages/container/core%2Fwget/1?tag=1.25.0-1">1.25.0-1</a>
+      HTML
+      allow(Utils::Curl).to receive(:curl_output) do |*curl_args, **|
+        curl_args.each_cons(2) do |flag, path|
+          next if flag != "--output"
+
+          downloads = downloads_by_tag[File.basename(path, ".html")]
+          next if downloads.nil?
+
+          File.write(path, <<~HTML)
+            <span class="text-left color-fg-muted">Last 30 days</span>
+            <span class="flex-auto text-right text-bold">#{downloads}</span>
+          HTML
+        end
+        instance_double(SystemCommand::Result, success?: true, stdout: index_html)
+      end
+    end
+
+    it "outputs downloads per tag, a total and the difference from analytics install events" do
+      stub_github_packages_pages("1.25.0-2" => "1,000", "1.25.0-1" => "1.5M")
+
+      expect { described_class.output_github_packages_downloads(wget, json, args:) }
+        .to output(
+          match(/^1 +\| 1\.25\.0-1 +\| 1,500,000 \| +99\.93%$/)
+            .and(match(/^2 +\| 1\.25\.0-2 +\| +1,000 \| +0\.07%$/))
+            .and(match(/^Total +\| +\| 1,501,000 \| +100\.00%$/))
+            .and(include("Difference from 750,500 analytics install events (30 days): +100.00%")),
+        ).to_stdout
+    end
+
+    it "warns instead of outputting a partial total when a tag's downloads cannot be fetched" do
+      stub_github_packages_pages("1.25.0-2" => "1,000")
+
+      expect { described_class.output_github_packages_downloads(wget, json, args:) }
+        .to output(/Failed to fetch GitHub Packages downloads for: 1\.25\.0-1$/).to_stderr
+        .and not_to_output.to_stdout
+    end
   end
 end

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -294,48 +294,60 @@ module Utils
       # It relies on screen scraping some GitHub HTML that's not available as an API.
       # This seems very likely to break in the future.
       # That said, it's the only way to get the data we want right now.
-      sig { params(formula: Formula, args: Homebrew::Cmd::Info::Args).void }
-      def output_github_packages_downloads(formula, args:)
+      sig { params(formula: Formula, json: T::Hash[String, T.untyped], args: Homebrew::Cmd::Info::Args).void }
+      def output_github_packages_downloads(formula, json, args:)
         return unless args.github_packages_downloads?
         return unless formula.core_formula?
 
+        require "tmpdir"
         require "utils/curl"
 
         escaped_formula_name = GitHubPackages.image_formula_name(formula.name)
                                              .gsub("/", "%2F")
         formula_url_suffix = "container/core%2F#{escaped_formula_name}/"
         formula_url = "https://github.com/Homebrew/homebrew-core/pkgs/#{formula_url_suffix}"
-        output = Utils::Curl.curl_output("--fail", formula_url)
+        output = Utils::Curl.curl_output("--fail", "--compressed", formula_url)
         return unless output.success?
 
-        formula_version_urls = output.stdout
-                                     .scan(%r{/orgs/Homebrew/packages/#{formula_url_suffix}\d+\?tag=[^"]+})
-                                     .map do |url|
-          T.cast(url, String).sub("/orgs/Homebrew/packages/", "/Homebrew/homebrew-core/pkgs/")
-        end
-        return if formula_version_urls.empty?
+        tag_urls = output.stdout
+                         .scan(%r{/orgs/Homebrew/packages/#{formula_url_suffix}(\d+\?tag=([^"]+))})
+                         .to_h { |version, tag| [tag.to_s, "#{formula_url}#{version}"] }
+        return if tag_urls.empty?
 
-        thirty_day_download_count = 0
-        formula_version_urls.each do |formula_version_url_suffix|
-          formula_version_url = "https://github.com#{formula_version_url_suffix}"
-          output = Utils::Curl.curl_output("--fail", formula_version_url)
-          next unless output.success?
+        downloads_by_tag = Dir.mktmpdir("github-packages-downloads", HOMEBREW_TEMP) do |tmpdir|
+          Utils::Curl.curl_output("--fail", "--compressed", "--parallel",
+                                  *tag_urls.flat_map { |tag, url| ["--output", "#{tmpdir}/#{tag}.html", url] })
 
-          last_thirty_days_match = output.stdout.match(
-            %r{<span class="[\s\-a-z]*">Last 30 days</span>\s*<span class="[\s\-a-z]*">([\d.M,]+)</span>}m,
-          )
-          next if last_thirty_days_match.blank?
+          tag_urls.keys.filter_map do |tag|
+            version_html = Pathname("#{tmpdir}/#{tag}.html")
+            next unless version_html.exist?
 
-          last_thirty_days_downloads = last_thirty_days_match.captures.fetch(0).tr(",", "")
-          thirty_day_download_count += if (millions_match = last_thirty_days_downloads.match(/(\d+\.\d+)M/).presence)
-            (millions_match.captures.first.to_f * 1_000_000).to_i
-          else
-            last_thirty_days_downloads.to_i
+            downloads = version_html.read[%r{>Last 30 days</span>\s*<span[^>]*>([\d.,]+M?)<}, 1]
+            next if downloads.nil?
+
+            count = if downloads.end_with?("M")
+              (downloads.to_f * 1_000_000).to_i
+            else
+              downloads.tr(",", "").to_i
+            end
+            [tag, count]
           end
         end
+        missing_tags = tag_urls.keys - downloads_by_tag.map(&:first)
+        if missing_tags.any?
+          opoo "Failed to fetch GitHub Packages downloads for: #{missing_tags.join(", ")}"
+          return
+        end
 
-        ohai "GitHub Packages Downloads"
-        puts "#{Formatter.number_readable(thirty_day_download_count)} (30 days)"
+        table_output("github-packages-downloads", "30", downloads_by_tag.sort_by { |_, count| -count }.to_h,
+                     name_header: "Tag")
+
+        install_count = json.dig("analytics", "install", "30d")&.values&.sum
+        return unless install_count&.positive?
+
+        difference = ((downloads_by_tag.sum { |_, count| count } - install_count) * 100.0) / install_count
+        puts "Difference from #{format_count(install_count)} analytics install events (30 days): " \
+             "#{format("%+.2f", difference)}%"
       end
 
       sig { params(formula: Formula, args: Homebrew::Cmd::Info::Args).void }
@@ -350,7 +362,7 @@ module Utils
         return if json.blank? || json["analytics"].blank?
 
         output_analytics(json, args:)
-        output_github_packages_downloads(formula, args:)
+        output_github_packages_downloads(formula, json, args:)
       rescue ArgumentError
         # Ignore failed API requests
         nil
@@ -426,10 +438,10 @@ module Utils
       sig {
         params(
           category: String, days: String, results: T::Hash[String, Integer], os_version: T::Boolean,
-          cask_install: T::Boolean
+          cask_install: T::Boolean, name_header: T.nilable(String)
         ).void
       }
-      def table_output(category, days, results, os_version: false, cask_install: false)
+      def table_output(category, days, results, os_version: false, cask_install: false, name_header: nil)
         oh1 "#{category} (#{days} days)"
         total_count = results.values.sum
         formatted_total_count = format_count(total_count)
@@ -438,7 +450,9 @@ module Utils
         index_header = "Index"
         count_header = "Count"
         percent_header = "Percent"
-        name_with_options_header = if os_version
+        name_with_options_header = if name_header
+          name_header
+        elsif os_version
           "macOS Version"
         elsif cask_install
           "Token"


### PR DESCRIPTION
`brew info --github-packages-downloads` printed a single 30 day total. Show a table per GitHub Packages tag with a grand total instead, in the same `table_output` format as the other analytics tables, and add the signed percentage difference from the 30 day analytics `install` events so under-reporting is visible at a glance:

  ```
  ==> github-packages-downloads (30 days)
  Index | Tag      |  Count |  Percent
  -----:|----------|-------:|--------:
  1     | 1.25.0-2 | 99,129 |   99.26%
  2     | 1.25.0   |    427 |    0.43%
  3     | 1.25.0-1 |    263 |    0.26%
  4     | 1.24.5   |     32 |    0.03%
  5     | 1.25.0_1 |     15 |    0.02%
  Total |          | 99,866 |  100.00%
  Difference from 16,181 analytics install events (30 days): +517.18%
  ```

A per-platform (bottle tag, OS or architecture) breakdown is not possible from GitHub Packages. GitHub counts downloads per version, i.e. per manifest. Homebrew fetches the multi-arch index by version tag (`manifests/1.25.0-2`) and then the bottle blob by digest: blobs are not versions so they are never counted, and the per-platform child manifests only see a handful of lifetime downloads from tools like `docker` or `oras` (10-135 each versus ~100k per month on the tagged index above). Per-platform install data only exists in the Influx analytics `os` and `arch` tags.

- Fetch all tag pages with one `curl --parallel --compressed` call into a temporary directory instead of one uncompressed `curl` process per tag. Five pages take ~0.12s instead of ~2.2s (33KB versus 210KB each, over a single HTTP/2 connection); the regex parsing was never the cost.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude with Fable at Extra High effort, with local review and testing.

-----