### PR TITLE
Never install downloads with checksum mismatches

### DIFF
--- a/Library/Homebrew/bottle.rb
+++ b/Library/Homebrew/bottle.rb
@@ -180,6 +180,8 @@ class Bottle
     expected_checksum = resource.checksum
     return if expected_checksum.nil?
     return unless cached_download.file?
+    # Hash directly, bypassing the digest cache: this must catch local
+    # corruption that kept the file's size and modification time.
     return if cached_download.sha256 == expected_checksum.hexdigest
 
     opoo "Removing corrupt cached download: #{cached_download.basename}"
@@ -227,7 +229,20 @@ class Bottle
   end
 
   sig { void }
-  def stage = with_corrupt_download_retry { downloader.stage }
+  def stage
+    with_corrupt_download_retry do
+      # Trusted immutable blobs skip the rehash (see `downloaded_and_valid?`);
+      # any other cached bottle must match its checksum before being poured.
+      verify_download_integrity(cached_download) unless downloaded_and_valid?
+      downloader.stage
+    end
+  rescue ChecksumMismatchError
+    # The retry's fresh download can itself fail verification, raising from
+    # inside the rescue clause above: remove the known-bad download so the
+    # next attempt fetches it again.
+    clear_cache
+    raise
+  end
 
   sig { params(timeout: T.nilable(T.any(Integer, Float)), quiet: T::Boolean).void }
   def fetch_tab(timeout: nil, quiet: false)

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -313,7 +313,10 @@ module Homebrew
             shared_download_queue.fetch(heading: fetch_heading)
             # Only redo the slower unprefetched fetch for the kind of package
             # that actually failed, so e.g. one bad bottle does not also
-            # re-verify every already downloaded cask.
+            # re-verify every already downloaded cask. The unprefetched fetch
+            # must fetch failed formulae again from scratch, so they cannot
+            # stay marked as already fetched.
+            Install.forget_failed_formula_downloads(download_queue: shared_download_queue)
             failed_cask_downloads, failed_formula_downloads =
               shared_download_queue.failed_downloads.partition { |download| download.is_a?(Cask::Download) }
             formulae_prefetched = false if failed_formula_downloads.any?

--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -131,8 +131,9 @@ module Homebrew
     # reported with a ✘ line but neither raise nor mark the fetch or run
     # as failed, for metadata prefetches such as the bottle manifest of a
     # version whose bottle has not been published yet, where dependency
