### PR TITLE
extend/pathname: one lstat per entry in compute_disk_usage

### DIFF
--- a/Library/Homebrew/extend/pathname/disk_usage_extension.rb
+++ b/Library/Homebrew/extend/pathname/disk_usage_extension.rb
@@ -55,12 +55,12 @@ module DiskUsageExtension
       file_count = 0
       disk_usage = 0
       path.find do |f|
-        if f.directory?
-          disk_usage += f.lstat.size
+        # use Pathname#lstat instead of Pathname#stat to get info of symlink itself.
+        stat = f.lstat
+        if stat.directory? || (stat.symlink? && f.directory?)
+          disk_usage += stat.size
         else
-          file_count += 1 if f.basename.to_s != ".DS_Store"
-          # use Pathname#lstat instead of Pathname#stat to get info of symlink itself.
-          stat = f.lstat
+          file_count += 1 if File.basename(f.to_s) != ".DS_Store"
           file_id = [stat.dev, stat.ino]
           # count hardlinks only once.
           unless scanned_files.include?(file_id)

--- a/Library/Homebrew/test/pathname_spec.rb
+++ b/Library/Homebrew/test/pathname_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Pathname do
       touch [dir/".DS_Store", dir/"a-file"]
       File.truncate(dir/"a-file", 1_048_576)
       ln_s dir/"a-file", dir/"a-symlink"
+      ln_s dir/"a-directory", dir/"a-directory-symlink"
       ln dir/"a-file", dir/"a-hardlink"
     end
 


### PR DESCRIPTION
`Find.find` already `lstats` every entry; the block then called `Pathname#directory?` (a second `stat`, following symlinks) and `Pathname#lstat` again, plus a `Pathname` allocation for the `basename`. Take one stat and branch on it instead.

Should reduce syscalls by 1/3 and save ~20% on operations.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Fable 5 with review.

-----

Performance details below

<details>

| tree | entries | before | after | speedup |
|---|---|---|---|---|
| synthetic (see below) | 57,221 | 1.058 s ± 0.034 s | 834.3 ms ± 16.4 ms | **1.27× ± 0.05** |
| `Cellar/ruby/4.0.6_1` | 22,069 | 457.2 ms ± 19.4 ms | 383.4 ms ± 19.6 ms | **1.19× ± 0.08** |
| `Cellar/texlive/20260301` | 202,459 | 3.424 s ± 0.127 s | 2.841 s ± 0.119 s | **1.21× ± 0.07** |

Most of the win is system time, as expected for a syscall reduction — on the
synthetic tree 0.671 s → 0.492 s sys, 0.374 s → 0.326 s user.

### Where it comes from

`Find` already `lstat`s every entry to decide whether to recurse. The old block
then called `Pathname#directory?` (a `stat(2)`, following symlinks) and
`Pathname#lstat` (another `lstat(2)`) on the same path — three stat syscalls per
entry. Taking one `Stat` and branching on it leaves two:

| | before | after |
|---|---|---|
| `Find` internal `lstat(2)` | 57,221 | 57,221 |
| `Pathname#lstat` → `lstat(2)` | 57,221 | 57,221 |
| `Pathname#directory?` → `stat(2)` | 57,221 | 3 |
| **total** | **171,663** | **114,445** (−33.3%) |

</details>