### PR TITLE
Verify cached downloads at every consumption boundary

### DIFF
--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -62,15 +62,26 @@ module Homebrew
         download = Homebrew::API::SourceDownload.new(
           "https://raw.githubusercontent.com/#{tap}/#{git_head}/#{path}",
           checksum,
-          cache: HOMEBREW_CACHE_API_SOURCE/"#{tap}/#{git_head}"/path.dirname,
+          formula:,
+          cache:   HOMEBREW_CACHE_API_SOURCE/"#{tap}/#{git_head}"/path.dirname,
         )
 
         if enqueue
           require "download_queue"
           download_queue ||= Homebrew.default_download_queue
           download_queue.enqueue(download)
-        elsif !download.symlink_location.exist? || !download.symlink_location.symlink?
-          download.fetch
+        else
+          begin
+            if !download.symlink_location.exist? || !download.symlink_location.symlink?
+              download.fetch
+            elsif checksum
+              download.verify_download_integrity(download.symlink_location)
+            end
+          rescue ChecksumMismatchError
+            # Remove the known-bad download so the next attempt fetches it again.
+            download.clear_cache
+            raise
+          end
         end
 
         download

--- a/Library/Homebrew/api/formula_bottle.rb
+++ b/Library/Homebrew/api/formula_bottle.rb
@@ -14,9 +14,10 @@ module Homebrew
           name:           String,
           formula_struct: Homebrew::API::FormulaStruct,
           bottle_tag:     Utils::Bottles::Tag,
+          formula:        T.nilable(::Formula),
         ).returns(T.nilable(::Bottle))
       }
-      def self.bottle(name:, formula_struct:, bottle_tag: Utils::Bottles.tag)
+      def self.bottle(name:, formula_struct:, bottle_tag: Utils::Bottles.tag, formula: nil)
         return unless formula_struct.stable?
         return unless formula_struct.bottle?
 
@@ -33,13 +34,17 @@ module Homebrew
 
         return unless bottle_specification.tag?(bottle_tag)
 
-        ::Bottle.new(
-          nil,
-          bottle_specification,
-          bottle_tag,
-          name:,
-          pkg_version: PkgVersion.new(::Version.new(formula_struct.stable_version), formula_struct.revision),
-        )
+        if formula
+          ::Bottle.new(formula, bottle_specification, bottle_tag)
+        else
+          ::Bottle.new(
+            nil,
+            bottle_specification,
+            bottle_tag,
+            name:,
+            pkg_version: PkgVersion.new(::Version.new(formula_struct.stable_version), formula_struct.revision),
+          )
+        end
       end
     end
   end

--- a/Library/Homebrew/api/source_download.rb
+++ b/Library/Homebrew/api/source_download.rb
@@ -15,18 +15,23 @@ module Homebrew
     class SourceDownload
       include Downloadable
 
+      sig { returns(::Formula) }
+      attr_reader :formula
+
       sig {
         params(
           url:      String,
           checksum: T.nilable(Checksum),
+          formula:  ::Formula,
           mirrors:  T::Array[String],
           cache:    T.nilable(Pathname),
         ).void
       }
-      def initialize(url, checksum, mirrors: [], cache: nil)
+      def initialize(url, checksum, formula:, mirrors: [], cache: nil)
         super()
         @url = T.let(URL.new(url, using: API::SourceDownloadStrategy), URL)
         @checksum = checksum
+        @formula = formula
         @mirrors = mirrors
         @cache = cache
       end
@@ -47,6 +52,12 @@ module Homebrew
       sig { returns(Pathname) }
       def symlink_location
         downloader.symlink_location
+      end
+
+      sig { override.void }
+      def clear_cache
+        super
+        symlink_location.unlink if symlink_location.symlink?
       end
     end
   end

--- a/Library/Homebrew/bottle.rb
+++ b/Library/Homebrew/bottle.rb
@@ -144,6 +144,10 @@ class Bottle
     retry
   end
 
+  # Whether the cached bottle can be reused without downloading it again. An
+  # immutable GitHub Packages blob is named after its own digest, so matching
+  # that name is enough to skip the download — but it says nothing about the
+  # file's contents, which every consumer must still verify before extracting.
   sig { override.returns(T::Boolean) }
   def downloaded_and_valid?
     return false unless cached_download.file?
@@ -158,10 +162,10 @@ class Bottle
     downloader.bottle_blob_sha256 == resource_checksum.hexdigest
   end
 
-  # A cached immutable blob is trusted without rehashing it (see
-  # `downloaded_and_valid?`), so a locally corrupted bottle would fail to
-  # extract on every run: verify it after a failed extraction and, when it was
-  # indeed corrupt, discard it and retry with a freshly downloaded one.
+  # Callers verify the cached download before consuming it. On failure, discard
+  # the cached file only when it is genuinely corrupt and retry once with a
+  # fresh download; a file that matches its checksum is kept and the original
+  # error re-raised.
   sig { params(quiet: T::Boolean, _block: T.proc.void).void }
   def with_corrupt_download_retry(quiet: false, &_block)
     yield
@@ -231,9 +235,7 @@ class Bottle
   sig { void }
   def stage
     with_corrupt_download_retry do
-      # Trusted immutable blobs skip the rehash (see `downloaded_and_valid?`);
-      # any other cached bottle must match its checksum before being poured.
-      verify_download_integrity(cached_download) unless downloaded_and_valid?
+      verify_download_integrity(cached_download)
       downloader.stage
     end
   rescue ChecksumMismatchError
