### PR TITLE
Target Intel Clang under Rosetta

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -304,6 +304,13 @@ class Cmd
 
     return args if !refurbish_args? && !configure?
 
+    # Apple Clang on macOS 26 can default to arm64 on Apple Silicon even
+    # when Homebrew runs under Rosetta 2, making Intel-only optimisation
+    # flags such as `-march=westmere` invalid.
+    if mac? && ["clang", "clang++"].include?(tool) &&
+       ENV.values_at("HOMEBREW_PROCESSOR", "HOMEBREW_PHYSICAL_PROCESSOR") == ["Intel", "arm64"]
+      args << "-arch" << "x86_64"
+    end
     args << "-w" unless configure?
     args << "-#{ENV["HOMEBREW_OPTIMIZATION_LEVEL"]}"
     optflags.each do |optflag|

--- a/Library/Homebrew/test/shims/super/cc_spec.rb
+++ b/Library/Homebrew/test/shims/super/cc_spec.rb
@@ -80,6 +80,20 @@ RSpec.describe CcShim::Cmd do
     described_class.new("gcc", argv).args
   end
 
+  it "targets x86_64 with Apple Clang under Rosetta 2" do
+    setup_env(real_prefix)
+    ENV["HOMEBREW_CC"] = "clang"
+    ENV["HOMEBREW_OPTFLAGS"] = "-march=westmere"
+    ENV["HOMEBREW_PROCESSOR"] = "Intel"
+    ENV["HOMEBREW_PHYSICAL_PROCESSOR"] = "arm64"
+
+    command = described_class.new("clang", ["-c", "test.c"])
+    allow(command).to receive(:mac?).and_return(true)
+
+    expect(command.args)
+      .to include("-arch", "x86_64", "-march=westmere")
+  end
+
   context "when no path component of the prefix is a symlink" do
     it "keeps the prefix, declared dependencies and references to self" do
       expect(include_flags(real_prefix)).to include(


### PR DESCRIPTION
- Apple Clang on macOS 26 can select its native arm64 target even while Intel Homebrew runs under Rosetta 2. Superenv then combines that target with `-march=westmere`, which Clang rejects.
- Detect the translated process using Homebrew's logical and physical processor values.
- Pass `-arch x86_64` only to Apple `clang` and `clang++`, leaving native ARM builds and alternative compilers unchanged.
- Cover the failing flag combination with a shim regression test.
- Users must still invoke Intel Homebrew with `arch -x86_64`.

Fixes #23722

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Codex with GPT 5.6-sol at Extra High effort, with local review and testing.

-----