### PR TITLE
formula_creator: add deny network for go and rust

### DIFF
--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -225,8 +225,19 @@ module Homebrew
           # end
 
         <% end %>
-        <% if [:autotools, :cmake, :meson, :perl, nil].include? @mode %>
+        <% if [:autotools, :cmake, :go, :meson, :perl, :rust, nil].include? @mode %>
           deny_network_access!
+
+        <% end %>
+        <% if @mode == :go %>
+          def fetch
+            system "go", "mod", "download"
+          end
+
+        <% elsif @mode == :rust %>
+          def fetch
+            system "cargo", "fetch", "--locked", "--target", "host-tuple"
+          end
 
         <% end %>
           def install
@@ -289,7 +300,7 @@ module Homebrew
             bin.install libexec/"bin/\#{name}"
             bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV["GEM_HOME"])
         <% elsif @mode == :rust %>
-            system "cargo", "install", *std_cargo_args
+            system "cargo", "install", "--offline", *std_cargo_args
         <% elsif @mode == :zig %>
             system "zig", "build", *std_zig_args
         <% else %>

--- a/Library/Homebrew/test/formula_creator_spec.rb
+++ b/Library/Homebrew/test/formula_creator_spec.rb
@@ -102,6 +102,10 @@ RSpec.describe Homebrew::FormulaCreator do
                     includes: ["deny_network_access!", "std_cmake_args"],
                     excludes: ["unrecognized options", 'resource "']
 
+    it_behaves_like "expected", :go,
+                    includes: ["deny_network_access!", "std_go_args", /"go".*"download"/],
+                    excludes: ["unrecognized options", 'resource "']
+
     it_behaves_like "expected", :meson,
                     includes: ["deny_network_access!", "std_meson_args"],
                     excludes: ["unrecognized options", 'resource "']
@@ -109,6 +113,10 @@ RSpec.describe Homebrew::FormulaCreator do
     it_behaves_like "expected", :perl,
                     includes: ["deny_network_access!", "PERL5LIB", 'resource "'],
                     excludes: ["unrecognized options"]
+
+    it_behaves_like "expected", :rust,
+                    includes: ["deny_network_access!", "std_cargo_args", /"cargo".*"fetch"/],
+                    excludes: ["unrecognized options", 'resource "']
 
     it_behaves_like "expected", nil,
                     includes: ["deny_network_access!", "unrecognized options"],


### PR DESCRIPTION
Create Go and Rust-based formulae with `deny_network_access!`. These account for majority of newly added formulae.

These require a separate fetch step.

For Rust, it matches our existing documentation. Testing functionality in https://github.com/Homebrew/homebrew-core/pull/300798

For Go, it uses `go mod download` to fetch into cache that we defined. Testing functionality in https://github.com/Homebrew/homebrew-core/pull/301819

---

For remaining:
* Still looking into Cabal and Zig which I think support separate fetch phase.
* Python is complicated. May need to figure out how to handle PyPI build dependencies better.
* Not sure yet on Crystal, Node and Ruby. 

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