@@ -337,6 +339,7 @@ class Bottle
       FileUtils.rm(bottle_poured_file) if bottle_poured_file.symlink?
       FileUtils.rm_r(bottle_tmp_keg) if bottle_tmp_keg.directory?
 
+      verify_download_integrity(download)
       UnpackStrategy.detect(download, prioritize_extension: true)
                     .extract_nestedly(to: HOMEBREW_TEMP_CELLAR)
 

--- a/Library/Homebrew/bottle.rb
+++ b/Library/Homebrew/bottle.rb
@@ -169,8 +169,11 @@ class Bottle
   sig { params(quiet: T::Boolean, _block: T.proc.void).void }
   def with_corrupt_download_retry(quiet: false, &_block)
     yield
-  rescue
-    discard_corrupt_cached_download
+  rescue => e
+    # A checksum mismatch has already hashed the file and proven it
+    # corrupt; only other failures, e.g. during extraction, need a fresh
+    # hash to decide whether the file can be kept.
+    discard_corrupt_cached_download(known_corrupt: e.is_a?(ChecksumMismatchError))
     raise if cached_download.exist?
 
     downloading!
@@ -179,14 +182,20 @@ class Bottle
     yield
   end
 
-  sig { void }
-  def discard_corrupt_cached_download
+  sig { params(known_corrupt: T::Boolean).void }
+  def discard_corrupt_cached_download(known_corrupt: false)
     expected_checksum = resource.checksum
     return if expected_checksum.nil?
     return unless cached_download.file?
-    # Hash directly, bypassing the digest cache: this must catch local
-    # corruption that kept the file's size and modification time.
-    return if cached_download.sha256 == expected_checksum.hexdigest
+
+    unless known_corrupt
+      # The remembered digest cannot be trusted here: the failed extraction
+      # may mean the file was corrupted in place without changing the
+      # metadata that keys the digest cache, so forget it and hash afresh.
+      verification_cache = Downloadable.verification_cache
+      verification_cache.invalidate!(cached_download)
+      return if verification_cache.sha256(cached_download) == expected_checksum.hexdigest
+    end
 
     opoo "Removing corrupt cached download: #{cached_download.basename}"
     clear_cache

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -316,9 +316,9 @@ module Homebrew
             # re-verify every already downloaded cask. The unprefetched fetch
             # must fetch failed formulae again from scratch, so they cannot
             # stay marked as already fetched.
-            Install.forget_failed_formula_downloads(download_queue: shared_download_queue)
             failed_cask_downloads, failed_formula_downloads =
               shared_download_queue.failed_downloads.partition { |download| download.is_a?(Cask::Download) }
+            Install.unmark_failed_formulae(failed_formula_downloads)
             formulae_prefetched = false if failed_formula_downloads.any?
             prefetched_casks = false if failed_cask_downloads.any?
             if prefetched_casks

--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -5,6 +5,7 @@ require "formula"
 require "formula_creator"
 require "missing_formula"
 require "cask/cask_loader"
+require "downloadable"
 
 module Homebrew
   module DevCmd
@@ -116,7 +117,7 @@ module Homebrew
             strategy = DownloadStrategyDetector.detect(url)
             downloader = strategy.new(url, token, version.to_s, cache: Cask::Cache.path)
             downloader.fetch
-            downloader.cached_location.sha256
+            Downloadable.verification_cache.sha256(downloader.cached_location)
           end
 
           [url.gsub(version.to_s, "\#{version}"), sha256]

--- a/Library/Homebrew/downloadable.rb
+++ b/Library/Homebrew/downloadable.rb
@@ -15,12 +15,68 @@ module Downloadable
   requires_ancestor { Kernel }
 
   # Remembers the SHA-256 digest of each file hashed in this process, keyed
-  # by its path, size and modification time, so a file is hashed at most
-  # once per on-disk state no matter how many download objects or
+  # by its resolved path, size and modification time, so a file is hashed
+  # at most once per on-disk state no matter how many download objects or
   # verifications reference it.
   class VerificationCache
     include Context
     include Utils::Output::Mixin
