### PR TITLE
search: use String#delete instead of gsub for simplify_string

### DIFF
--- a/Library/Homebrew/search.rb
+++ b/Library/Homebrew/search.rb
@@ -233,7 +233,7 @@ module Homebrew
 
     sig { params(string: String).returns(String) }
     def self.simplify_string(string)
-      string.downcase.gsub(/[^a-z\d@+]/i, "")
+      string.downcase.delete("^a-z0-9@+")
     end
 
     sig { params(selectable: SelectableType, regex: Regexp, _block: SearchBlockType).returns(SearchResultType) }


### PR DESCRIPTION
`String#delete` with a negated character set does the same character-class filtering as the regexp substitution, without compiling and running a regexp on every candidate name.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Fable 5 with review.

-----

Small perf gain in terms of timing, roughly 55ms -> 19ms

`hyperfine --warmup 5 -L v old,new --setup 'cp {v}.rb Library/Homebrew/search.rb'`

| Command | before | after | speedup |
|---|---|---|---|
| `brew search --desc wget` (20 runs) | 543.6 ms ± 30.7 | 500.8 ms ± 16.4 | 1.09 ± 0.07× |
| `brew desc --search wget` (30 runs) | 557.6 ms ± 51.7 | 510.7 ms ± 15.1 | 1.09 ± 0.11× |