### PR TITLE
Harden unsigned API, trust, installer and output boundaries

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -29,6 +29,9 @@ module Homebrew
     HOMEBREW_CACHE_API = T.let((HOMEBREW_CACHE/"api").freeze, Pathname)
     HOMEBREW_CACHE_API_SOURCE = T.let((HOMEBREW_CACHE/"api-source").freeze, Pathname)
     DEFAULT_API_STALE_SECONDS = T.let(7 * 24 * 60 * 60, Integer) # 7 days
+    # Revalidate unsigned per-resource responses hourly to limit how long a
+    # poisoned cache can persist without requiring a request for every command.
+    UNSIGNED_API_STALE_SECONDS = T.let(60 * 60, Integer)
 
     sig { params(endpoint: String).returns(T::Hash[String, T.untyped]) }
     def self.fetch(endpoint)

--- a/Library/Homebrew/api/cask.rb
+++ b/Library/Homebrew/api/cask.rb
@@ -28,7 +28,8 @@ module Homebrew
       sig { params(name: String).void }
       def self.fetch_cask_json!(name)
         endpoint = "cask/#{name}.json"
-        json_cask, updated = Homebrew::API.fetch_json_api_file endpoint
+        json_cask, updated = Homebrew::API.fetch_json_api_file endpoint,
+                                                               stale_seconds: Homebrew::API::UNSIGNED_API_STALE_SECONDS
 
         json_cask = JSON.parse((HOMEBREW_CACHE_API/endpoint).read) unless updated
 

--- a/Library/Homebrew/api/cask/cask_struct_generator.rb
+++ b/Library/Homebrew/api/cask/cask_struct_generator.rb
@@ -6,6 +6,9 @@ module Homebrew
     module Cask
       # Methods for generating CaskStruct instances from API data.
       module CaskStructGenerator
+        include ::Utils::Output::Mixin
+        extend ::Utils::Output::Mixin
+
         module_function
 
         # NOTE: this will be used to load installed cask JSON files,
@@ -144,8 +147,16 @@ module Homebrew
 
         sig { params(artifacts: T::Array[T::Hash[Symbol, T.untyped]]).returns(T::Array[CaskStruct::ArtifactArgs]) }
         def process_artifacts(artifacts)
-          artifacts.map do |artifact|
-            key = T.must(artifact.keys.find { |artifact_key| artifact_key != :target })
+          artifacts.filter_map do |artifact|
+            key = artifact.keys.find { |artifact_key| artifact_key != :target }
+            if key.nil?
+              odebug "Ignoring cask artifact without a stanza key: #{artifact.keys.inspect}"
+              next
+            end
+            unless ::Cask::DSL::ARTIFACT_DSL_METHODS.include?(key)
+              odebug "Ignoring unsupported cask artifact stanza: #{key}"
+              next
+            end
 
             # Pass an empty block to artifacts like postflight that can't be loaded from the API,
             # but need to be set to something.

--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -29,7 +29,8 @@ module Homebrew
       sig { params(name: String).void }
       def self.fetch_formula_json!(name)
         endpoint = "formula/#{name}.json"
-        json_formula, updated = Homebrew::API.fetch_json_api_file endpoint
+        json_formula, updated = Homebrew::API.fetch_json_api_file endpoint,
+                                                                  stale_seconds: Homebrew::API::UNSIGNED_API_STALE_SECONDS
 
         json_formula = JSON.parse((HOMEBREW_CACHE_API/endpoint).read) unless updated
 

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -563,7 +563,12 @@ module Cask
           end
 
           localised_cask_struct.artifacts(appdir:).each do |key, args, kwargs, block|
-            send(key, *args, **kwargs, &block)
+            unless DSL::ARTIFACT_DSL_METHODS.include?(key)
+              odebug "Ignoring unsupported artifact stanza '#{key}' in cask '#{token}'"
+              next
+            end
+
+            public_send(key, *args, **kwargs, &block)
           end
 
           caveats T.must(localised_cask_struct.caveats(appdir:)) if localised_cask_struct.caveats?

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -87,6 +87,12 @@ module Cask
       Artifact::UninstallPostflightSteps,
     ].freeze
 