+
+    # Raised by the integration-test-only check in `Pathname#sha256` when an
+    # unchanged file is hashed again without this cache being involved.
+    class RepeatedHashingError < RuntimeError; end
+
+    CACHE_MEDIATED_HASHING_KEY = :homebrew_verification_cache_mediated_hashing
+
+    class << self
+      # The identity and change metadata that determine whether a file can
+      # be considered unchanged on disk: the device, inode, size and
+      # nanosecond modification and change times ensure a replaced or
+      # rewritten file is treated as new, even when its size and
+      # modification time are restored, as the change time cannot be set
+      # from userland.
+      sig { params(filename: Pathname).returns(T.nilable(String)) }
+      def on_disk_state(filename)
+        stat = filename.stat
+        "#{stat.dev}|#{stat.ino}|#{stat.size}|" \
+          "#{stat.mtime.to_i}.#{stat.mtime.nsec}|#{stat.ctime.to_i}.#{stat.ctime.nsec}"
+      rescue SystemCallError
+        nil
+      end
+
+      # Guards against repeated verification creeping in without this cache:
+      # every `Pathname#sha256` call reports here and, in `brew` commands
+      # run by integration tests only, rehashing an unchanged file outside
+      # the cache raises. Hashing is cheap there while a repeat in real use
+      # would rehash a download that can be hundreds of megabytes.
+      sig { params(filename: Pathname).void }
+      def check_repeated_hashing(filename)
+        return if ENV["HOMEBREW_CHECK_REPEATED_HASHING"].blank?
+
+        state = on_disk_state(filename)
+        return if state.nil?
+
+        require "concurrent/set"
+        @hashed_states ||= T.let(Concurrent::Set.new, T.nilable(Concurrent::Set))
+        # `add?` atomically records the state and reports whether it was new.
+        return unless @hashed_states.add?(state).nil?
+        return if Thread.current[CACHE_MEDIATED_HASHING_KEY]
+
+        raise RepeatedHashingError, <<~ERROR
+          Refusing to hash '#{filename}' again: its unchanged contents were already hashed in this process.
+          Verify downloads through `Downloadable#verify_download_integrity` so its digest cache reuses the existing hash.
+          This check only runs when `$HOMEBREW_CHECK_REPEATED_HASHING` is set, e.g. in Homebrew's integration tests.
+        ERROR
+      end
+
+      sig { type_parameters(:U).params(_block: T.proc.returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
+      def while_hashing_through_cache(&_block)
+        Thread.current[CACHE_MEDIATED_HASHING_KEY] = true
+        yield
+      ensure
+        Thread.current[CACHE_MEDIATED_HASHING_KEY] = nil
+      end
+    end
 
     sig { void }
     def initialize
@@ -52,24 +108,34 @@ module Downloadable
         return digest
       end
 
-      digest = filename.sha256
+      digest = self.class.while_hashing_through_cache { filename.sha256 }
       # Only remember the digest when the file did not change while its
       # contents were being hashed.
       @digests[key] = digest if key && key == key_for(filename)
       digest
     end
 
+    # Forgets the remembered digest for the file's current on-disk state,
+    # for callers that suspect its contents changed without the metadata
+    # that keys this cache changing, e.g. in-place corruption suggested by
+    # a failed extraction.
+    sig { params(filename: Pathname).void }
+    def invalidate!(filename)
+      key = key_for(filename)
+      @digests.delete(key) if key
+    end
+
     private
 
-    # The device, inode, size and nanosecond modification and change times
-    # ensure a replaced or rewritten file is hashed again, even when its
-    # size and modification time are restored: the change time cannot be
-    # set from userland.
+    # The resolved path unifies verifications through a symlink with those
+    # through its target, e.g. a download verified once at its cache
+    # location and once through the cache's symlink to it.
     sig { params(filename: Pathname).returns(T.nilable(String)) }
     def key_for(filename)
-      stat = filename.stat
-      "#{filename.expand_path}|#{stat.dev}|#{stat.ino}|#{stat.size}|" \
-        "#{stat.mtime.to_i}.#{stat.mtime.nsec}|#{stat.ctime.to_i}.#{stat.ctime.nsec}"
+      state = self.class.on_disk_state(filename)
+      return if state.nil?
+
+      "#{filename.realpath}|#{state}"
     rescue SystemCallError
       nil
     end

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -925,10 +925,7 @@ class ChecksumMissingError < ArgumentError; end
 # Raised by {Pathname#verify_checksum} when verification fails.
 class ChecksumMismatchError < RuntimeError
   sig { returns(Checksum) }
-  attr_reader :expected
-
-  sig { returns(Checksum) }
-  attr_reader :actual
+  attr_reader :expected, :actual
 
   sig { params(path: T.any(Pathname, String), expected: Checksum, actual: Checksum).void }
   def initialize(path, expected, actual)

--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -220,6 +220,9 @@ class Pathname
   sig { returns(String) }
   def sha256
     require "digest/sha2"
+    # In integration tests only, raise when an unchanged file is rehashed
+    # without the digest cache being involved.
+    ::Downloadable::VerificationCache.check_repeated_hashing(self) if defined?(::Downloadable::VerificationCache)
     Digest::SHA256.file(self).hexdigest
   end
 

--- a/Library/Homebrew/external_patch.rb
+++ b/Library/Homebrew/external_patch.rb
@@ -51,6 +51,17 @@ class ExternalPatch
 
   sig { void }
   def apply
+    begin
+      if downloaded?
+        verify_download_integrity(cached_download) if resource.checksum.present?
+      else
+        fetch
+      end
+    rescue ChecksumMismatchError
+      clear_cache
+      raise
+    end
+
     base_dir = Pathname.pwd
     resource.unpack do
       patch_dir = Pathname.pwd

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "digest"
+require "downloadable"
 require "erb"
 require "utils/github"
 require "utils/output"
@@ -133,7 +134,9 @@ module Homebrew
             raise "Downloaded URL is not archive"
           end
 
-          @sha256 = T.let(filepath.sha256, T.nilable(String))
+          # The missing-checksum warning during the fetch above has already
+          # hashed the file, so reuse its digest.
+          @sha256 = T.let(Downloadable.verification_cache.sha256(filepath), T.nilable(String))
         end
 
         if @github

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1657,6 +1657,7 @@ on_request: installed_on_request?, options:)
     @api_bottle = Homebrew::API::FormulaBottle.bottle(
       name:           formula.name,
       formula_struct: Homebrew::API::Internal.formula_struct(formula.name),
+      formula:,
     )
   end
 

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -14,6 +14,7 @@ require "messages"
 require "utils/output"
 require "utils/topological_hash"
 require "install/check"
+require "api/source_download"
 
 module Homebrew
   # Helper module for performing (pre-)install checks.
@@ -200,10 +201,10 @@ module Homebrew
                download_queue:     Homebrew::DownloadQueue).returns(T::Array[FormulaInstaller])
       }
       def reject_failed_downloads(formula_installers, download_queue:)
-        failed_names = forget_failed_formula_downloads(download_queue:)
-        return formula_installers if failed_names.empty?
+        failed_full_names = unmark_failed_formulae(download_queue.failed_downloads)
+        return formula_installers if failed_full_names.empty?
 
