### PR TITLE
formula_creator: add deny network to some modes

### DIFF
--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -217,12 +217,16 @@ module Homebrew
           # depends_on "cmake" => :build
         <% end %>
 
-        <% if @mode == :perl || :python || :ruby %>
+        <% if [:perl, :ruby].include? @mode %>
           # Additional dependency
           # resource "" do
           #   url ""
           #   sha256 ""
           # end
+
+        <% end %>
+        <% if [:autotools, :cmake, :meson, :perl, nil].include? @mode %>
+          deny_network_access!
 
         <% end %>
           def install

--- a/Library/Homebrew/test/formula_creator_spec.rb
+++ b/Library/Homebrew/test/formula_creator_spec.rb
@@ -78,4 +78,40 @@ RSpec.describe Homebrew::FormulaCreator do
       end
     end
   end
+
+  describe "#write_formula!" do
+    shared_examples "expected" do |mode, includes:, excludes:|
+      sig { returns(Pathname) }
+      subject(:formula) do
+        described_class.new(url: "https://brew.sh/foo-0.1.tgz", mode:).write_formula!
+      end
+
+      specify "when using #{mode} template" do
+        expect(formula).to be_a_file
+        contents = formula.read
+        expect(contents).to include(*includes)
+        expect(contents).not_to include(*excludes)
+      end
+    end
+
+    it_behaves_like "expected", :autotools,
+                    includes: ["deny_network_access!", "std_configure_args", "unrecognized options"],
+                    excludes: ['resource "']
+
+    it_behaves_like "expected", :cmake,
+                    includes: ["deny_network_access!", "std_cmake_args"],
+                    excludes: ["unrecognized options", 'resource "']
+
+    it_behaves_like "expected", :meson,
+                    includes: ["deny_network_access!", "std_meson_args"],
+                    excludes: ["unrecognized options", 'resource "']
+
+    it_behaves_like "expected", :perl,
+                    includes: ["deny_network_access!", "PERL5LIB", 'resource "'],
+                    excludes: ["unrecognized options"]
+
+    it_behaves_like "expected", nil,
+                    includes: ["deny_network_access!", "unrecognized options"],
+                    excludes: ['resource "']
+  end
 end


### PR DESCRIPTION
When creating a new formula, add `deny_network_access!` to the following modes:
* `:cmake` - has been default via trap_fetchcontent_provider.cmake
* `:meson` - has been default via `--wrap-mode=nofallback`
* `:perl` - build and test dependencies are provided via resources
* `:autotools` - these are pre-generated configure scripts and we typically want to prevent network here given prior security incidents
* `nil` - if unknown, start without network access as safer default

Others can be added after we check if fetching works.

Also fix typo in resources portion as `|| :python || :ruby` was always true and drop `:python` which is handled via update-python-resources

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

n/a

-----