+    ARTIFACT_DSL_METHODS = T.let(Set.new([
+      *ORDINARY_ARTIFACT_CLASSES.map(&:dsl_key),
+      *ARTIFACT_BLOCK_CLASSES.flat_map { |klass| [klass.dsl_key, klass.uninstall_dsl_key] },
+      *INSTALL_STEP_ARTIFACT_CLASSES.map(&:dsl_key),
+    ]).freeze, T::Set[Symbol])
+
     DSL_METHODS = T.let(Set.new([
       :arch,
       :artifacts,
@@ -130,10 +136,7 @@ module Cask
       :on_os_blocks_exist?,
       :on_system_block_min_os,
       :depends_on_set_in_block?,
-      *ORDINARY_ARTIFACT_CLASSES.map(&:dsl_key),
-      *ACTIVATABLE_ARTIFACT_CLASSES.map(&:dsl_key),
-      *ARTIFACT_BLOCK_CLASSES.flat_map { |klass| [klass.dsl_key, klass.uninstall_dsl_key] },
-      *INSTALL_STEP_ARTIFACT_CLASSES.map(&:dsl_key),
+      *ARTIFACT_DSL_METHODS,
     ]).freeze, T::Set[Symbol])
 
     include OnSystem::MacOSAndLinux

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -674,12 +674,17 @@ module Homebrew
       else
         []
       end
+      api_resource_files = %w[cask formula].flat_map do |resource_type|
+        directory = cache/"api"/resource_type
+        directory.directory? ? directory.children : []
+      end
       api_source_files = (cache/"api-source").glob("*/*/*/**/*").select { |path| path.file? || path.symlink? }
       gh_actions_artifacts = (cache/"gh-actions-artifact").directory? ? (cache/"gh-actions-artifact").children : []
 
       cache_entries(files, type: nil) +
         cache_entries(cask_files, type: :cask) +
         cache_entries(api_package_files, type: :api_package) +
+        cache_entries(api_resource_files, type: :api_package) +
         cache_entries(api_source_files, type: :api_source) +
         cache_entries(gh_actions_artifacts, type: :gh_actions_artifact)
     end

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -491,20 +491,23 @@ module Homebrew
     sig { params(info: T::Hash[Symbol, T.untyped], verbose: T::Boolean, ambiguous_cask: T::Boolean).void }
     private_class_method def self.print_latest_version(info, verbose: false, ambiguous_cask: false)
       package_or_resource_s = info[:resource].present? ? "  " : ""
-      package_or_resource_s += "#{Tty.blue}#{info[:formula] || info[:cask] || info[:resource]}#{Tty.reset}"
+      package_or_resource = Tty.strip_ansi((info[:formula] || info[:cask] || info[:resource]).to_s)
+      package_or_resource_s += "#{Tty.blue}#{package_or_resource}#{Tty.reset}"
       package_or_resource_s += " (cask)" if ambiguous_cask
       package_or_resource_s += " (guessed)" if verbose && !info[:meta][:livecheck_defined]
 
+      current = Tty.strip_ansi(info[:version][:current].to_s)
       current_s = if info[:version][:newer_than_upstream]
-        "#{Tty.red}#{info[:version][:current]}#{Tty.reset}"
+        "#{Tty.red}#{current}#{Tty.reset}"
       else
-        info[:version][:current]
+        current
       end
 
+      latest = Tty.strip_ansi(info[:version][:latest].to_s)
       latest_s = if info[:version][:outdated]
-        "#{Tty.green}#{info[:version][:latest]}#{Tty.reset}"
+        "#{Tty.green}#{latest}#{Tty.reset}"
       else
-        info[:version][:latest]
+        latest
       end
 
       puts "#{package_or_resource_s}: #{current_s} ==> #{latest_s}"
@@ -792,10 +795,10 @@ module Homebrew
 
           if verbose
             match_version_map.each do |match, version|