-        formula_installers.reject { |fi| failed_names.include?(fi.formula.name) }
+        formula_installers.reject { |fi| failed_full_names.include?(fi.formula.full_name) }
       end
 
       # A formula whose download failed must not stay marked as fetched:
@@ -211,16 +212,23 @@ module Homebrew
       # downloads are enqueued, so a later retry pass would otherwise skip
       # fetching entirely and install from a known-bad cached download without
       # any checksum verification (issue 23714).
-      sig { params(download_queue: Homebrew::DownloadQueue).returns(T::Array[String]) }
-      def forget_failed_formula_downloads(download_queue:)
-        failed_names = download_queue.failed_downloads.filter_map do |downloadable|
-          case downloadable
-          when Bottle then downloadable.name
-          when Resource then downloadable.owner&.name
+      sig { params(downloadables: T::Array[Downloadable]).returns(T::Array[String]) }
+      def unmark_failed_formulae(downloadables)
+        failed_full_names = downloadables.filter_map do |downloadable|
+          owner = case downloadable
+          when Bottle
+            downloadable.resource.owner
+          when Resource
+            downloadable.owner
+          when Homebrew::API::SourceDownload
+            downloadable.formula
           end
+          owner = owner.owner if owner.is_a?(SoftwareSpec)
+          owner.full_name if owner.is_a?(Formula)
         end
