### PR TITLE
Enable shorter-prefix bottle relocation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -550,9 +550,17 @@ jobs:
           - name: test-bot (Linux arm64)
             runs-on: ubuntu-24.04-arm
             container: ghcr.io/homebrew/ubuntu24.04:latest
+          - name: test-bot (Linux arm64, padded prefix)
+            runs-on: ubuntu-24.04-arm
+            container: ghcr.io/homebrew/ubuntu24.04:latest
+            prefix-constant: LINUX_ARM64_BOTTLE_PREFIX
           - name: test-bot (Linux x86_64)
             runs-on: ubuntu-latest
             container: ghcr.io/homebrew/ubuntu24.04:main
+          - name: test-bot (Linux x86_64, padded prefix)
+            runs-on: ubuntu-latest
+            container: ghcr.io/homebrew/ubuntu24.04:main
+            prefix-constant: LINUX_X86_64_BOTTLE_PREFIX
           - name: test-bot (no Sorbet)
             runs-on: ubuntu-latest
             container: ghcr.io/homebrew/ubuntu24.04:main
@@ -566,6 +574,9 @@ jobs:
             runs-on: macos-15-intel
           - name: test-bot (macOS arm64)
             runs-on: macos-26
+          - name: test-bot (macOS arm64, padded prefix)
+            runs-on: macos-26
+            prefix-constant: MACOS_ARM64_BOTTLE_PREFIX
     env:
       HOMEBREW_TEST_BOT_ANALYTICS: 1
     steps:
@@ -611,6 +622,18 @@ jobs:
           core: true
           cask: false
 
+      - name: Set up padded bottle prefix
+        if: matrix.prefix-constant
+        env:
+          PREFIX_CONSTANT: ${{ matrix.prefix-constant }}
+        run: |
+          padded_prefix="$(brew ruby -- -e 'puts Homebrew.const_get(ARGV.fetch(0))' "${PREFIX_CONSTANT}")"
+          test "${#padded_prefix}" -eq 64
+          mkdir -p "${padded_prefix}/bin"
+          ln -s "$(brew --repository)/bin/brew" "${padded_prefix}/bin/brew"
+          test "$("${padded_prefix}/bin/brew" --prefix)" = "${padded_prefix}"
+          echo "${padded_prefix}/bin" >> "${GITHUB_PATH}"
+
       - run: brew install gnu-tar
 
       - name: Disable Sorbet runtime
@@ -628,6 +651,8 @@ jobs:
       - run: brew test-bot --only-cleanup-before
 
       - run: brew test-bot --only-setup
+        env:
+          HOMEBREW_TEST_BOT_IGNORE_DOCTOR_FAILURE: ${{ matrix.prefix-constant && '1' || null }}
 
       - run: brew test-bot --only-formulae --only-json-tab --test-default-formula
 

--- a/Library/Homebrew/bottle_specification.rb
+++ b/Library/Homebrew/bottle_specification.rb
@@ -94,7 +94,7 @@ class BottleSpecification
     prefix = Pathname(cellar.to_s).parent.to_s
 
     # Raw prefix strings are patched in place, so the byte length decides.
-    relocatable = padded_prefix || Homebrew::EnvConfig.relocate_build_prefix?
+    relocatable = !Homebrew::EnvConfig.no_relocate_build_prefix?
     cellar_relocatable = relocatable && cellar.to_s.bytesize >= HOMEBREW_CELLAR.to_s.bytesize
     prefix_relocatable = relocatable && prefix.bytesize >= HOMEBREW_PREFIX.to_s.bytesize
 

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -538,6 +538,7 @@ module Homebrew
 
             tab = keg.tab
             original_tab = tab.dup
+            tab.built_prefix = prefix if tab.built_prefix
             tab.poured_from_bottle = false
             tab.time = nil
             tab.changed_files = changed_files&.dup

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -612,6 +612,11 @@ module Homebrew
                      "shadowed by other commands earlier on `$PATH`.",
         boolean:     true,
       },