-              puts "#{match} => #{version.inspect}"
+              puts Tty.strip_ansi("#{match} => #{version.inspect}")
             end
           else
-            puts match_version_map.values.join(", ")
+            puts Tty.strip_ansi(match_version_map.values.join(", "))
           end
         end
 
@@ -829,14 +832,14 @@ module Homebrew
 
             if verbose
               throttled_match_version_map.each do |match, version|
-                puts "#{match} => #{version.inspect}"
+                puts Tty.strip_ansi("#{match} => #{version.inspect}")
               end
             elsif throttled_match_version_map.present?
-              puts throttled_match_version_map.values.join(", ")
+              puts Tty.strip_ansi(throttled_match_version_map.values.join(", "))
             end
 
             if version_info[:latest_throttled] == version_info[:latest] && throttled_match_version_map.blank?
-              puts "#{version_info[:latest_throttled]} (throttle interval elapsed)"
+              puts Tty.strip_ansi("#{version_info[:latest_throttled]} (throttle interval elapsed)")
             end
           end
         end
@@ -1049,10 +1052,10 @@ module Homebrew
 
           if verbose
             match_version_map.each do |match, version|
-              puts "#{match} => #{version.inspect}"
+              puts Tty.strip_ansi("#{match} => #{version.inspect}")
             end
           else
-            puts match_version_map.values.join(", ")
+            puts Tty.strip_ansi(match_version_map.values.join(", "))
           end
         end
 