-        FormulaInstaller.fetched.delete_if { |formula| failed_names.include?(formula.name) } if failed_names.any?
-        failed_names
+
+        FormulaInstaller.fetched.delete_if { |formula| failed_full_names.include?(formula.full_name) }
+        failed_full_names
       end
 
       sig {

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -105,10 +105,11 @@ class Resource
     prepare_patches
     fetch_patches(skip_downloaded: true)
     begin
-      fetch unless downloaded?
-      # Never unpack a cached download that does not match the expected
-      # checksum, e.g. one left behind by a failed download elsewhere.
-      verify_download_integrity(cached_download) if checksum.present?
+      if !downloaded?
+        fetch
+      elsif !staged && checksum.present?
+        verify_download_integrity(cached_download)
+      end
     rescue ChecksumMismatchError
       # Remove the known-bad download so the next attempt fetches it again.
       clear_cache

--- a/Library/Homebrew/test/api/formula_spec.rb
+++ b/Library/Homebrew/test/api/formula_spec.rb
@@ -169,6 +169,44 @@ RSpec.describe Homebrew::API::Formula do
 
       described_class.source_download(f)
     end
+
+    it "verifies a cached source file before trusting its symlink" do
+      target = mktmpdir/"testball_target.rb"
+      target.write("mismatched")
+      symlink = mktmpdir/"testball.rb"
+      FileUtils.ln_s(target, symlink)
+      allow(f).to receive(:ruby_source_checksum)
+        .and_return(Checksum.new(Digest::SHA256.hexdigest("valid")))
+      allow_any_instance_of(Homebrew::API::SourceDownload).to receive(:symlink_location).and_return(symlink)
+
+      expect { described_class.source_download(f) }.to raise_error(ChecksumMismatchError)
+      expect(symlink).not_to exist
+    end
+
+    it "removes a freshly downloaded source file that fails verification" do
+      missing = mktmpdir/"testball.rb"
+      checksum = Checksum.new(Digest::SHA256.hexdigest("valid"))
+      allow(f).to receive(:ruby_source_checksum).and_return(checksum)
+      allow_any_instance_of(Homebrew::API::SourceDownload).to receive(:symlink_location).and_return(missing)
+      allow_any_instance_of(Homebrew::API::SourceDownload).to receive(:fetch)
+        .and_raise(ChecksumMismatchError.new(missing, checksum, Checksum.new(Digest::SHA256.hexdigest("bad"))))
+      expect_any_instance_of(Homebrew::API::SourceDownload).to receive(:clear_cache)
+
+      expect { described_class.source_download(f) }.to raise_error(ChecksumMismatchError)
+    end
+
+    it "reuses a cached source file that matches its checksum" do
+      content = "valid"
+      target = mktmpdir/"testball_target.rb"
+      target.write(content)
+      symlink = mktmpdir/"testball.rb"
+      FileUtils.ln_s(target, symlink)
+      allow(f).to receive(:ruby_source_checksum).and_return(Checksum.new(Digest::SHA256.hexdigest(content)))
+      allow_any_instance_of(Homebrew::API::SourceDownload).to receive(:symlink_location).and_return(symlink)
+      expect_any_instance_of(Homebrew::API::SourceDownload).not_to receive(:fetch)
+
+      expect(described_class.source_download(f).symlink_location).to eq(symlink)
+    end
   end
 
   describe "::source_download_formula" do

--- a/Library/Homebrew/test/bottle_spec.rb
+++ b/Library/Homebrew/test/bottle_spec.rb
@@ -93,22 +93,27 @@ RSpec.describe Bottle do
       expect(bottle.cached_download).not_to exist
     end
 
-    it "trusts cached immutable blobs without rehashing them when pouring" do
+    it "does not extract a cached bottle until its checksum is verified" do
+      valid_content = "valid"
       bottle_spec = BottleSpecification.new
       bottle_spec.root_url(HOMEBREW_BOTTLE_DEFAULT_DOMAIN)
-      bottle_spec.sha256(
-        cellar:        :any_skip_relocation,
-        arm64_big_sur: "d7b9f4e8bf83608b71fe958a99f19f2e5e68bb2582965d32e41759c24f1aef97",
-      )
+      bottle_spec.sha256(cellar: :any_skip_relocation, arm64_big_sur: Digest::SHA256.hexdigest(valid_content))
       bottle = described_class.new(nil, bottle_spec, Utils::Bottles::Tag.from_symbol(:arm64_big_sur),
                                    name: "foo", pkg_version: PkgVersion.new(Version.new("1.2.3"), 0))
       bottle.cached_download.dirname.mkpath
-      bottle.cached_download.write("cached")
-      allow(bottle.downloader).to receive(:stage)
-
-      expect(bottle.resource).not_to receive(:verify_download_integrity)
+      bottle.cached_download.write("mismatched")
+      staged_content = []
+      allow(bottle.downloader).to receive(:stage) { staged_content << bottle.cached_download.read }
+      expect(bottle).to receive(:fetch) do
+        bottle.cached_download.write(valid_content)
+        bottle.verify_download_integrity(bottle.cached_download)
+      end
 
       bottle.stage
+
+      expect(staged_content).to eq([valid_content])
+    ensure
+      bottle&.clear_cache
     end
   end
 
@@ -125,23 +130,83 @@ RSpec.describe Bottle do
       bottle
     end
 
+    it "does not verify a bottle that was already queue-staged" do
+      staged_path = T.let(nil, T.nilable(Pathname))
+      marker = T.let(nil, T.nilable(Pathname))
+      bottle = cached_bottle("0" * 64, "mismatched")
+      staged_path = bottle.staged_path_from_download_queue
+      marker = bottle.staged_path_from_download_queue_marker
+      staged_path.mkpath
+      FileUtils.ln_s(staged_path, marker)
+      expect(bottle).not_to receive(:verify_download_integrity)
+      expect(UnpackStrategy).not_to receive(:detect)
+
+      bottle.stage_from_download_queue(bottle.cached_download, pour: true)
+    ensure
+      FileUtils.rm_f(marker) if marker
+      FileUtils.rm_r(staged_path) if staged_path&.directory?
+      bottle&.clear_cache
+    end
+
+    it "does not queue-stage a cached bottle until its checksum is verified" do
+      valid_content = "valid"
+      bottle = cached_bottle(Digest::SHA256.hexdigest(valid_content), "mismatched")
+      unpack_strategy = instance_double(UnpackStrategy::Tar)
+      staged_content = []
+      allow(UnpackStrategy).to receive(:detect) do
+        staged_content << bottle.cached_download.read
+        unpack_strategy
+      end
+      allow(unpack_strategy).to receive(:extract_nestedly) { bottle.staged_path_from_download_queue.mkpath }
+      expect(bottle).to receive(:fetch) do
+        bottle.cached_download.write(valid_content)
+        bottle.verify_download_integrity(bottle.cached_download)
+      end
+
+      bottle.stage_from_download_queue(bottle.cached_download, pour: true)
+
+      expect(staged_content).to eq([valid_content])
+    ensure
+      bottle&.clear_cache
+    end
+
     it "downloads a corrupt cached bottle again and extracts it", :aggregate_failures do
-      bottle = cached_bottle("d7b9f4e8bf83608b71fe958a99f19f2e5e68bb2582965d32e41759c24f1aef97", "corrupt")
+      valid_content = "valid"
+      bottle = cached_bottle(Digest::SHA256.hexdigest(valid_content), "corrupt")
       unpack_strategy = instance_double(UnpackStrategy::Tar)
       allow(unpack_strategy).to receive(:extract_nestedly) { bottle.staged_path_from_download_queue.mkpath }
       extractions = 0
       allow(UnpackStrategy).to receive(:detect) do
         extractions += 1
-        raise "gzip decompression failed" if extractions == 1
-
         unpack_strategy
       end
 
-      expect(bottle).to receive(:fetch) { bottle.cached_download.write("valid") }
+      expect(bottle).to receive(:fetch) do
+        bottle.cached_download.write(valid_content)
+        bottle.verify_download_integrity(bottle.cached_download)
+      end
 
       expect { bottle.stage_from_download_queue(bottle.cached_download, pour: true) }
         .to output(/Removing corrupt cached download/).to_stderr
-      expect(extractions).to eq(2)
+      expect(extractions).to eq(1)
+    end
+
+    it "raises without extracting when the refetched download also fails verification", :aggregate_failures do
+      expected_checksum = Checksum.new(Digest::SHA256.hexdigest("valid"))
+      bottle = cached_bottle(expected_checksum.hexdigest, "mismatched")
+      expect(UnpackStrategy).not_to receive(:detect)
+      expect(bottle).to receive(:fetch) do
+        bottle.cached_download.write("still mismatched")
+        raise ChecksumMismatchError.new(bottle.cached_download, expected_checksum,
+                                        Checksum.new(Digest::SHA256.hexdigest("still mismatched")))
+      end
+
+      expect do
+        expect { bottle.stage_from_download_queue(bottle.cached_download, pour: true) }
+          .to raise_error(ChecksumMismatchError)
+      end.to output(/Removing corrupt cached download/).to_stderr
+    ensure
+      bottle&.clear_cache
     end
 
     it "keeps a cached bottle matching its checksum that fails to extract", :aggregate_failures do

--- a/Library/Homebrew/test/bottle_spec.rb
+++ b/Library/Homebrew/test/bottle_spec.rb
@@ -67,6 +67,10 @@ RSpec.describe Bottle do
       bottle.cached_download.write("corrupt")
       allow(bottle.downloader).to receive(:stage)
       expect(bottle).to receive(:fetch) { bottle.cached_download.write(valid_content) }
+      # The mismatched verification has already hashed the corrupt file, so
+      # discarding it must not hash it a second time: once for the corrupt
+      # file and once for the fresh download.
+      expect(Digest::SHA256).to receive(:file).twice.and_call_original
 
       expect { bottle.stage }.to output(/Removing corrupt cached download/).to_stderr
     end

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -1224,13 +1224,21 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
   end
 
   it "only distrusts the formula half of a shared prefetch whose bottle download failed" do
-    expect(run_upgrade_with_failed_shared_prefetch(instance_double(Bottle)))
-      .to eq(use_prefetched: false, skip_prefetch: true)
+    bottle_spec = BottleSpecification.new
+    bottle_spec.sha256(arm64_big_sur: "deadbeef" * 8)
+    formula = formula("deno") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/deno-2.7.11.tar.gz"
+    end
+    failed_bottle = Bottle.new(formula, bottle_spec, Utils::Bottles::Tag.from_symbol(:arm64_big_sur))
+
+    expect(run_upgrade_with_failed_shared_prefetch(failed_bottle))
+      .to eq(use_prefetched: false, skip_prefetch: true, failed_formula_fetched: false)
   end
 
   it "only distrusts the cask half of a shared prefetch whose cask download failed" do
     expect(run_upgrade_with_failed_shared_prefetch(Cask::Download.new(Cask::Cask.new("codex"))))
-      .to eq(use_prefetched: true, skip_prefetch: false)
+      .to eq(use_prefetched: true, skip_prefetch: false, failed_formula_fetched: true)
   end
 
   def run_upgrade_with_failed_shared_prefetch(failed_download)
@@ -1248,6 +1256,11 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       version:           "0.118.0",
     )
     installer = Cask::Installer.allocate
