### PR TITLE
utils/tty: memoise a failed stty size

### DIFF
--- a/Library/Homebrew/test/utils/tty_spec.rb
+++ b/Library/Homebrew/test/utils/tty_spec.rb
@@ -40,6 +40,24 @@ RSpec.describe Tty do
     end
   end
 
+  describe "::size" do
+    before do
+      described_class.remove_instance_variable(:@size) if described_class.instance_variable_defined?(:@size)
+    end
+
+    after do
+      described_class.remove_instance_variable(:@size) if described_class.instance_variable_defined?(:@size)
+    end
+
+    it "memoises a failed `stty size` probe instead of respawning it" do
+      expect(described_class).to receive(:`).with("/bin/stty size 2>/dev/null").once.and_return("")
+
+      # We call this twice to check the failure is memoised
+      expect(described_class.size).to be_nil
+      expect(described_class.size).to be_nil
+    end
+  end
+
   describe "::width" do
     specify do
       expect(described_class.width).to be_a(Integer)

--- a/Library/Homebrew/utils/tty.rb
+++ b/Library/Homebrew/utils/tty.rb
@@ -113,10 +113,11 @@ module Tty
     def size
       return @size if defined?(@size)
 
+      @size = T.let(nil, T.nilable([Integer, Integer]))
       height, width = `/bin/stty size 2>/dev/null`.presence&.split&.map(&:to_i)
-      return if height.nil? || width.nil?
+      @size = [height, width] if height && width
 
-      @size = T.let([height, width], T.nilable([Integer, Integer]))
+      @size
     end
 
     sig { returns(Integer) }


### PR DESCRIPTION
`tty.size` returns before assigning `@size` when `stty size` fails, so height and width each re-spawn `stty` on every non-tty run; assigning `nil` before the check memoises the failure.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Fable 5 with manual review

-----