-    # resolution just falls back to a full install; known-bad cached files
-    # from checksum mismatches are still removed.
+    # resolution just falls back to a full install. Known-bad cached files
+    # from checksum mismatches are always removed, tolerated or not, so
+    # they can never be reused or staged.
     sig {
       params(only: T.nilable(T::Class[Downloadable]), heading: T.nilable(String),
              allow_failures: T::Boolean).void
@@ -165,6 +166,8 @@ module Homebrew
 
           @failed_downloads << downloadable
           ofail "#{downloadable.download_queue_type} reports different checksum: #{e.expected}"
+          # Remove the known-bad download so it can never be staged later.
+          unlink_cached_download(downloadable)
         rescue
           raise unless allow_failures
 
@@ -204,13 +207,14 @@ module Homebrew
             elsif future.rejected?
               if exception.is_a?(ChecksumMismatchError)
                 @failed_downloads << downloadable
-                actual = Digest::SHA256.file(downloadable.cached_download).hexdigest
                 actual_message, expected_message = align_checksum_mismatch_message(downloadable.download_queue_type)
 
                 report_or_defer_failure do
                   ofail "#{actual_message} #{exception.expected}"
-                  puts "#{expected_message} #{actual}"
+                  puts "#{expected_message} #{exception.actual}"
                 end
+                # Remove the known-bad download so it can never be staged later.
+                unlink_cached_download(downloadable)
               elsif exception.is_a?(CannotInstallFormulaError)
                 unlink_cached_download(downloadable)
                 raise exception

--- a/Library/Homebrew/downloadable.rb
+++ b/Library/Homebrew/downloadable.rb
@@ -14,47 +14,62 @@ module Downloadable
   abstract!
   requires_ancestor { Kernel }
 
-  # Remembers which files have already been checksum-verified in this process,
-  # so the same unchanged file is not hashed once per download object that
-  # references it.
+  # Remembers the SHA-256 digest of each file hashed in this process, keyed
+  # by its path, size and modification time, so a file is hashed at most
+  # once per on-disk state no matter how many download objects or
+  # verifications reference it.
   class VerificationCache
     include Context
     include Utils::Output::Mixin
 
     sig { void }
     def initialize
-      require "concurrent/set"
+      require "concurrent/map"
 
-      @verified = T.let(Concurrent::Set.new, Concurrent::Set)
+      @digests = T.let(Concurrent::Map.new, Concurrent::Map)
     end
 
-    # Verifies the file against the checksum unless this file, in this
-    # state, has already been verified against it in this process.
+    # Verifies the file against the checksum. Repeated verifications of a
+    # file unchanged on disk only compare against its remembered digest.
     sig { params(filename: Pathname, checksum: T.nilable(Checksum)).void }
     def verify(filename, checksum)
-      key = key_for(filename, checksum)
-
-      if key && @verified.include?(key)
-        odebug "Skipping checksum verification for '#{filename.basename}' (already verified in this run)"
-        return
-      end
+      raise ChecksumMissingError if checksum.blank?
 
       ohai "Verifying checksum for '#{filename.basename}'" if verbose?
-      filename.verify_checksum(checksum)
+      actual = Checksum.new(sha256(filename))
+      return if checksum == actual
 
-      @verified.add(key) if key
+      raise ChecksumMismatchError.new(filename, checksum, actual)
+    end
+
+    # The file's SHA-256 digest, hashing its contents at most once per
+    # on-disk state in this process.
+    sig { params(filename: Pathname).returns(String) }
+    def sha256(filename)
+      key = key_for(filename)
+      if key && (digest = @digests[key])
+        odebug "Skipping SHA-256 hashing for '#{filename.basename}' (unchanged since last hashed in this run)"
+        return digest
+      end
+
+      digest = filename.sha256
+      # Only remember the digest when the file did not change while its
+      # contents were being hashed.
+      @digests[key] = digest if key && key == key_for(filename)
+      digest
     end
 
     private
 
-    # The size and modification time ensure a file downloaded again to the
-    # same path (e.g. after `--force` cleared the cache) is verified again.
-    sig { params(filename: Pathname, checksum: T.nilable(Checksum)).returns(T.nilable(String)) }
-    def key_for(filename, checksum)
-      return if checksum.nil?
-
+    # The device, inode, size and nanosecond modification and change times
+    # ensure a replaced or rewritten file is hashed again, even when its
+    # size and modification time are restored: the change time cannot be
+    # set from userland.
+    sig { params(filename: Pathname).returns(T.nilable(String)) }
+    def key_for(filename)
       stat = filename.stat
-      "#{filename.expand_path}|#{checksum.hexdigest}|#{stat.size}|#{stat.mtime.to_f}"
+      "#{filename.expand_path}|#{stat.dev}|#{stat.ino}|#{stat.size}|" \
+        "#{stat.mtime.to_i}.#{stat.mtime.nsec}|#{stat.ctime.to_i}.#{stat.ctime.nsec}"
     rescue SystemCallError
       nil
     end
@@ -248,7 +263,7 @@ module Downloadable
       Cannot verify integrity of '#{filename.basename}'.
       No checksum was provided.
       For your reference, the checksum is:
-        sha256 "#{filename.sha256}"
+        sha256 "#{Downloadable.verification_cache.sha256(filename)}"
     EOS
   end
 

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -927,9 +927,13 @@ class ChecksumMismatchError < RuntimeError
   sig { returns(Checksum) }
   attr_reader :expected
 
+  sig { returns(Checksum) }
+  attr_reader :actual
+
   sig { params(path: T.any(Pathname, String), expected: Checksum, actual: Checksum).void }
   def initialize(path, expected, actual)
     @expected = expected
+    @actual = actual
 
     super <<~EOS
       SHA-256 mismatch

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -200,15 +200,27 @@ module Homebrew
                download_queue:     Homebrew::DownloadQueue).returns(T::Array[FormulaInstaller])
       }
       def reject_failed_downloads(formula_installers, download_queue:)