+    failed_formula = formula("deno") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/deno-2.7.11.tar.gz"
+    end
+    FormulaInstaller.fetched << failed_formula
     allow(installer).to receive_messages(cask:, check_requirements: nil, downloader: failed_download,
                                          download_failed!: nil, download_failed?: false, enqueue_downloads: nil,
                                          enqueue_dependency_downloads: nil)
@@ -1285,6 +1298,7 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     allow(Homebrew.messages).to receive(:display_messages)
 
     cmd.run
+    upgraded[:failed_formula_fetched] = FormulaInstaller.fetched.include?(failed_formula)
     upgraded
   end
 

--- a/Library/Homebrew/test/download_queue_spec.rb
+++ b/Library/Homebrew/test/download_queue_spec.rb
@@ -183,6 +183,58 @@ RSpec.describe Homebrew::DownloadQueue do
     expect(Homebrew).not_to have_failed
   end
 
+  it "removes known-bad cached files for fatal checksum mismatches" do
+    cached_download.dirname.mkpath
+    cached_download.write("corrupt")
+    allow(retryable_download).to receive(:fetch)
+      .and_raise(ChecksumMismatchError.new(cached_download, Checksum.new("aa" * 32), Checksum.new("bb" * 32)))
+
+    download_queue.enqueue(downloadable)
+
+    expect { download_queue.fetch }.to output(/different checksum/).to_stderr
+    expect(cached_download).not_to exist
+    expect(download_queue.failed_downloads).to eq([downloadable])
+  end
+
+  it "reports every fatal checksum mismatch when downloads share a cached file" do
+    cached_download.dirname.mkpath
+    cached_download.write("corrupt")
+    shared_downloadable = instance_double(
+      Downloadable,
+      cached_download:,
+      checksum:                        nil,
+      downloaded_and_valid?:           false,
+      downloader:                      nil,
+      download_queue_message:          "API Source testball",
+      download_queue_name:             "testball",
+      download_queue_type:             "API Source",
+      staged_path_from_download_queue: nil,
+    )
+    allow(retryable_download).to receive(:fetch)
+      .and_raise(ChecksumMismatchError.new(cached_download, Checksum.new("aa" * 32), Checksum.new("bb" * 32)))
+
+    download_queue.enqueue(downloadable)
+    download_queue.enqueue(shared_downloadable)
+
+    expect { download_queue.fetch }.to output(/different checksum.*different checksum/m).to_stderr
+    expect(cached_download).not_to exist
+    expect(download_queue.failed_downloads).to contain_exactly(downloadable, shared_downloadable)
+  end
+
+  it "removes known-bad cached files for fatal checksum mismatches in serial mode" do
+    allow(Homebrew::EnvConfig).to receive(:download_concurrency).and_return(1)
+    cached_download.dirname.mkpath
+    cached_download.write("corrupt")
+    allow(retryable_download).to receive(:fetch)
+      .and_raise(ChecksumMismatchError.new(cached_download, Checksum.new("aa" * 32), Checksum.new("bb" * 32)))
+
+    download_queue.enqueue(downloadable)
+
+    expect { download_queue.fetch }.to output(/different checksum/).to_stderr
+    expect(cached_download).not_to exist
+    expect(download_queue.failed_downloads).to eq([downloadable])
+  end
+
   it "cancels remaining downloads and raises on a bottle manifest failure in serial mode" do
     allow(Homebrew::EnvConfig).to receive(:download_concurrency).and_return(1)
     allow(retryable_download).to receive(:fetch).and_raise(Resource::BottleManifest::Error.new("manifest missing"))

--- a/Library/Homebrew/test/downloadable_spec.rb
+++ b/Library/Homebrew/test/downloadable_spec.rb
@@ -51,4 +51,46 @@ RSpec.describe Downloadable::VerificationCache do
       end
     end
   end