--- a/Library/Homebrew/test/api/cask/cask_struct_generator_spec.rb
+++ b/Library/Homebrew/test/api/cask/cask_struct_generator_spec.rb
@@ -45,9 +45,9 @@ RSpec.describe Homebrew::API::Cask::CaskStructGenerator do
   specify "::process_artifacts" do
     input = [
       { preflight: nil },
-      { foo:       ["arg1", "arg2"] },
-      { bar:       ["arg1", "arg2", { kwarg1: "value1" }] },
-      { baz:       [{ kwarg1: "value1" }] },
+      { pkg:        ["arg1", "arg2"] },
+      { uninstall:  ["arg1", "arg2", { kwarg1: "value1" }] },
+      { stage_only: [{ kwarg1: "value1" }] },
       {
         target:         "$HOMEBREW_PREFIX/share/zsh/site-functions/_foo",
         zsh_completion: ["$APPDIR/Foo.app/Contents/Resources/completions/zsh/_foo"],
@@ -63,15 +63,28 @@ RSpec.describe Homebrew::API::Cask::CaskStructGenerator do
     ]
     expected_output = [
       [:preflight, [], {}, Homebrew::API::CaskStruct::EMPTY_BLOCK],
-      [:foo, ["arg1", "arg2"], {}, nil],
-      [:bar, ["arg1", "arg2"], { kwarg1: "value1" }, nil],
-      [:baz, [], { kwarg1: "value1" }, nil],
+      [:pkg, ["arg1", "arg2"], {}, nil],
+      [:uninstall, ["arg1", "arg2"], { kwarg1: "value1" }, nil],
+      [:stage_only, [], { kwarg1: "value1" }, nil],
       [:zsh_completion, ["$APPDIR/Foo.app/Contents/Resources/completions/zsh/_foo"], {}, nil],
       [:zsh_completion, ["$APPDIR/Bar.app/Contents/Resources/completions/zsh/_bar"], {}, nil],
       [:app, ["Foo.app"], { target: "Bar.app" }, nil],
     ]
     output = described_class.process_artifacts(input)
     expect(output).to eq expected_output
+  end
+
+  it "rejects unknown artifact keys" do
+    input = [
+      { system: ["/usr/bin/true"] },
+      { instance_eval: ["raise 'unexpected dispatch'"] },
+    ]
+
+    expect(described_class.process_artifacts(input)).to be_empty
+  end
+
+  it "rejects artifacts without a DSL key" do
+    expect(described_class.process_artifacts([{ target: "/Applications/Foo.app" }])).to be_empty
   end
 
   specify "::process_url_specs" do

--- a/Library/Homebrew/test/api/cask_spec.rb
+++ b/Library/Homebrew/test/api/cask_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Homebrew::API::Cask do
 
   before do
     stub_const("Homebrew::API::HOMEBREW_CACHE_API", cache_dir)
+    described_class.clear_cache
   end
 
   def mock_curl_download(stdout:)
@@ -42,6 +43,18 @@ RSpec.describe Homebrew::API::Cask do
       mock_curl_download stdout: casks_json
       casks_output = described_class.all_casks
       expect(casks_output).to eq casks_hash
+    end
+  end
+
+  describe "::cask_json" do
+    it "revalidates a stale per-cask response" do
+      target = cache_dir/"cask/foo.json"
+      target.dirname.mkpath
+      target.write('{"version":"old"}')
+      FileUtils.touch(target, mtime: Time.now - (2 * 60 * 60))
+      mock_curl_download stdout: '{"version":"new"}'
+
+      expect(described_class.cask_json("foo")).to eq("version" => "new")
     end
   end
 end

--- a/Library/Homebrew/test/api/formula_spec.rb
+++ b/Library/Homebrew/test/api/formula_spec.rb
@@ -126,6 +126,18 @@ RSpec.describe Homebrew::API::Formula do
     end
   end
 
+  describe "::formula_json" do
+    it "revalidates a stale per-formula response" do
+      target = cache_dir/"formula/foo.json"
+      target.dirname.mkpath
+      target.write('{"versions":{"stable":"old"}}')
+      FileUtils.touch(target, mtime: Time.now - (2 * 60 * 60))
+      mock_curl_download stdout: '{"versions":{"stable":"new"}}'
+
+      expect(described_class.formula_json("foo")).to eq("versions" => { "stable" => "new" })
+    end
+  end
+
   describe "::source_download" do
     let(:f) { Testball.new }
 

--- a/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
@@ -181,6 +181,54 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
   end
 
   describe "#load" do
+    it "does not dispatch unknown raw artifacts" do
+      marker = mktmpdir/"unexpected-dispatch"
+      cask_struct = Homebrew::API::CaskStruct.new(
+        version:       "1.0",
+        sha256:        "0" * 64,
+        url_args:      ["https://example.invalid/unknown-raw-artifact.zip"],
+        raw_artifacts: [[:instance_eval, ["FileUtils.touch(#{marker.to_s.dump})"], {}, nil]],
+      )
+      loader = described_class.new(
+        "unknown-raw-artifact",
+        from_json:          cask_struct.serialize,
+        from_internal_json: true,
+      )
+
+      expect { loader.load(config: nil) }.not_to change(marker, :exist?).from(false)
+    end
+
+    it "preserves supported stage-only, package, and uninstall artifacts" do
+      base_source = {
+        "token"   => "supported-artifacts",
+        "version" => "1.0",
+        "sha256"  => "0" * 64,
+        "url"     => "https://example.invalid/supported-artifacts.zip",
+      }
+      stage_only_cask = described_class.new(
+        "supported-stage-only",
+        from_json:               base_source.merge("artifacts" => [{ "stage_only" => [true] }]),
+        path:                    Pathname("/tmp/supported-stage-only.json"),
+        from_installed_caskfile: true,
+      ).load(config: nil)
+      pkg_cask = described_class.new(
+        "supported-pkg",
+        from_json:               base_source.merge(
+          "artifacts" => [
+            { "pkg" => ["Test.pkg"] },
+            { "uninstall" => [{ "pkgutil" => "com.example.test" }] },
+          ],
+        ),
+        path:                    Pathname("/tmp/supported-pkg.json"),
+        from_installed_caskfile: true,
+      ).load(config: nil)
+
+      expect([stage_only_cask.artifacts_list, pkg_cask.artifacts_list]).to eq([
+        [{ stage_only: [true] }],
+        [{ uninstall: [{ pkgutil: "com.example.test" }] }, { pkg: ["Test.pkg"] }],
+      ])
+    end
+
     it "handles greedy outdated checks for installed metadata without a URL" do
       token = "url-less-installed-cask"
       caskroom = mktmpdir

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -721,6 +721,32 @@ RSpec.describe Homebrew::Cleanup do
       expect(api_package_files.map(&:exist?)).to eq([true, true])
     end
 
+    it "cleans up per-resource API files when pruning" do
+      cache = mktmpdir/"cache"
+      api_resource_files = [cache/"api/cask/foo.json", cache/"api/formula/foo.json"]
+      api_resource_files.each do |file|
+        file.dirname.mkpath
+        FileUtils.touch file
+      end
+
+      described_class.new(days: 0, cache:).cleanup_cache
+
+      expect(api_resource_files.map(&:exist?)).to eq([false, false])
+    end
+
+    it "cleans up per-resource API files with scrub" do
+      cache = mktmpdir/"cache"
+      api_resource_files = [cache/"api/cask/foo.json", cache/"api/formula/foo.json"]
+      api_resource_files.each do |file|
+        file.dirname.mkpath
+        FileUtils.touch file
+      end
+
+      described_class.new(scrub: true, cache:).cleanup_cache
+
+      expect(api_resource_files.map(&:exist?)).to eq([false, false])
+    end
+
     it "cleans up non-current internal package API files with scrub" do
       cache = mktmpdir/"cache"
       api_internal = cache/"api/internal"

--- a/Library/Homebrew/test/livecheck/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_spec.rb
@@ -454,6 +454,50 @@ RSpec.describe Homebrew::Livecheck do
       HTML
     end
 
+    context "with terminal control characters" do
+      let(:terminal_control_version) { "0.0.2\e]0;changed-title\a" }
+      let(:f_terminal_control_version) do
+        formula("terminal_control_version") do
+          T.bind(self, T.class_of(Formula))
+          desc "Formula with terminal controls in an upstream version"
+          url "https://brew.sh/terminal-control-version-0.0.1.tgz"
+
+          livecheck do
+            url :stable
+            regex(/terminal-control-version-(.+)\.tgz/i)
+          end
+        end
+      end
+
+      before do
+        allow(Homebrew::Livecheck::Strategy).to receive(:page_content).and_return({
+          content: %Q(<a href="terminal-control-version-#{terminal_control_version}.tgz">Download</a>),
+        })
+      end
+
+      it "renders upstream terminal controls inert in human-readable output" do
+        expect { livecheck.run_checks([f_terminal_control_version], debug: true, verbose: true) }
+          .not_to output(/[\e\a\r]/).to_stdout
+      end
+
+      it "preserves upstream control characters as JSON data" do
+        expected = JSON.pretty_generate([
+          {
+            formula: "terminal_control_version",
+            version: {
+              current:             "0.0.1",
+              latest:              terminal_control_version,
+              outdated:            true,
+              newer_than_upstream: false,
+            },
+          },
+        ])
+
+        expect { livecheck.run_checks([f_terminal_control_version], json: true) }
+          .to output("#{expected}\n").to_stdout
+      end
+    end
+
     it "sets `latest_throttled` to the highest throttled version" do
       allow(Homebrew::Livecheck::Strategy).to receive(:page_content).and_return({
         content: <<~HTML,

--- a/Library/Homebrew/test/trust_spec.rb
+++ b/Library/Homebrew/test/trust_spec.rb
@@ -420,6 +420,75 @@ RSpec.describe Homebrew::Trust, :trust_store do
     FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
   end
 
+  it "requires trust for a symlink outside the tap directory that resolves into an untrusted tap" do
+    tap = Tap.fetch("thirdparty", "linked-source")
+    formula_path = tap.formula_dir/"linked-formula.rb"
+    formula_path.dirname.mkpath
+    formula_path.write("class LinkedFormula < Formula; end\n")
+    linked_path = Pathname(TEST_TMPDIR)/"linked-formula.rb"
+    FileUtils.ln_s formula_path, linked_path
+
+    with_env(HOMEBREW_REQUIRE_TAP_TRUST: "1") do
+      expect { described_class.require_trusted_formula!("linked-formula", linked_path) }
+        .to raise_error(Homebrew::UntrustedTapError)
+    end
+  ensure
+    FileUtils.rm_f linked_path if linked_path
+    FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+  end
+
+  it "uses the canonical tap identity when a symlink crosses between taps" do
+    trusted_tap = Tap.fetch("thirdparty", "trusted-links")
+    untrusted_tap = Tap.fetch("thirdparty", "untrusted-targets")
+    target_path = untrusted_tap.formula_dir/"linked-formula.rb"
+    target_path.dirname.mkpath
+    target_path.write("class LinkedFormula < Formula; end\n")
+    linked_path = trusted_tap.formula_dir/"linked-formula.rb"
+    linked_path.dirname.mkpath
+    FileUtils.ln_s target_path, linked_path
+    described_class.trust!(:tap, trusted_tap)
+
+    with_env(HOMEBREW_REQUIRE_TAP_TRUST: "1") do
+      expect { described_class.require_trusted_formula!("linked-formula", linked_path) }
+        .to raise_error(Homebrew::UntrustedTapError)
+    end
+  ensure
+    described_class.clear!(:tap)
+    FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+  end
+
+  it "preserves the nominal tap identity for a symlinked whole-tap root" do
+    tap = Tap.fetch("thirdparty", "linked-root")
+    real_tap_path = mktmpdir/"linked-root"
+    (real_tap_path/"Formula").mkpath
+    tap.path.parent.mkpath
+    FileUtils.ln_s real_tap_path, tap.path
+    formula_path = tap.formula_dir/"linked-formula.rb"
+    formula_path.write("class LinkedFormula < Formula; end\n")
+    described_class.trust!(:tap, tap)
+
+    with_env(HOMEBREW_REQUIRE_TAP_TRUST: "1") do
+      expect { described_class.require_trusted_formula!("linked-formula", formula_path) }.not_to raise_error
+    end
+  ensure
+    described_class.clear!(:tap)
+    FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+  end
+
+  it "falls back to the nominal tap identity for a symlink loop" do
+    tap = Tap.fetch("thirdparty", "looping-link")
+    formula_path = tap.formula_dir/"looping-formula.rb"
+    formula_path.dirname.mkpath
+    FileUtils.ln_s formula_path.basename, formula_path
+
+    with_env(HOMEBREW_REQUIRE_TAP_TRUST: "1") do
+      expect { described_class.require_trusted_formula!("looping-formula", formula_path) }
+        .to raise_error(Homebrew::UntrustedTapError)
+    end
+  ensure
+    FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+  end
+
   it "reads the invoking user's trust store for sudoed services" do
     root_home = Pathname(TEST_TMPDIR)/"root-home"
     sudo_home = Pathname(TEST_TMPDIR)/"sudo-home"

--- a/Library/Homebrew/test/utils/tty_spec.rb
+++ b/Library/Homebrew/test/utils/tty_spec.rb
@@ -6,6 +6,29 @@ RSpec.describe Tty do
     it "removes ANSI escape codes from a string" do
       expect(described_class.strip_ansi("\033[36;7mhello\033[0m")).to eq("hello")
     end
+
+    it "removes terminal control strings, C1 controls, bells, and carriage returns" do
+      string = [
+        "\e[31mred\e[0m",
+        "\e]0;title\a",
+        "\ePdevice-control\e\\",
+        "\e_application-command\e\\",
+        "\e^privacy-message\e\\",
+        "\u009B31mC1 red\u009B0m",
+        "\u009Dtitle\u009C",
+        "bell\a carriage\rreturn",
+        "lone escape\e",
+      ].join(" ")
+
+      expect(described_class.strip_ansi(string)).to eq("red     C1 red  bell carriagereturn lone escape")
+    end
+
+    it "sanitises binary strings without changing their encoding" do
+      string = "A\xFF\e[31mB".b
+      sanitised = described_class.strip_ansi(string)
+
+      expect([sanitised, sanitised.encoding]).to eq(["A\xFFB".b, Encoding::ASCII_8BIT])
+    end
   end
 
   describe "::collapse_carriage_returns" do

--- a/Library/Homebrew/trust.rb
+++ b/Library/Homebrew/trust.rb
@@ -545,6 +545,8 @@ module Homebrew
 
     sig { params(path: Pathname).returns(T.nilable(Tap)) }
     def self.tap_from_path(path)
+      Tap.from_path(path.realpath) || Tap.from_path(path)
+    rescue SystemCallError
       Tap.from_path(path)
     end
     private_class_method :tap_from_path

--- a/Library/Homebrew/utils/tty.rb
+++ b/Library/Homebrew/utils/tty.rb
@@ -44,6 +44,28 @@ module Tty
 
   CODES = T.let(COLOR_CODES.merge(STYLE_CODES).freeze, T::Hash[Symbol, Integer])
 
+  TERMINAL_CONTROL_SEQUENCE = %r{
+      (?:\e\]|\u009D).*?(?:\a|\e\\|\u009C|\z) |
+      (?:\e[P^_X]|\u0090|\u0098|\u009E|\u009F).*?(?:\e\\|\u009C|\z) |
+      (?:\e\[|\u009B)[0-?]*[\x20-/]*[@-~] |
+      \e[\x20-/]*[@-~] |
+      \e |
+      [\u0080-\u009F] |
+      [\a\r]
+    }mx
+  private_constant :TERMINAL_CONTROL_SEQUENCE
+
+  BINARY_TERMINAL_CONTROL_SEQUENCE = /
+      (?:\x1B\]|\x9D).*?(?:\x07|\x1B\\|\x9C|\z) |
+      (?:\x1B[P^_X]|\x90|\x98|\x9E|\x9F).*?(?:\x1B\\|\x9C|\z) |
+      (?:\x1B\[|\x9B)[0-?]*[\x20-\x2F]*[@-~] |
+      \x1B[\x20-\x2F]*[@-~] |
+      \x1B |
+      [\x80-\x9F] |
+      [\x07\r]
+    /mnx
+  private_constant :BINARY_TERMINAL_CONTROL_SEQUENCE
+
   class << self
     sig { params(stream: T.any(IO, StringIO), _block: T.proc.params(arg0: T.any(IO, StringIO)).void).void }
     def with(stream, &_block)
@@ -57,7 +79,11 @@ module Tty
 
     sig { params(string: String).returns(String) }
     def strip_ansi(string)
-      string.gsub(/\033\[\d+(;\d+)*m/, "")
+      if string.ascii_only? || (string.encoding == Encoding::UTF_8 && string.valid_encoding?)
+        string.gsub(TERMINAL_CONTROL_SEQUENCE, "")
+      else
+        string.b.gsub(BINARY_TERMINAL_CONTROL_SEQUENCE, "".b).force_encoding(string.encoding)
+      end
     end
 
     # Simulates a terminal rendering `\r` overwrites (e.g. curl's `--progress-bar`).

--- a/package/scripts/postinstall
+++ b/package/scripts/postinstall
@@ -80,8 +80,47 @@ then
   cd /usr/local
 fi
 
+refuse_symlinked_directories() {
+  for dir in Caskroom Cellar Frameworks bin etc include lib opt sbin share var var/homebrew var/homebrew/linked
+  do
+    if [[ -L "${dir}" ]]
+    then
+      echo "Refusing to operate on symlinked ${dir} in ${homebrew_directory}." >&2
+      exit 1
+    fi
+  done
+}
+
+enter_managed_directory() {
+  local directory="$1"
+  local expected_path="$2"
+  local display_path="$3"
+
+  if [[ -L "${directory}" ]]
+  then
+    echo "Refusing to operate on symlinked ${display_path} in ${homebrew_directory}." >&2
+    exit 1
+  fi
+
+  cd -P "${directory}"
+  if [[ "$(pwd -P)" != "${expected_path}" ]]
+  then
+    echo "Refusing to operate on ${display_path} outside ${homebrew_directory}." >&2
+    exit 1
+  fi
+}
+
+prefix_directory="$(pwd -P)"
+
 # create missing directories
-mkdir -vp Caskroom Cellar Frameworks etc include lib opt sbin share var/homebrew/linked
+refuse_symlinked_directories
+mkdir -vp Caskroom Cellar Frameworks etc include lib opt sbin share var
+(
+  enter_managed_directory var "${prefix_directory}/var" var
+  mkdir -vp homebrew
+  enter_managed_directory homebrew "${prefix_directory}/var/homebrew" var/homebrew
+  mkdir -vp linked
+)
 
 # optionally define an install user at /var/tmp/.homebrew_pkg_user.plist
 # otherwise, get valid logged in user
@@ -92,7 +131,15 @@ homebrew_pkg_user="$(homebrew-package-user)" ||
   }
 
 # set permissions
-chmod ug=rwx Caskroom Cellar Frameworks bin etc include lib opt sbin share var var/homebrew var/homebrew/linked
+refuse_symlinked_directories
+chmod -h ug=rwx Caskroom Cellar Frameworks bin etc include lib opt sbin share var
+(
+  enter_managed_directory var "${prefix_directory}/var" var
+  enter_managed_directory homebrew "${prefix_directory}/var/homebrew" var/homebrew
+  chmod ug=rwx .
+  enter_managed_directory linked "${prefix_directory}/var/homebrew/linked" var/homebrew/linked
+  chmod ug=rwx .
+)
 if [[ "${homebrew_directory}" == "/usr/local/Homebrew" ]]
 then
   chown -h "${homebrew_pkg_user}:admin" bin bin/brew etc include lib opt sbin share var


### PR DESCRIPTION
Five places where unsigned or upstream-controlled data reached a privileged operation without a boundary check. They share a shape worth fixing together: metadata we do not control deciding what code runs, what gets cached, or what the terminal renders. Each is fixed at the sink rather than the caller, so an alternate loader or a changed call path cannot bypass it, and each has regression coverage.

- Cask artifact dispatch used `send` with a key taken from unsigned per-cask JSON, so any method on the DSL object, including private `Kernel` methods, could be selected. The API struct generator and the loader now each check a `Cask::DSL::ARTIFACT_DSL_METHODS` allowlist, and the loader uses `public_send`.
- Per-resource `api/cask/*.json` and `api/formula/*.json` are unsigned and were cached forever. They now revalidate hourly through the existing conditional-request path, and `brew cleanup` enumerates them like the other API package files.
- `Homebrew::Trust` identified taps lexically, so a symlink from a trusted tap into an untrusted one was attributed to the trusted tap. It now prefers the canonical path, falling back to lexical on any `SystemCallError` so a symlinked tap root still resolves.
- `package/scripts/postinstall` created and chmodded `var/homebrew/linked` by name, so substituting a component could redirect root's `chmod` outside the prefix. It now refuses symlinked managed directories, enters each level with `cd -P` and verifies `pwd -P` before operating on `.`, and uses `chmod -h`.
- `Tty.strip_ansi` removed only SGR sequences, so upstream version strings in `brew livecheck` carried CSI, OSC and DCS straight to the terminal. It now also neutralizes C1 controls, BEL, carriage returns, lone escapes and unterminated control strings across UTF-8, ASCII and binary input without changing the returned encoding. JSON output is left alone and stays byte-identical.

An earlier revision of this branch also hardened download redirect handling. That work is split out and will come separately: refusing redirects at the transfer with `--max-redirs 0` broke every bottle download, because ghcr.io answers `HEAD` on a blob with `200` and only redirects on `GET`, so a `HEAD` preflight cannot see the redirect the real request will follow. Nothing under `download_strategy/` or `utils/curl.rb` is touched here.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

OpenAI Daybreak Blue found the issues and drafted the implementation and tests; Claude Code (Opus 5) reviewed the diff adversarially, which is how the redirect work came to be split out. I revalidated the rest, verified each new test fails without its fix and passes with it, and ran `brew lgtm` plus the targeted API, cask loader, trust, cleanup, livecheck and TTY specs.

-----
