### PR TITLE
formula_auditor: reject Linux libomp dependency in core formula

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -446,6 +446,10 @@ module Homebrew
           if dep.tags.include?(:recommended) || dep.tags.include?(:optional)
             problem "Formulae in homebrew/core should not have optional or recommended dependencies"
           end
+
+          if Homebrew::SimulateSystem.simulating_or_running_on_linux? && dep.name == "libomp"
+            problem "Formulae in homebrew/core should not use 'libomp' on Linux"
+          end
         end
 
         next unless @core_tap

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -1438,6 +1438,42 @@ RSpec.describe Homebrew::FormulaAuditor do
         end
       end
     end
+
+    describe "when a core formula has a libomp dependency" do
+      subject do
+        fa.audit_deps
+        fa.problems.first&.fetch(:message)
+      end
+
+      let(:fa) do
+        formula_auditor "foo", <<~RUBY, core_tap: true
+          class Foo < Formula
+            url "https://brew.sh/foo-1.0.tgz"
+            homepage "https://brew.sh"
+
+            depends_on "libomp"
+          end
+        RUBY
+      end
+
+      around do |example|
+        Homebrew::SimulateSystem.with(os:) do
+          example.run
+        end
+      end
+
+      describe "on Linux" do
+        let(:os) { :linux }
+
+        it { is_expected.to include("should not use 'libomp' on Linux") }
+      end
+
+      describe "on macOS" do
+        let(:os) { :macos }
+
+        it { is_expected.to be_nil }
+      end
+    end
   end
 
   describe "#audit_stable_version" do


### PR DESCRIPTION
libomp exists for usage with Apple Clang. Also, libomp and libgomp are incompatible so core formulae should use libgomp on Linux.

An alternative is to make libomp macOS-only; however, there isn't any reason a Linux user can't install libomp and force GCC-built binaries to link to it.

Although we typically use a cop for these, OS-specific dependencies are trickier to handle without reading the formula.

Part of stuff I've had to manually check & fix:
- https://github.com/Homebrew/homebrew-core/pull/300232

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

No AI

-----