+
+  it "reuses the digest of a file already hashed at its real path when verifying through a symlink" do
+    symlink = file.dirname/"digest-cache-symlink.tar.gz"
+    FileUtils.rm_f(symlink)
+    FileUtils.ln_s(file, symlink)
+    expect(Digest::SHA256).to receive(:file).once.and_call_original
+
+    cache.verify(file, checksum)
+    cache.verify(symlink, checksum)
+  end
+
+  it "hashes a file again after its remembered digest is invalidated" do
+    expect(Digest::SHA256).to receive(:file).twice.and_call_original
+
+    cache.sha256(file)
+    cache.invalidate!(file)
+    expect(cache.sha256(file)).to eq(checksum.hexdigest)
+  end
+
+  describe "::check_repeated_hashing" do
+    before do
+      ENV["HOMEBREW_CHECK_REPEATED_HASHING"] = "1"
+    end
+
+    it "raises when an unchanged file is rehashed without the cache being involved" do
+      file.sha256
+
+      expect { file.sha256 }.to raise_error(Downloadable::VerificationCache::RepeatedHashingError)
+    end
+
+    it "raises when a file already hashed through the cache is rehashed directly" do
+      cache.sha256(file)
+
+      expect { file.sha256 }.to raise_error(Downloadable::VerificationCache::RepeatedHashingError)
+    end
+
+    it "allows repeated digest reads through the cache" do
+      cache.sha256(file)
+
+      expect(cache.sha256(file)).to eq(checksum.hexdigest)
+    end
+  end
 end

--- a/Library/Homebrew/test/exceptions_spec.rb
+++ b/Library/Homebrew/test/exceptions_spec.rb
@@ -225,6 +225,7 @@ RSpec.describe "Exception" do
     let(:actual_checksum) { instance_double(Checksum, to_s: "deadcafe") }
 
     it(:to_s) { expect(error.to_s).to include("SHA-256 mismatch") }
+    it(:actual) { expect(error.actual).to eq(actual_checksum) }
 
     it "does not add an HTML hint for non-HTML downloads" do
       Tempfile.create("brew-checksum-test") do |file|

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -1503,6 +1503,10 @@ RSpec.describe FormulaInstaller do
         installer.prelude_fetch
       end
 
+      it "associates an API bottle with its formula" do
+        expect(installer.api_bottle&.resource&.owner).to eq(deno_formula)
+      end
+
       it "enqueues only the bottle manifest when fetching metadata" do
         expect(installer.download_queue).to receive(:enqueue).with(an_instance_of(Resource::BottleManifest))
 

--- a/Library/Homebrew/test/install_spec.rb
+++ b/Library/Homebrew/test/install_spec.rb
@@ -52,24 +52,60 @@ RSpec.describe Homebrew::Install do
     it "skips the formula whose download failed, keeps the rest and unmarks the failure as fetched" do
       bottle_spec = BottleSpecification.new
       bottle_spec.sha256(arm64_big_sur: "deadbeef" * 8)
-      failed_bottle = Bottle.new(nil, bottle_spec, Utils::Bottles::Tag.from_symbol(:arm64_big_sur),
-                                 name: "bad-bottle", pkg_version: PkgVersion.new(Version.new("1.0"), 0))
       bad_formula = formula("bad-bottle") do
         T.bind(self, T.class_of(Formula))
         url "foo-1.0"
       end
-      bad_fi = instance_double(FormulaInstaller, formula: bad_formula)
-      good_fi = instance_double(FormulaInstaller, formula: formula("good-bottle") do
+      good_formula = formula("good-bottle") do
         T.bind(self, T.class_of(Formula))
         url "foo-1.0"
-      end)
+      end
+      failed_bottle = Bottle.new(bad_formula, bottle_spec, Utils::Bottles::Tag.from_symbol(:arm64_big_sur))
+      bad_fi = instance_double(FormulaInstaller, formula: bad_formula)
+      good_fi = instance_double(FormulaInstaller, formula: good_formula)
       download_queue = instance_double(Homebrew::DownloadQueue, failed_downloads: [failed_bottle])
-      FormulaInstaller.fetched << bad_formula
+      FormulaInstaller.fetched.merge([bad_formula, good_formula])
 
       expect(described_class.reject_failed_downloads([bad_fi, good_fi], download_queue:)).to eq([good_fi])
-      # A retry pass must fetch the failed formula again rather than skip it
-      # as already fetched and install its known-bad cached download.
-      expect(FormulaInstaller.fetched).to be_empty
+      expect(FormulaInstaller.fetched).to contain_exactly(good_formula)
+    end
+
+    it "clears fetched state when an API source download fails" do
+      bad_formula = formula("bad-source") do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      good_formula = formula("good-source") do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      failed_download = Homebrew::API::SourceDownload.new(
+        "https://brew.sh/bad-source.rb",
+        Checksum.new("aa" * 32),
+        formula: bad_formula,
+      )
+      FormulaInstaller.fetched.merge([bad_formula, good_formula])
+
+      expect(described_class.unmark_failed_formulae([failed_download])).to eq([bad_formula.full_name])
+      expect(FormulaInstaller.fetched).to contain_exactly(good_formula)
+    end
+
+    it "does not clear a same-named formula from another tap" do
+      bad_formula = formula("shared-name") do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      other_formula = formula("shared-name", tap: Tap.fetch("other", "tap")) do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      failed_resource = bad_formula.resource
+      raise "formula resource unavailable" if failed_resource.nil?
+
+      FormulaInstaller.fetched.merge([bad_formula, other_formula])
+
+      expect(described_class.unmark_failed_formulae([failed_resource])).to eq([bad_formula.full_name])
+      expect(FormulaInstaller.fetched).to contain_exactly(other_formula)
     end
   end
 

