### PR TITLE
test/spec_helper: skip missing test tools under brew test-bot

### DIFF
--- a/Library/Homebrew/test/dev-cmd/tests_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tests_spec.rb
@@ -119,9 +119,18 @@ RSpec.describe Homebrew::DevCmd::Tests do
 
     it "fails when a dependency is missing on CI" do
       ENV["CI"] = "1"
+      ENV.delete("HOMEBREW_TEST_BOT")
 
       expect { ensure_test_dependency!(false, "Dependency is not installed.") }
         .to raise_error(RuntimeError, "Dependency is not installed.")
+    end
+
+    it "skips when a dependency is missing under `brew test-bot`" do
+      ENV["CI"] = "1"
+      ENV["HOMEBREW_TEST_BOT"] = "1"
+
+      expect(self).to receive(:skip).with("Dependency is not installed.")
+      ensure_test_dependency!(false, "Dependency is not installed.")
     end
   end
 

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -78,11 +78,13 @@ module Test
       requires_ancestor { RSpec::Core::Pending }
 
       # Skip missing tools locally, but fail on CI so runner dependency
-      # regressions cannot silently reduce coverage.
+      # regressions cannot silently reduce coverage. `brew test-bot`'s
+      # portable-ruby validation runs this suite in homebrew-core build
+      # containers that intentionally lack some tools, so skip there too.
       def ensure_test_dependency!(available, message)
         return if available
 
-        raise message if ENV["CI"]
+        raise message if ENV["CI"] && !ENV["HOMEBREW_TEST_BOT"]
 
         skip message
       end


### PR DESCRIPTION
c261086b58 made `ensure_test_dependency!` raise on CI when a test tool is missing, so runner dependency regressions cannot silently reduce coverage. `brew test-bot`'s portable-ruby validation runs the same suite inside homebrew-core's Linux build containers, which intentionally lack systemd and Python, so the first portable-ruby rebuild since then (Homebrew/homebrew-core#301326) failed on Linux with "No LaunchCTL or SystemD found." and "Python is not installed." and fail-fast cancelled the remaining legs.

Skip instead of raising when `HOMEBREW_TEST_BOT` is set: `brew test-bot` exports it for its whole process tree and its portable-ruby validation is the only path that runs this suite, while Homebrew/brew CI invokes `brew tests` directly, so coverage enforcement there is unchanged. Once this lands, rerunning the homebrew-core job picks it up with no further changes.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Fable 5) diagnosed the CI failure from the run logs and drafted the fix; I reviewed the diff and ran the checks under both env combinations.

-----