+      HOMEBREW_NO_RELOCATE_BUILD_PREFIX:         {
+        description: "If set, do not relocate bottles built for a different prefix at install time. " \
+                     "Homebrew will build from source instead.",
+        boolean:     true,
+      },
       HOMEBREW_NO_REQUIRE_TAP_TRUST:             {
         # odeprecated: remove in a later release after tap trust checks are the default.
         description: "If set, do not require non-official tap formulae, casks or commands to be trusted. " \
@@ -657,12 +662,6 @@ module Homebrew
         boolean:     true,
         odeprecated: true,
         replacement: "the default IRB backend (Pry is largely unmaintained upstream)",
-      },
-      HOMEBREW_RELOCATE_BUILD_PREFIX:            {
-        description: "If set, pour bottles built for a longer prefix and patch the build prefix into their " \
-                     "binaries at install time.",
-        boolean:     true,
-        hidden:      true,
       },
       HOMEBREW_REQUIRE_TAP_TRUST:                {
         # odeprecated: make tap trust checks default in a later release.

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -282,16 +282,11 @@ class FormulaInstaller
       if output_warning
         cellar = bottle.built_cellar.to_s
         prefix = Pathname(cellar).parent
-        # Raw prefix strings can only be replaced in place by an equal-or-shorter
-        # byte string, so the byte length difference is the fact that matters.
-        excess = [HOMEBREW_PREFIX.to_s.bytesize - prefix.to_s.bytesize,
-                  HOMEBREW_CELLAR.to_s.bytesize - cellar.bytesize].max
-        cause = if excess.positive?
-          "Your prefix is #{excess} bytes longer than the bottle's build prefix."
-        elsif excess.negative?
-          "Your prefix is #{-excess} bytes shorter than the bottle's build prefix."
+        cause = if Homebrew::EnvConfig.no_relocate_build_prefix?
+          "`HOMEBREW_NO_RELOCATE_BUILD_PREFIX` disables bottle build-prefix relocation."
         else
-          "Your prefix is the same length as the bottle's build prefix."
+          "Your prefix `#{HOMEBREW_PREFIX}` is #{HOMEBREW_PREFIX.to_s.length} characters long, but this bottle " \
+            "can only be relocated to a prefix with a maximum length of #{prefix.to_s.length} characters."
         end
         opoo <<~EOS
           Building #{formula.full_name} from source as the bottle needs:
@@ -1748,7 +1743,7 @@ on_request: installed_on_request?, options:)
     build_cellar = tab.built_prefix ? "#{prefix}/Cellar" : cellar.to_s
     return if build_cellar == HOMEBREW_CELLAR.to_s && prefix == HOMEBREW_PREFIX.to_s
 