--- a/Library/Homebrew/test/patching_spec.rb
+++ b/Library/Homebrew/test/patching_spec.rb
@@ -111,6 +111,26 @@ RSpec.describe "patching", type: :system do
     ).to be_patched
   end
 
+  specify "external_patch_dsl_rejects_unverified_cached_download" do
+    f = formula do
+      T.bind(self, T.class_of(Formula))
+      patch do
+        url "file://#{patch_fixture("noop-a")}"
+        sha256 "0" * 64
+      end
+    end
+    external_patch = f.stable.patches.last
+    external_patch.cached_download.dirname.mkpath
+    FileUtils.cp patch_fixture("noop-a"), external_patch.cached_download
+
+    expect do
+      f.brew(fetch: false) { |formula, _| formula.patch }
+    end.to raise_error(ChecksumMismatchError)
+    expect(external_patch.cached_download).not_to exist
+  ensure
+    external_patch&.clear_cache
+  end
+
   specify "local_patch_dsl_resolves_path_loaded_formulae_from_formula_directory" do
     expect(
       formula(path: fixture("testball.rb")) do

--- a/Library/Homebrew/test/resource_spec.rb
+++ b/Library/Homebrew/test/resource_spec.rb
@@ -240,6 +240,24 @@ RSpec.describe Resource do
       # a fresh copy instead of failing on the same file again.
       expect(resource.cached_download).not_to exist
     end
+
+    it "stages a cached download that matches its checksum" do
+      resource.downloader.fetch
+
+      expect { resource.stage(mktmpdir) }.not_to raise_error
+    end
+
+    it "does not verify the cached download when reusing an existing staging directory" do
+      resource.downloader.fetch
+
+      mktmpdir do |staging_path|
+        (staging_path/"source").mkpath
+        (staging_path/".source_modified_time").write(last_modified.to_i.to_s)
+        expect(resource).not_to receive(:verify_download_integrity)
+
+        resource.stage(staging_path:, staged: true) { nil }
+      end
+    end
   end
 
   describe "#owner" do

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -99,18 +99,21 @@ module Test
         env["HOMEBREW_AVOID_NESTED_SANDBOXING"] = "1"
         env["HOMEBREW_INTEGRATION_COVERAGE_DIR"] = ENV.fetch("HOMEBREW_INTEGRATION_COVERAGE_DIR", nil)
         env.merge!(
-          "PATH"                         => path,
-          "HOMEBREW_PATH"                => path,
-          "HOMEBREW_BREW_FILE"           => HOMEBREW_PREFIX/"bin/brew",
-          "HOMEBREW_INTEGRATION_TEST"    => command_id,
-          "HOMEBREW_TEST_TMPDIR"         => TEST_TMPDIR,
-          "HOMEBREW_DEV_CMD_RUN"         => "true",
-          "HOMEBREW_ASK"                 => nil,
-          "HOMEBREW_USE_RUBY_FROM_PATH"  => ENV.fetch("HOMEBREW_USE_RUBY_FROM_PATH", nil),
-          "HOMEBREW_NO_INSTALL_FROM_API" => ENV.fetch("HOMEBREW_NO_INSTALL_FROM_API", nil),
-          "HOMEBREW_SORBET_RUNTIME"      => nil,
-          "HOMEBREW_SORBET_RECURSIVE"    => nil,
-          "GEM_HOME"                     => nil,
+          "PATH"                            => path,
+          "HOMEBREW_PATH"                   => path,
+          "HOMEBREW_BREW_FILE"              => HOMEBREW_PREFIX/"bin/brew",
+          "HOMEBREW_INTEGRATION_TEST"       => command_id,
+          # Fail on repeated hashing of unchanged files that bypasses
+          # `Downloadable::VerificationCache`.
+          "HOMEBREW_CHECK_REPEATED_HASHING" => "1",
+          "HOMEBREW_TEST_TMPDIR"            => TEST_TMPDIR,
+          "HOMEBREW_DEV_CMD_RUN"            => "true",
+          "HOMEBREW_ASK"                    => nil,
+          "HOMEBREW_USE_RUBY_FROM_PATH"     => ENV.fetch("HOMEBREW_USE_RUBY_FROM_PATH", nil),
+          "HOMEBREW_NO_INSTALL_FROM_API"    => ENV.fetch("HOMEBREW_NO_INSTALL_FROM_API", nil),
+          "HOMEBREW_SORBET_RUNTIME"         => nil,
+          "HOMEBREW_SORBET_RECURSIVE"       => nil,
+          "GEM_HOME"                        => nil,
         )
 
         @ruby_args ||= begin


### PR DESCRIPTION
Follow-up to #23717, which fixed the `brew upgrade` retry lifecycle reported in #23714. Cached bytes were still trusted at several of the points where they are actually consumed.

Checksum-bearing bytes are now verified at each consumption boundary rather than only on fetch: API formula Ruby before `Formulary.factory` evaluates it, formula source and resources before unpacking, external patches before they are applied, and bottles before both direct and queued extraction. Each boundary removes the known-bad file so the next attempt refetches. Failed formula downloads are unmarked as fetched by tap-qualified `full_name`, leaving a same-named formula from another tap alone.

`Bottle#stage` no longer skips verification for immutable GitHub Packages blobs: `downloaded_and_valid?` only compares the digest in the blob's name, which is enough to skip a download but says nothing about its contents. This costs one SHA-256 pass over a bottle cached by an earlier run; one downloaded in the same run is already verified during the fetch.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the fix and pass with it, ran `brew lgtm` + targeted specs, and put the change through a Daybreak Blue security review.

-----
