### PR TITLE
bundle: require cask/cask_loader before use

### DIFF
--- a/Library/Homebrew/bundle/adder.rb
+++ b/Library/Homebrew/bundle/adder.rb
@@ -44,6 +44,7 @@ module Homebrew
           when :brew
             Formulary.factory(arg).desc
           when :cask
+            Kernel.require "cask/cask_loader"
             ::Cask::CaskLoader.load(arg).desc
           end
 

--- a/Library/Homebrew/bundle/remover.rb
+++ b/Library/Homebrew/bundle/remover.rb
@@ -79,6 +79,8 @@ module Homebrew
 
         return formula if formula.present?
 
+        require "cask/cask_loader"
+
         begin
           ::Cask::CaskLoader.load(name)
         rescue ::Cask::CaskUnavailableError

--- a/Library/Homebrew/test/cmd/bundle/add_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle/add_subcommand_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Homebrew::Cmd::Bundle::AddSubcommand do
   end
 
   let(:global) { false }
+  let(:file) { "/tmp/some_random_brewfile#{Random.rand(2 ** 16)}" }
   let(:context) { bundle_subcommand_context(:add, global:, file:, no_type_args: false) }
   let(:args_object) do
     args_for_subcommand(:add, *args, formulae?: type == :brew, casks?: type == :cask, taps?: type == :tap,
@@ -117,6 +118,22 @@ RSpec.describe Homebrew::Cmd::Bundle::AddSubcommand do
     it "installs and trusts the tap before loading the cask" do
       add
       expect(events).to eq([:tap, :trust, :load])
+    end
+  end
+
+  it "adds a cask and its description comment", :cask, :integration_test do
+    mktmpdir do |path|
+      brewfile = path/"Brewfile"
+      brewfile.write ""
+
+      expect { brew "bundle", "add", "local-transmission", "--cask", "--file=#{brewfile}" }
+        .to not_to_output.to_stdout
+        .and not_to_output.to_stderr
+        .and be_a_success
+      expect(brewfile.read).to eq <<~BREWFILE
+        # BitTorrent client
+        cask "local-transmission"
+      BREWFILE
     end
   end
 end

--- a/Library/Homebrew/test/cmd/bundle/remove_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle/remove_subcommand_spec.rb
@@ -3,7 +3,6 @@
 
 require "bundle"
 require "bundle/subcommand/remove"
-require "cask/cask_loader"
 
 RSpec.describe Homebrew::Cmd::Bundle::RemoveSubcommand do
   subject(:remove) do
@@ -130,6 +129,22 @@ RSpec.describe Homebrew::Cmd::Bundle::RemoveSubcommand do
         # FIXME: Why doesn't this work?
         # expect { remove }.to output("--formula").to_stderr
       end
+    end
+  end
+
+  it "removes a cask and its description comment", :cask, :integration_test do
+    mktmpdir do |path|
+      brewfile = path/"Brewfile"
+      brewfile.write <<~BREWFILE
+        # BitTorrent client
+        cask "local-transmission"
+      BREWFILE
+
+      expect { brew "bundle", "remove", "local-transmission", "--cask", "--file=#{brewfile}" }
+        .to not_to_output.to_stdout
+        .and not_to_output.to_stderr
+        .and be_a_success
+      expect(brewfile.read).to eq("\n")
     end
   end
 end

--- a/Library/Homebrew/test/dev-cmd/tests_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tests_spec.rb
@@ -260,7 +260,7 @@ RSpec.describe Homebrew::DevCmd::Tests do
         expect(changed_test_files).to include("test/cmd/outdated_spec.rb")
         expect(changed_test_files).not_to include("test/cmd/help_spec.rb")
         expect(changed_test_files).not_to include("test/dev-cmd/pr-pull_spec.rb")
-        expect(changed_test_files).not_to include("test/cmd/bundle/remove_subcommand_spec.rb")
+        expect(changed_test_files).not_to include("test/cmd/bundle/cleanup_subcommand_spec.rb")
       end
     end
   end


### PR DESCRIPTION
`Homebrew::Bundle::Remover.find_formula_or_cask` and `Homebrew::Bundle::Adder.add` both reference `Cask::CaskLoader` without requiring it, so reaching either for a cask dies with `Error: uninitialized constant Cask::CaskLoader`. Reported in #23713 against `brew bundle remove`; `brew bundle add` has the same bug.

`brew bundle add` fails for every cask. `brew bundle remove` only fails when the entry has a preceding comment, which is the only time it loads the cask, to check whether that comment is the cask's description. `adder.rb` needs `Kernel.require` rather than a bare `require` because `module_function` puts the call in an instance context Sorbet will not resolve `require` in.

Both spec files required `cask/cask_loader` at the top, which loaded the constant into the RSpec process and hid the bug. This drops that require from the remove spec and adds an integration test to each subcommand spec, since a fresh subprocess is the only place this reproduces.

Reproduce on `main`:

```
brew bundle add firefox --cask --file=/tmp/Brewfile.test
```

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the fix and pass with it, and ran `brew lgtm` + targeted specs.

-----
