### PR TITLE
formula: update `cargo fetch` example

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1589,7 +1589,7 @@ class Formula
   #
   # ```ruby
   # def fetch
-  #   system "cargo", "fetch", "--locked"
+  #   system "cargo", "fetch", "--locked", "--target", "host-tuple"
   # end
   #
   # def install

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1229,7 +1229,7 @@ Package managers such as Cargo, Go modules, npm and Bundler download dependencie
 class Foo < Formula
   # ...
   def fetch
-    system "cargo", "fetch", "--locked"
+    system "cargo", "fetch", "--locked", "--target", "host-tuple"
   end
 
   def install


### PR DESCRIPTION
By default, `cargo fetch` downloads packages for all targets but most formulae only need native packages so this results in unnecessary network and file I/O operations.

Arch Linux also runs the same updated command:
- https://wiki.archlinux.org/title/Rust_package_guidelines#Prepare
- https://doc.rust-lang.org/cargo/commands/cargo-fetch.html#fetch-options

Only documentation changes (comment and docs page). No functional impact.

In separate PR, may consider a functional modification to set `--offline` in std_cargo_args.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