+        failed_names = forget_failed_formula_downloads(download_queue:)
+        return formula_installers if failed_names.empty?
+
+        formula_installers.reject { |fi| failed_names.include?(fi.formula.name) }
+      end
+
+      # A formula whose download failed must not stay marked as fetched:
+      # `FormulaInstaller#enqueue_fetch` marks formulae as fetched when their
+      # downloads are enqueued, so a later retry pass would otherwise skip
+      # fetching entirely and install from a known-bad cached download without
+      # any checksum verification (issue 23714).
+      sig { params(download_queue: Homebrew::DownloadQueue).returns(T::Array[String]) }
+      def forget_failed_formula_downloads(download_queue:)
         failed_names = download_queue.failed_downloads.filter_map do |downloadable|
           case downloadable
           when Bottle then downloadable.name
           when Resource then downloadable.owner&.name
           end
         end
-        return formula_installers if failed_names.empty?
-
-        formula_installers.reject { |fi| failed_names.include?(fi.formula.name) }
+        FormulaInstaller.fetched.delete_if { |formula| failed_names.include?(formula.name) } if failed_names.any?
+        failed_names
       end
 
       sig {

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -104,7 +104,16 @@ class Resource
 
     prepare_patches
     fetch_patches(skip_downloaded: true)
-    fetch unless downloaded?
+    begin
+      fetch unless downloaded?
+      # Never unpack a cached download that does not match the expected
+      # checksum, e.g. one left behind by a failed download elsewhere.
+      verify_download_integrity(cached_download) if checksum.present?
+    rescue ChecksumMismatchError
+      # Remove the known-bad download so the next attempt fetches it again.
+      clear_cache
+      raise
+    end
 
     unpack(target, debug_symbols:, staging_path:, staged:, &block)
   end

--- a/Library/Homebrew/retryable_download.rb
+++ b/Library/Homebrew/retryable_download.rb
@@ -75,7 +75,7 @@ module Homebrew
 
       unless quiet
         puts "Downloaded to: #{download}" unless already_downloaded
-        puts "SHA-256: #{download.sha256}"
+        puts "SHA-256: #{Downloadable.verification_cache.sha256(download)}"
       end
 
       json_download = downloadable.is_a?(API::JSONDownload)

--- a/Library/Homebrew/test/bottle_spec.rb
+++ b/Library/Homebrew/test/bottle_spec.rb
@@ -55,6 +55,63 @@ RSpec.describe Bottle do
     end
   end
 
+  describe "#stage" do
+    it "verifies a cached bottle against its checksum and refetches on mismatch", :aggregate_failures do
+      valid_content = "valid"
+      bottle_spec = BottleSpecification.new
+      bottle_spec.root_url("https://example.com")
+      bottle_spec.sha256(cellar: :any_skip_relocation, arm64_big_sur: Digest::SHA256.hexdigest(valid_content))
+      bottle = described_class.new(nil, bottle_spec, Utils::Bottles::Tag.from_symbol(:arm64_big_sur),
+                                   name: "foo", pkg_version: PkgVersion.new(Version.new("1.2.3"), 0))
+      bottle.cached_download.dirname.mkpath
+      bottle.cached_download.write("corrupt")
+      allow(bottle.downloader).to receive(:stage)
+      expect(bottle).to receive(:fetch) { bottle.cached_download.write(valid_content) }
+
+      expect { bottle.stage }.to output(/Removing corrupt cached download/).to_stderr
+    end
+
+    it "removes the cached bottle when the refetched download also fails verification", :aggregate_failures do
+      valid_content = "valid"
+      bottle_spec = BottleSpecification.new
+      bottle_spec.root_url("https://example.com")
+      expected_checksum = Checksum.new(Digest::SHA256.hexdigest(valid_content))
+      bottle_spec.sha256(cellar: :any_skip_relocation, arm64_big_sur: expected_checksum.hexdigest)
+      bottle = described_class.new(nil, bottle_spec, Utils::Bottles::Tag.from_symbol(:arm64_big_sur),
+                                   name: "foo", pkg_version: PkgVersion.new(Version.new("1.2.3"), 0))
+      bottle.cached_download.dirname.mkpath
+      bottle.cached_download.write("corrupt")
+      expect(bottle).to receive(:fetch) do
+        bottle.cached_download.write("still corrupt")
+        raise ChecksumMismatchError.new(bottle.cached_download, expected_checksum,
+                                        Checksum.new(Digest::SHA256.hexdigest("still corrupt")))
+      end
+
+      expect do
+        expect { bottle.stage }.to raise_error(ChecksumMismatchError)
+      end.to output(/Removing corrupt cached download/).to_stderr
+      expect(bottle.cached_download).not_to exist
+    end
+
+    it "trusts cached immutable blobs without rehashing them when pouring" do
+      bottle_spec = BottleSpecification.new
+      bottle_spec.root_url(HOMEBREW_BOTTLE_DEFAULT_DOMAIN)
+      bottle_spec.sha256(
+        cellar:        :any_skip_relocation,
+        arm64_big_sur: "d7b9f4e8bf83608b71fe958a99f19f2e5e68bb2582965d32e41759c24f1aef97",
+      )
+      bottle = described_class.new(nil, bottle_spec, Utils::Bottles::Tag.from_symbol(:arm64_big_sur),
+                                   name: "foo", pkg_version: PkgVersion.new(Version.new("1.2.3"), 0))
+      bottle.cached_download.dirname.mkpath
+      bottle.cached_download.write("cached")
+      allow(bottle.downloader).to receive(:stage)
+
+      expect(bottle.resource).not_to receive(:verify_download_integrity)
+
+      bottle.stage
+    end
+  end
+
   describe "#stage_from_download_queue" do
     sig { params(checksum: String, content: String).returns(Bottle) }
     def cached_bottle(checksum, content)

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -135,6 +135,25 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     end
   end
 
+  it "does not upgrade a Formula whose download has a checksum mismatch", :integration_test do
+    formula_name = "testball"
+    formula_rack = HOMEBREW_CELLAR/formula_name
+    tarball = TEST_FIXTURE_DIR/"tarballs/testball-0.1.tbz"
+    write_formula formula_name, <<~RUBY
+      url "file://#{tarball}"
+      version "0.2"
+      sha256 "#{"bad0" * 16}"
+    RUBY
+    (formula_rack/"0.1/foo").mkpath
+
+    expect { brew "upgrade" }
+      .to output(/reports different checksum/).to_stderr
+      .and not_to_output(/Upgrading testball/).to_stdout
+      .and be_a_failure
+
+    expect(formula_rack/"0.2").not_to exist
+  end
+
   # links newer version when upgrade was interrupted
   it "links a newer Formula version when upgrade was interrupted" do
     formula_name = "testball_bottle"

--- a/Library/Homebrew/test/download_queue_spec.rb
+++ b/Library/Homebrew/test/download_queue_spec.rb
@@ -123,6 +123,39 @@ RSpec.describe Homebrew::DownloadQueue do
     expect(Homebrew).not_to have_failed
   end
 
+  it "removes known-bad cached files for checksum mismatch failures" do
+    cached_download.dirname.mkpath
+    cached_download.write("corrupt")
+    allow(retryable_download).to receive(:fetch)
+      .and_raise(ChecksumMismatchError.new(cached_download, Checksum.new("aa" * 32), Checksum.new("bb" * 32)))
+
+    download_queue.enqueue(downloadable)
+
+    # The reported checksum comes from the failed verification rather than
+    # rehashing the file, which the report itself has already removed.
+    expect { download_queue.fetch }
+      .to output(/reports different checksum: +#{"aa" * 32}/).to_stderr
+      .and output(/checksum of downloaded file: +#{"bb" * 32}/).to_stdout
+    expect(download_queue.failed_downloads).to eq([downloadable])
+    expect(cached_download).not_to exist
+    expect(Homebrew).to have_failed
+  end
+
+  it "removes known-bad cached files for checksum mismatch failures in serial mode" do
+    allow(Homebrew::EnvConfig).to receive(:download_concurrency).and_return(1)
+    cached_download.dirname.mkpath
+    cached_download.write("corrupt")
+    allow(retryable_download).to receive(:fetch)
+      .and_raise(ChecksumMismatchError.new(cached_download, Checksum.new("aa" * 32), Checksum.new("bb" * 32)))
+
+    download_queue.enqueue(downloadable)
+
+    expect { download_queue.fetch }.to output(/reports different checksum/).to_stderr
+    expect(download_queue.failed_downloads).to eq([downloadable])
+    expect(cached_download).not_to exist
+    expect(Homebrew).to have_failed
+  end
+
   it "removes known-bad cached files for tolerated checksum mismatches" do
     cached_download.dirname.mkpath
     cached_download.write("corrupt")

--- a/Library/Homebrew/test/downloadable_spec.rb
+++ b/Library/Homebrew/test/downloadable_spec.rb
@@ -1,0 +1,54 @@
+# typed: true
+# frozen_string_literal: true
+
+require "downloadable"
+
+RSpec.describe Downloadable::VerificationCache do
+  subject(:cache) { described_class.new }
+
+  let(:file) { HOMEBREW_CACHE/"downloads/digest-cache-test.tar.gz" }
+  let(:checksum) { Checksum.new(Digest::SHA256.hexdigest("contents")) }
+
+  before do
+    file.dirname.mkpath
+    file.write("contents")
+  end
+
+  it "hashes an unchanged file at most once across verifications and digest reads" do
+    expect(Digest::SHA256).to receive(:file).once.and_call_original
+
+    cache.verify(file, checksum)
+    cache.verify(file, checksum)
+    expect(cache.sha256(file)).to eq(checksum.hexdigest)
+  end
+
+  it "hashes a file again when its contents change on disk" do
+    cache.sha256(file)
+    file.write("changed contents")
+
+    expect(cache.sha256(file)).to eq(Digest::SHA256.hexdigest("changed contents"))
+  end
+
+  it "hashes a replacement file again despite an identical size and restored modification time" do
+    modification_time = Time.utc(2026, 1, 1)
+    File.utime(modification_time, modification_time, file)
+    cache.sha256(file)
+    replacement = file.dirname/"replacement.tar.gz"
+    replacement.write("CONTENTS")
+    File.utime(modification_time, modification_time, replacement)
+    FileUtils.mv(replacement, file)
+
+    expect(cache.sha256(file)).to eq(Digest::SHA256.hexdigest("CONTENTS"))
+  end
+
+  it "raises for a checksum mismatch without rehashing the unchanged file" do
+    bad_checksum = Checksum.new("bad0" * 16)
+    expect(Digest::SHA256).to receive(:file).once.and_call_original
+
+    2.times do
+      expect { cache.verify(file, bad_checksum) }.to raise_error(ChecksumMismatchError) do |error|
+        expect(error.actual).to eq(checksum)
+      end
+    end
+  end
+end

--- a/Library/Homebrew/test/install_spec.rb
+++ b/Library/Homebrew/test/install_spec.rb
@@ -49,22 +49,27 @@ RSpec.describe Homebrew::Install do
   end
 
   describe "::reject_failed_downloads" do
-    it "skips the formula whose download failed and keeps the rest" do
+    it "skips the formula whose download failed, keeps the rest and unmarks the failure as fetched" do
       bottle_spec = BottleSpecification.new
       bottle_spec.sha256(arm64_big_sur: "deadbeef" * 8)
       failed_bottle = Bottle.new(nil, bottle_spec, Utils::Bottles::Tag.from_symbol(:arm64_big_sur),
                                  name: "bad-bottle", pkg_version: PkgVersion.new(Version.new("1.0"), 0))
-      bad_fi = instance_double(FormulaInstaller, formula: formula("bad-bottle") do
+      bad_formula = formula("bad-bottle") do
         T.bind(self, T.class_of(Formula))
         url "foo-1.0"
-      end)
+      end
+      bad_fi = instance_double(FormulaInstaller, formula: bad_formula)
       good_fi = instance_double(FormulaInstaller, formula: formula("good-bottle") do
         T.bind(self, T.class_of(Formula))
         url "foo-1.0"
       end)
       download_queue = instance_double(Homebrew::DownloadQueue, failed_downloads: [failed_bottle])
+      FormulaInstaller.fetched << bad_formula
 
       expect(described_class.reject_failed_downloads([bad_fi, good_fi], download_queue:)).to eq([good_fi])
+      # A retry pass must fetch the failed formula again rather than skip it
+      # as already fetched and install its known-bad cached download.
+      expect(FormulaInstaller.fetched).to be_empty
     end
   end
 

--- a/Library/Homebrew/test/resource_spec.rb
+++ b/Library/Homebrew/test/resource_spec.rb
@@ -229,6 +229,17 @@ RSpec.describe Resource do
 
       expect(resource.source_modified_time).to eq(last_modified)
     end
+
+    it "refuses to unpack a cached download that does not match the checksum and removes it" do
+      resource.sha256("bad0" * 16)
+      resource.cached_download.dirname.mkpath
+      FileUtils.cp tarball, resource.cached_download
+
+      expect { resource.stage(mktmpdir) }.to raise_error(ChecksumMismatchError)
+      # The known-bad download must be removed so the next attempt fetches
+      # a fresh copy instead of failing on the same file again.
+      expect(resource.cached_download).not_to exist
+    end
   end
 
   describe "#owner" do
@@ -310,7 +321,7 @@ RSpec.describe Resource do
     other_resource = described_class.new("other")
     other_resource.sha256(digest)
 
-    expect(fn).to receive(:verify_checksum).once.and_call_original
+    expect(fn).to receive(:sha256).once.and_call_original
 
     resource.verify_download_integrity(fn)
     other_resource.verify_download_integrity(fn)
@@ -320,20 +331,17 @@ RSpec.describe Resource do
     fn = Pathname.new("test")
 
     allow(fn).to receive(:file?).and_return(true)
-    expect(fn).to receive(:verify_checksum).and_raise(ChecksumMissingError)
-    expect(fn).to receive(:sha256)
+    expect(fn).to receive(:sha256).and_return(Digest::SHA256.hexdigest("content"))
 
-    resource.verify_download_integrity(fn)
+    expect do
+      resource.verify_download_integrity(fn)
+    end.to output(/Cannot verify integrity/).to_stderr
   end
 
   specify "#verify_download_integrity_mismatch" do
     fn = Pathname.new("foo")
-    allow(fn).to receive(:file?).and_return(true)
-    checksum = resource.sha256(TEST_SHA256)
-
-    expect(fn).to receive(:verify_checksum)
-      .with(checksum)
-      .and_raise(ChecksumMismatchError.new(fn, checksum, Checksum.new(Digest::SHA256.new.hexdigest)))
+    allow(fn).to receive_messages(file?: true, sha256: Digest::SHA256.hexdigest("mismatch"))
+    resource.sha256(TEST_SHA256)
 
     expect do
       resource.verify_download_integrity(fn)


### PR DESCRIPTION
- `brew upgrade` could install a formula after reporting a checksum mismatch: the failed prefetch left the formula marked as fetched, so the retry pass skipped fetching and built from the known-bad cached file without any verification.
- Unmark formulae with failed downloads as fetched so retry passes fetch and verify them again from scratch.
- Remove known-bad cached files whenever a checksum mismatch is reported so they can never be reused or staged later.
- Verify checksums of already-cached downloads in `Resource#stage` and `Bottle#stage` (keeping the trusted immutable blob fast path) as a last line of defence before anything is unpacked or poured.
- Add an integration test upgrading a formula whose new version has a bad checksum plus unit tests for each defence layer.

Fixes #23714.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude with Fable at Extra High effort, with local review and testing.

-----