-    return if !tab.padded_prefix && !Homebrew::EnvConfig.relocate_build_prefix?
+    return if Homebrew::EnvConfig.no_relocate_build_prefix?
 
     tab.relocated_build_prefix = prefix
     tab.relocated_files = keg.relocate_build_prefix(keg, prefix, HOMEBREW_PREFIX,

--- a/Library/Homebrew/plans/relocatable-bottles.md
+++ b/Library/Homebrew/plans/relocatable-bottles.md
@@ -16,7 +16,8 @@ Every Homebrew/core bottle pours at every prefix under 65 characters long.
   performance helps everyone on every prefix, making more bottles
   relocatable helps every custom prefix at any length, pour-time patching
   helps short custom prefixes, and the 64-byte migration extends that to
-  long ones. Phases run sequentially, not in parallel.
+  long ones. Phases run sequentially, not in parallel, with a multi-month
+  user soak before catalogue-wide padded builds begin.
 
 This is a living document: edit or remove steps as they are implemented so
 it always describes the remaining work.
@@ -94,12 +95,12 @@ Raw C strings are the only length-limited content at pour time:
 `Keg#relocate_build_prefix` (`keg_relocate.rb`) implements that NUL-padded
 patching and re-signs patched Mach-O files, and
 `BottleSpecification#compatible_locations?` allows pouring a pinned bottle
-into an equal-or-shorter prefix, both gated behind the undocumented
-`HOMEBREW_RELOCATE_BUILD_PREFIX` environment variable. History: added
-default-on in #12534 (December 2021), reverted twice, then gated behind the
-variable in #13217 after #13209 reported hard install failures at a prefix
-longer than the bottled one. It is referenced nowhere in homebrew/core,
-homebrew-test-bot, homebrew/actions or homebrew/install today.
+into an equal-or-shorter prefix by default. The documented
+`HOMEBREW_NO_RELOCATE_BUILD_PREFIX` variable disables this. History:
+default-on was added in #12534 (December 2021), reverted twice, then gated
+behind a positive variable in #13217 after #13209 reported hard failures at
+a prefix longer than the bottled one. The length check now prevents that
+case and the positive variable was removed when default-on was restored.
 
 Prior art: conda-forge builds packages under a long placeholder prefix (up
 to 255 characters) and rewrites it at install time, including NUL-padded
@@ -171,13 +172,12 @@ Replaying the exact `keg_contain?` logic over the contents of 17 pinned and
    number (64) once migration completes; until then the interim rule is
    prefix length up to the bottled default (13 for arm64 macOS, 26 for
    Linux).
-8. Relocation-by-patching defaults on only when the whole catalogue is
-   64-built on the target platforms.
-9. `HOMEBREW_RELOCATE_BUILD_PREFIX` is added to `env_config.rb` with
-   `hidden: true` until the feature is hardened and diagnosable, and is
-   ultimately retired in favour of a `HOMEBREW_NO_RELOCATE_BUILD_PREFIX`
-   escape hatch. Until it is unhidden and considered stable no
-   user-facing message mentions it.
+8. Relocation-by-patching defaults on for equal-or-shorter prefixes. This
+   initially means up to 13 bytes on arm64 macOS and 26 on Linux. Only after
+   a multi-month soak and the padded catalogue migration does the default
+   contract expand to 64 bytes.
+9. `HOMEBREW_NO_RELOCATE_BUILD_PREFIX` is the documented escape hatch,
+   retained through the soak and padded migration.
 10. Non-intuitive logic must always be commented, especially relocation edge
     cases (NUL padding, string-table subtleties, codesign behaviour): this
     code is touched rarely and debugged under pressure.
@@ -202,7 +202,8 @@ Replaying the exact `keg_contain?` logic over the contents of 17 pinned and
 Each pinned bottle flipped to `cellar :any` pours at any prefix with no
 length limit and no new machinery.
 
-4. Reconcile checker divergences: resolved. The `abseil` class was pinned
+4. **Completed August 2026.**
+   Reconcile checker divergences: resolved. The `abseil` class was pinned
    by `file_linked_libraries` resolving `@rpath`/`@loader_path` load
    commands against the live keg at bottle time, turning relocatable
    linkage into absolute build-prefix paths; the checker now reads raw
@@ -218,24 +219,45 @@ length limit and no new machinery.
 7. Data-driven ignore extensions where blocker diagnostics show a class is
    functionally dead.
 
-### Phase 2: pour-time patching for pinned bottles (helps short custom prefixes)
+### Phase 2: pour-time patching for pinned bottles (completed August 2026)
 
-Whole dependency closures become pourable at prefixes up to the bottled
-default length (13 bytes arm64 macOS, 26 Linux), covering the hub formulae
+Whole dependency closures now pour at prefixes up to the bottled default
+length (13 bytes arm64 macOS, 26 Linux), covering the hub formulae
 (`openssl@3`, `gettext`, `glib`, `python@3.x`) that Phase 1 cannot.
+Relocation is the default for equal-or-shorter prefixes and
+`HOMEBREW_NO_RELOCATE_BUILD_PREFIX` provides a documented escape hatch.
+This exercises the already-published catalogue across more real custom
+prefixes before Homebrew commits to padded production builds.
 
-All homebrew/brew code and individual-formula fixes (the brew side of
+During a soak of at least a few months, Homebrew/brew CI pairs its existing
+default-prefix test-bot jobs with padded-prefix jobs on x86_64 Linux, arm64
+Linux and arm64 macOS. Both variants run the same source-build, bottle,
+reinstall, linkage and formula-test workflow; the padded jobs neither
+publish nor upload their bottles.
+
+All remaining homebrew/brew and individual-formula fixes (the brew side of
 Phase 3, the upstream hub track and the Completeness items) come before
-anything that touches homebrew/core CI or runs at catalogue scale: shadow
-builds, test-bot changes, infra cutover, sweeps and validation runs.
+anything that touches homebrew/core CI or runs at catalogue scale.
 
 ### Phase 3: migrate bottling to the 64-byte prefix (extends to long prefixes)
 
-13. Shadow builds: build a pinned plus path-length-sensitive sample at
-    the candidate 64-byte prefixes on all three target platforms.
-15. test-bot: build and test at the padded prefix; relocated-pour smoke test
-    for changed formulae (pour the fresh bottle into a scratch short
-    prefix), Linux first.
+**Client foundations completed August 2026:** canonical 64-byte prefixes
+exist, padded eligibility remains in tab or manifest metadata only and bottle
+selection uses that manifest data. Begin the production steps below only
+after Phase 2 has soaked for at least a few months.
+
+13. Extend the paired test-bot jobs to cover a pinned plus
+    path-length-sensitive sample and representative pinned dependency
+    closures at the candidate 64-byte prefixes on all three target platforms.
+15. test-bot: build changed formulae at the padded prefix, pour each fresh
+    bottle into a scratch short prefix, then run `brew linkage --test` and
+    `brew test`.
+Before cutover, version-gate symbolic cellar and `padded_prefix` metadata
+consumers, release supporting clients and ensure the marker remains
+per-platform rather than merging into `:all`. Resolve socket, shebang and
+build-path failures, audit scanner blind spots, decide the glibc strategy and
+retire or justify `pour_bottle? only_if: :default_prefix` gates.
+
 16. Infra cutover in order: x86_64 Linux runners first (no SIP, biggest
     pinned share), arm64 Linux second, arm64 macOS third.
 
@@ -260,13 +282,12 @@ builds, test-bot changes, infra cutover, sweeps and validation runs.
     this is the functional catch-all for scanner blind spots. Not before:
     it is a mass run whose results change with every rebottle.
 
-### Phase 5: default on
+### Phase 5: extend the default to 64 bytes
 
 20. Only when the catalogue is fully 64-built on the target platforms:
-    relocation-by-patching becomes the default for every prefix up to 64
-    bytes; the hidden variable is retired for
-    `HOMEBREW_NO_RELOCATE_BUILD_PREFIX`; `docs/Bottles.md`,
-    `docs/Installation.md` and homebrew/install messaging state the single
+    relocation-by-patching expands to every prefix up to 64 bytes; retain
+    `HOMEBREW_NO_RELOCATE_BUILD_PREFIX`; update `docs/Bottles.md`,
+    `docs/Installation.md` and homebrew/install messaging with the single
     global contract.
 
 ### Upstream fixes for the hubs

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
@@ -389,6 +389,9 @@ module Homebrew::EnvConfig
     def no_proxy; end
 
     sig { returns(T::Boolean) }
+    def no_relocate_build_prefix?; end
+
+    sig { returns(T::Boolean) }
     def no_require_tap_trust?; end
 
     sig { returns(T::Boolean) }
@@ -414,9 +417,6 @@ module Homebrew::EnvConfig
 
     sig { returns(T::Boolean) }
     def pry?; end
-
-    sig { returns(T::Boolean) }
-    def relocate_build_prefix?; end
 
     sig { returns(T::Boolean) }
     def require_tap_trust?; end

--- a/Library/Homebrew/test/bottle_specification_spec.rb
+++ b/Library/Homebrew/test/bottle_specification_spec.rb
@@ -46,14 +46,20 @@ RSpec.describe BottleSpecification do
       expect(bottle_spec.compatible_locations?).to be false
     end
 
-    it "accepts a longer bottle cellar when build prefix relocation is enabled" do
-      ENV["HOMEBREW_RELOCATE_BUILD_PREFIX"] = "1"
+    it "accepts a longer bottle cellar by default" do
       bottle_spec.sha256(cellar: "#{HOMEBREW_CELLAR}-longer", Utils::Bottles.tag.to_sym => "deadbeef" * 8)
 
       expect(bottle_spec.compatible_locations?).to be true
     end
 
-    it "accepts a padded bottle from tab metadata without build prefix relocation being enabled" do
+    it "rejects a longer bottle cellar when build prefix relocation is disabled" do
+      ENV["HOMEBREW_NO_RELOCATE_BUILD_PREFIX"] = "1"
+      bottle_spec.sha256(cellar: "#{HOMEBREW_CELLAR}-longer", Utils::Bottles.tag.to_sym => "deadbeef" * 8)
+
+      expect(bottle_spec.compatible_locations?).to be false
+    end
+
+    it "accepts a padded bottle from tab metadata" do
       tag = Utils::Bottles::Tag.from_symbol(:arm64_tahoe)
       bottle_spec.sha256(tag.to_sym => "deadbeef" * 8)
       stub_const("HOMEBREW_PREFIX", Pathname("/short"))

--- a/Library/Homebrew/test/dev-cmd/bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bottle_spec.rb
@@ -63,7 +63,8 @@ RSpec.describe Homebrew::DevCmd::Bottle do
   end
 
   it "builds a bottle for the given Formula", :integration_test do
-    setup_test_formula "testball", tab_attributes: { built_as_bottle: true }
+    setup_test_formula "testball",
+                       tab_attributes: { built_as_bottle: true, built_prefix: Keg::PREFIX_PLACEHOLDER }
     formula = Formula["testball"]
 
     # `brew bottle` should not fail with dead symlink
@@ -89,6 +90,7 @@ RSpec.describe Homebrew::DevCmd::Bottle do
         "changed_files"           => be_an(Array),
         "linkage_files"           => be_an(Array),
         "binary_relocation_files" => include("libexec/raw-prefix"),
+        "built_prefix"            => HOMEBREW_PREFIX.to_s,
       )
       binary_relocation_diagnostics = tag.fetch("binary_relocation_diagnostics")
       expect(binary_relocation_diagnostics.size).to eq(Homebrew::DevCmd::Bottle::MAXIMUM_STRING_MATCHES)

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -412,6 +412,17 @@ RSpec.describe FormulaInstaller do
         installer.pour
       end
     end
+
+    context "with a legacy bottle from a longer prefix" do
+      let(:bottle_cellar) { "#{HOMEBREW_PREFIX}-longer/Cellar" }
+
+      it "patches the build prefix by default" do
+        prefix = Pathname(bottle_cellar).parent.to_s
+        expect(keg).to receive(:relocate_build_prefix).with(keg, prefix, HOMEBREW_PREFIX, files: nil).and_return([])
+
+        installer.pour
+      end
+    end
   end
 
   describe "#pour_bottle? with a bottle built for another prefix" do
@@ -428,16 +439,28 @@ RSpec.describe FormulaInstaller do
       Class.new(described_class).new(f)
     end
 
-    it "states how much longer the prefix is than the bottle's" do
+    it "states when the prefix is too long to relocate the bottle" do
       installer = installer_for_cellar("/short/Cellar")
+      prefix = HOMEBREW_PREFIX.to_s
+      message = "Your prefix `#{prefix}` is #{prefix.length} characters long, but this bottle can only be " \
+                "relocated to a prefix with a maximum length of 6 characters."
 
-      expect { installer.pour_bottle?(output_warning: true) }.to output(/bytes longer than/).to_stderr
+      expect { installer.pour_bottle?(output_warning: true) }
+        .to output(satisfy { |stderr| stderr.include?(message) && stderr.exclude?("bytes") }).to_stderr
     end
 
-    it "states how much shorter the prefix is than the bottle's" do
+    it "pours a bottle built for a longer prefix by default" do
       installer = installer_for_cellar("#{HOMEBREW_PREFIX}-longer/Cellar")
 
-      expect { installer.pour_bottle?(output_warning: true) }.to output(/7 bytes shorter than/).to_stderr
+      expect(installer.pour_bottle?(output_warning: true)).to be true
+    end
+
+    it "states when build prefix relocation is disabled" do
+      ENV["HOMEBREW_NO_RELOCATE_BUILD_PREFIX"] = "1"
+      installer = installer_for_cellar("#{HOMEBREW_PREFIX}-longer/Cellar")
+
+      expect { installer.pour_bottle?(output_warning: true) }
+        .to output(/HOMEBREW_NO_RELOCATE_BUILD_PREFIX/).to_stderr
     end
   end
 

--- a/Library/Homebrew/test/test_bot/formulae_spec.rb
+++ b/Library/Homebrew/test/test_bot/formulae_spec.rb
@@ -27,6 +27,35 @@ RSpec.describe Homebrew::TestBot::Formulae do
     end
   end
 
+  describe "#install_padded_prefix_source_dependencies" do
+    it "installs dependencies without compatible bottles at a padded prefix" do
+      Dir.mktmpdir do |tmpdir|
+        formulae = described_class.new(
+          tap: nil, git: "git", dry_run: true, fail_fast: false, verbose: false,
+          output_paths: {
+            bottle:                     Pathname.new("#{tmpdir}/bottle.txt"),
+            linkage:                    Pathname.new("#{tmpdir}/linkage.txt"),
+            skipped_or_failed_formulae: Pathname.new("#{tmpdir}/skipped.txt"),
+          }
+        )
+        compatible = instance_double(Formula, bottle: instance_double(Bottle))
+        incompatible = instance_double(Formula, bottle: nil)
+        allow(Formulary).to receive(:factory).with("compatible").and_return(compatible)
+        allow(Formulary).to receive(:factory).with("incompatible").and_return(incompatible)
+        padded_prefix = Utils::Bottles.tag.padded_prefix
+        raise "Current tag has no padded prefix" if padded_prefix.nil?
+
+        stub_const("HOMEBREW_PREFIX", Pathname(padded_prefix))
+
+        formulae.install_padded_prefix_source_dependencies(%w[compatible incompatible])
+
+        expect(formulae.steps.map(&:command)).to eq [
+          %w[brew install --formulae --build-from-source incompatible],
+        ]
+      end
+    end
+  end
+
   describe "#annotate_added_dependencies" do
     it "writes a warning annotation for the new recursive dependency impact" do
       formula = formula("foo") do

--- a/Library/Homebrew/test/test_bot/setup_spec.rb
+++ b/Library/Homebrew/test/test_bot/setup_spec.rb
@@ -14,5 +14,20 @@ RSpec.describe Homebrew::TestBot::Setup do
 
       expect(setup.run!(args: instance_double(Homebrew::Cmd::TestBotCmd::Args)).passed?).to be(true)
     end
+
+    it "only ignores a doctor failure when requested" do
+      ignore_doctor_failures = []
+      step = instance_double(Homebrew::TestBot::Step, passed?: true)
+      allow(setup).to receive(:test) do |*arguments, **options|
+        ignore_doctor_failures << options[:ignore_failures] if arguments == %w[brew doctor]
+        step
+      end
+
+      setup.run!(args: instance_double(Homebrew::Cmd::TestBotCmd::Args))
+      ENV["HOMEBREW_TEST_BOT_IGNORE_DOCTOR_FAILURE"] = "1"
+      setup.run!(args: instance_double(Homebrew::Cmd::TestBotCmd::Args))
+
+      expect(ignore_doctor_failures).to eq [false, true]
+    end
   end
 end

--- a/Library/Homebrew/test_bot/formulae.rb
+++ b/Library/Homebrew/test_bot/formulae.rb
@@ -113,6 +113,17 @@ module Homebrew
         formula.install_etc_var
       end
 
+      sig { params(dependencies: T::Array[String]).void }
+      def install_padded_prefix_source_dependencies(dependencies)
+        return if HOMEBREW_PREFIX.to_s != Utils::Bottles.tag.padded_prefix
+
+        source_dependencies = dependencies.select { |dependency| Formulary.factory(dependency).bottle.nil? }
+        return if source_dependencies.empty?
+
+        test "brew", "install", "--formulae", "--build-from-source",
+             named_args: source_dependencies
+      end
+
       sig { returns(T::Boolean) }
       def verify_local_bottles
         # Portable Ruby bottles are handled differently.
@@ -395,6 +406,7 @@ module Homebrew
         unless @unchanged_dependencies.empty?
           test "brew", "fetch", "--formulae", "--retry",
                *@unchanged_dependencies
+          install_padded_prefix_source_dependencies(@unchanged_dependencies)
         end
 
         changed_dependencies = dependencies - @unchanged_dependencies

--- a/Library/Homebrew/test_bot/setup.rb
+++ b/Library/Homebrew/test_bot/setup.rb
@@ -13,10 +13,11 @@ module Homebrew
         # Always output `brew config` output even when it doesn't fail.
         test "brew", "config", verbose: true
 
+        ignore_doctor_failure = ENV["HOMEBREW_TEST_BOT_IGNORE_DOCTOR_FAILURE"].present?
         if ENV["HOMEBREW_TEST_BOT_VERBOSE_DOCTOR"]
-          test "brew", "doctor", "--debug", verbose: true
+          test "brew", "doctor", "--debug", verbose: true, ignore_failures: ignore_doctor_failure
         else
-          test "brew", "doctor"
+          test "brew", "doctor", ignore_failures: ignore_doctor_failure
         end
       end
     end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -4985,6 +4985,11 @@ command execution (e.g. `$(cat file)`).
 : If set, `brew info` and `brew install` will not warn when a formula's
   executables are shadowed by other commands earlier on `$PATH`.
 
+`HOMEBREW_NO_RELOCATE_BUILD_PREFIX`
+
+: If set, do not relocate bottles built for a different prefix at install time.
+  Homebrew will build from source instead.
+
 `HOMEBREW_NO_REQUIRE_TAP_TRUST`
 
 : If set, do not require non-official tap formulae, casks or commands to be

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -3222,6 +3222,9 @@ If set, \fBbrew install\fP \fIformula|cask\fP will not upgrade \fIformula|cask\f
 \fBHOMEBREW_NO_PATH_SHADOW_CHECK\fP
 If set, \fBbrew info\fP and \fBbrew install\fP will not warn when a formula\[u2019]s executables are shadowed by other commands earlier on \fB$PATH\fP\&\.
 .TP
+\fBHOMEBREW_NO_RELOCATE_BUILD_PREFIX\fP
+If set, do not relocate bottles built for a different prefix at install time\. Homebrew will build from source instead\.
+.TP
 \fBHOMEBREW_NO_REQUIRE_TAP_TRUST\fP
 If set, do not require non\-official tap formulae, casks or commands to be trusted\. This is not recommended and will be removed in a later release\. Also enables commands that evaluate all formulae and casks\.
 .TP


### PR DESCRIPTION
- Pour and patch pinned bottles by default at equal-or-shorter prefixes.
- Document the negative escape hatch and report the actual prefix, current character count and maximum supported length on fallback.
- Pair existing arm64 macOS, arm64 Linux and x86_64 Linux test-bot jobs with padded-prefix variants that do not upload bottles.
- Keep catalogue-wide padded builds behind a multi-month soak and record the blockers that must be resolved before that migration.

This change is part of [`plans/relocatable-bottles.md`](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/plans/relocatable-bottles.md)

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Codex with GPT 5.6-sol at Extra High effort, with local review and testing.

-----