### PR TITLE
doctor: remove `grep_v(String)` from JSON output

### DIFF
--- a/Library/Homebrew/cmd/doctor.rb
+++ b/Library/Homebrew/cmd/doctor.rb
@@ -63,7 +63,7 @@ module Homebrew
           end
 
           finding         = checks.public_send(method)
-          method_findings = T.let(Array(finding).compact, T::Array[T.any(Diagnostic::Finding, String)])
+          method_findings = T.let(Array(finding).compact, T::Array[Diagnostic::Finding])
           next if method_findings.empty?
 
           finding_collection.concat(method_findings.compact)
@@ -83,8 +83,7 @@ module Homebrew
           first_warning = false
         end
 
-        # TODO: Remove string filtering when all diagnostics are Finding objects
-        finding_maps = finding_collection.grep_v(String).map(&:to_h)
+        finding_maps = finding_collection.map(&:to_h)
         tier = (finding_maps.max_by { |f| f[:tier] } || {}).fetch(:tier, 1)
         if args.json?
           puts JSON.pretty_generate({ tier:, findings: finding_maps }).gsub(/\[\n\n\s*\]/, "[]")


### PR DESCRIPTION

`brew doctor --json` filters strings out of the finding collection before calling `to_h`, with a `TODO` to remove the filter once every diagnostic returns a `Finding`. That is now true: all 87 `check_` methods return `Finding` (or nilable/array of it), and the only string-returning method, `__check_stray_files`, isn't matched by `Checks#all` and is wrapped in `Finding.new` by every caller. This removes the `TODO` and the `grep_v(String)` filter and narrows `method_findings` to `T::Array[Diagnostic::Finding]`, with no behavior change since the filter never removed anything.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
 AI (Claude Code) assisted in finding this dead code and writing the change. I reviewed it and ran `brew lgtm` locally.