### PR TITLE
vulns: correct upstream fix boundaries and add reviewed overrides

### DIFF
--- a/Library/Homebrew/dev-cmd/advisory-match.rb
+++ b/Library/Homebrew/dev-cmd/advisory-match.rb
@@ -32,6 +32,8 @@ module Homebrew
         flag   "--repology=",
                description: "Load the formula to distro-package index from " \
                             "<file> instead of the published `data/repology.json`."
+        flag   "--overrides=",
+               description: "Load reviewed formula and advisory matching overrides from <file>."
         switch "--no-history",
                description: "Skip the `FormulaVersions` walk for the `fixed` " \
                             "boundary; use the current `pkg_version` instead."
@@ -56,7 +58,9 @@ module Homebrew
         Homebrew.with_no_api_env do
           latest_macos = MacOSVersion.new((HOMEBREW_MACOS_NEWEST_UNSUPPORTED.to_i - 1).to_s).to_sym
           Homebrew::SimulateSystem.with(os: latest_macos, arch: :arm) do
-            matcher = Homebrew::Vulns::Match.new(repology: local_repology, bulk: args.all? || args.index?)
+            matcher = Homebrew::Vulns::Match.new(repology:  local_repology,
+                                                 overrides: local_overrides,
+                                                 bulk:      args.all? || args.index?)
             next emit_index(matcher) if args.index?
 
             emitter = build_emitter
@@ -66,7 +70,7 @@ module Homebrew
                 # A below-introduced hit would otherwise look open to OSV
                 # consumers; it must not participate in alias maintenance.
                 actionable = hits.filter_map do |hit|
-                  status, = matcher.range_status(hit)
+                  status, = matcher.range_status(hit, formula_name: formula.name)
                   [hit, status] if status&.state != :not_applicable
                 end
                 record_ids_by_canonical = actionable.to_h do |hit, _status|
@@ -146,6 +150,13 @@ module Homebrew
         Homebrew::Vulns::Repology.from_file(Pathname(path))
       end
 
+      sig { returns(T.nilable(Homebrew::Vulns::AdvisoryOverrides)) }
+      def local_overrides
+        return unless (path = args.overrides)
+
+        Homebrew::Vulns::AdvisoryOverrides.from_file(Pathname(path))
+      end
+
       sig { returns(T::Enumerator[Formula]) }
       def each_formula
         return args.named.to_resolved_formulae.each unless args.all?
@@ -181,7 +192,7 @@ module Homebrew
         end
         hits.sort_by { |h| [-h.vulnerability.severity_level, h.canonical_id] }.each do |hit|
           v = hit.vulnerability
-          status, = matcher.range_status(hit)
+          status, = matcher.range_status(hit, formula_name: formula.name)
           state = case status&.state
           when nil       then "uncomparable"
           when :affected then "AFFECTED#{", upstream fix #{status&.fixed_in}" if status&.fixed_in}"

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/advisory_match.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/advisory_match.rbi
@@ -30,5 +30,8 @@ class Homebrew::DevCmd::AdvisoryMatch::Args < Homebrew::CLI::Args
   def output; end
 
   sig { returns(T.nilable(String)) }
+  def overrides; end
+
+  sig { returns(T.nilable(String)) }
   def repology; end
 end

--- a/Library/Homebrew/test/dev-cmd/advisory-match_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/advisory-match_spec.rb
@@ -798,6 +798,62 @@ RSpec.describe Homebrew::DevCmd::AdvisoryMatch do
     end
   end
 
+  it "loads reviewed candidate corrections from --overrides=<file>" do
+    stub_osv_hit("CVE-2024-1234", fixed: "2.31.0")
+
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "overrides.yml")
+      File.write(path, <<~YAML)
+        requests:
+          advisories:
+            CVE-2024-1234:
+              range_state: affected
+              upstream_fixed_in:
+      YAML
+
+      records = JSON.parse(capture_stdout do
+        cmd_for("requests", "--json", "--no-history", "--overrides", path).run
+      end)
+      affected = records.first.fetch("affected").first
+      expect(affected.dig("ranges", 0, "events")).to eq [{ "introduced" => "0" }]
+      expect(affected.fetch("ecosystem_specific")).to eq("fix" => nil, "range_state" => "affected")
+    end
+  end
+
+  it "uses an affected override before transition detection in --new-history mode" do
+    stub_osv_hit("CVE-2024-1234", fixed: "2.31.0")
+    expect(FormulaVersions).not_to receive(:new)
+
+    Dir.mktmpdir do |dir|
+      overrides_path = File.join(dir, "overrides.yml")
+      File.write(overrides_path, <<~YAML)
+        requests:
+          advisories:
+            CVE-2024-1234:
+              range_state: affected
+              upstream_fixed_in:
+      YAML
+      record_path = File.join(dir, "BREW-requests-CVE-2024-1234.json")
+      File.write(record_path, JSON.generate({
+        "id"                => "BREW-requests-CVE-2024-1234",
+        "upstream"          => ["CVE-2024-1234"],
+        "affected"          => [{
+          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [{ "introduced" => "0" }] }],
+        }],
+        "database_specific" => { "source" => "matched" },
+      }))
+
+      expect do
+        cmd_for("requests", "--output", dir, "--new-history", "--overrides", overrides_path).run
+      end.to output(/0 history walks/).to_stdout
+
+      affected = JSON.parse(File.read(record_path)).fetch("affected").first
+      expect(affected.dig("ranges", 0, "events")).to eq [{ "introduced" => "0" }]
+      expect(affected.fetch("ecosystem_specific")).to eq("fix" => nil, "range_state" => "affected")
+    end
+  end
+
   it "raises on an unreadable --repology file" do
     expect { cmd_for("requests", "--json", "--repology", "/nonexistent/repology.json").run }
       .to raise_error(Errno::ENOENT)

--- a/Library/Homebrew/test/vulns/advisory_overrides_spec.rb
+++ b/Library/Homebrew/test/vulns/advisory_overrides_spec.rb
@@ -1,0 +1,54 @@
+# typed: true
+# frozen_string_literal: true
+
+require "vulns/advisory_overrides"
+
+RSpec.describe Homebrew::Vulns::AdvisoryOverrides do
+  it "loads formula skips and candidate-specific state and fix corrections" do
+    overrides = described_class.new({
+      "linux-headers" => { "skip" => true },
+      "safety"        => { "advisories" => {
+        "CVE-2026-81726" => { "range_state" => "affected", "upstream_fixed_in" => nil },
+      } },
+    })
+
+    expect(overrides.skip_formula?("linux-headers")).to be true
+    expect(overrides.skip_formula?("safety")).to be false
+    entry = overrides.advisory_override("safety", ["PYSEC-2026-1", "CVE-2026-81726"])
+    expect(entry).to have_attributes(state: :affected, fixed_in: nil, fixed_in_overridden: true)
+  end
+
+  it "rejects unknown fields so misspelled corrections do not silently fail" do
+    data = { "safety" => { "advisories" => {
+      "CVE-2026-81726" => { "range_status" => "affected" },
+    } } }
+
+    expect { described_class.new(data) }
+      .to raise_error(Homebrew::Vulns::AdvisoryOverrides::Error, /unknown key.*range_status/)
+  end
+
+  it "rejects a non-mapping root instead of disabling every override" do
+    ["false\n", "", "---\n"].each do |yaml|
+      Tempfile.create(["advisory-overrides", ".yml"]) do |file|
+        file.write(yaml)
+        file.flush
+        expect { described_class.from_file(Pathname(file.path)) }
+          .to raise_error(Homebrew::Vulns::AdvisoryOverrides::Error, /top level must be a mapping/)
+      end
+    end
+  end
+
+  it "rejects YAML aliases and tagged objects" do
+    [
+      "shared: &shared\n  skip: true\ncopy: *shared\n",
+      "--- !ruby/object:Object {}\n",
+    ].each do |yaml|
+      Tempfile.create(["advisory-overrides", ".yml"]) do |file|
+        file.write(yaml)
+        file.flush
+        expect { described_class.from_file(Pathname(file.path)) }
+          .to raise_error(Homebrew::Vulns::AdvisoryOverrides::Error)
+      end
+    end
+  end
+end

--- a/Library/Homebrew/test/vulns/match_spec.rb
+++ b/Library/Homebrew/test/vulns/match_spec.rb
@@ -463,6 +463,22 @@ RSpec.describe Homebrew::Vulns::Match do
 
       expect(yielded).to eq [["aa", ["CVE-2024-0001"]], ["bb", []]]
     end
+
+    it "does not identify or query a formula skipped by reviewed overrides" do
+      skipped = formula("aa") do
+        T.bind(self, T.class_of(Formula))
+        url "https://github.com/owner/aa/archive/refs/tags/v1.0.tar.gz"
+      end
+      overrides = Homebrew::Vulns::AdvisoryOverrides.new({ "aa" => { "skip" => true } })
+      bulk = described_class.new(repology:, cpan_sec:, overrides:, bulk: true)
+      expect(bulk).not_to receive(:identify)
+      expect(Homebrew::Vulns::OSV).not_to receive(:query_batch)
+
+      yielded = []
+      bulk.each_advisory_batch([skipped]) { |formula, hits| yielded << [formula.name, hits] }
+
+      expect(yielded).to eq [["aa", []]]
+    end
   end
 
   describe "#advisories_for" do
@@ -586,6 +602,47 @@ RSpec.describe Homebrew::Vulns::Match do
       aff = record[:affected].first
       expect(aff[:ranges]).to eq [{ type: "ECOSYSTEM", events: [{ introduced: "0" }] }]
       expect(aff[:ecosystem_specific]).to eq(fix: nil, range_state: "affected", upstream_fixed_in: "2.32.0")
+    end
+
+    it "does not report last_affected as an upstream fix version" do
+      hit = registry_hit(affected_events: [{ "introduced" => "0" }, { "last_affected" => "2.0" }])
+
+      record = matcher.to_brew_record(requests, hit, now:)
+
+      expect(record.dig(:affected, 0, :ranges, 0, :events))
+        .to eq [{ introduced: "0" }, { fixed: requests.pkg_version.to_s }]
+      expect(record.dig(:affected, 0, :ecosystem_specific)).to eq(fix: "bump", range_state: "fixed")
+    end
+
+    it "applies a reviewed advisory override before emitting the range state and upstream fix" do
+      overrides = Homebrew::Vulns::AdvisoryOverrides.new({
+        "requests" => { "advisories" => {
+          "CVE-2024-1234" => { "range_state" => "affected", "upstream_fixed_in" => nil },
+        } },
+      })
+      overridden = described_class.new(repology:, cpan_sec:, overrides:)
+      hit = registry_hit(affected_events: [{ "introduced" => "0" }, { "fixed" => "2.31.0" }])
+
+      record = overridden.to_brew_record(requests, hit, now:)
+
+      expect(record.dig(:affected, 0, :ranges, 0, :events)).to eq [{ introduced: "0" }]
+      expect(record.dig(:affected, 0, :ecosystem_specific)).to eq(fix: nil, range_state: "affected")
+    end
+
+    it "can supply a reviewed upstream fix after a last_affected boundary" do
+      overrides = Homebrew::Vulns::AdvisoryOverrides.new({
+        "requests" => { "advisories" => {
+          "CVE-2024-1234" => { "upstream_fixed_in" => "2.1" },
+        } },
+      })
+      overridden = described_class.new(repology:, cpan_sec:, overrides:)
+      hit = registry_hit(affected_events: [{ "introduced" => "0" }, { "last_affected" => "2.0" }])
+
+      record = overridden.to_brew_record(requests, hit, now:)
+
+      expect(record.dig(:affected, 0, :ecosystem_specific, :upstream_fixed_in)).to eq "2.1"
+      expect(overridden.range_status(hit, formula_name: "other")&.first)
+        .to have_attributes(state: :fixed, fixed_in: nil)
     end
 
     it "emits fix: nil and demotes confidence when no comparable range exists (GIT-only)" do

--- a/Library/Homebrew/test/vulns/vulnerability_spec.rb
+++ b/Library/Homebrew/test/vulns/vulnerability_spec.rb
@@ -233,7 +233,54 @@ RSpec.describe Homebrew::Vulns::Vulnerability do
       expect(v.range_status("PyPI", "requests", "2.0"))
         .to have_attributes(state: :affected, fixed_in: nil)
       expect(v.range_status("PyPI", "requests", "2.1"))
-        .to have_attributes(state: :fixed, fixed_in: "2.0")
+        .to have_attributes(state: :fixed, fixed_in: nil)
+    end
+
+    it "does not reuse an older fixed event after a later last_affected interval" do
+      v = vuln("id" => "CVE-1", "affected" => [
+        affected("PyPI", "requests",
+                 range("ECOSYSTEM",
+                       { "introduced" => "0" }, { "fixed" => "1.0" },
+                       { "introduced" => "2.0" }, { "last_affected" => "3.0" })),
+      ])
+
+      expect(v.range_status("PyPI", "requests", "4.0"))
+        .to have_attributes(state: :fixed, fixed_in: nil)
+    end
+
+    it "settles SemVer-equal terminal boundaries with the range's own comparator" do
+      v = vuln("id" => "CVE-1", "affected" => [
+        affected("PyPI", "requests",
+                 range("SEMVER", { "introduced" => "0" }, { "fixed" => "1.0.0+2" })),
+        affected("PyPI", "requests",
+                 range("SEMVER", { "introduced" => "0" }, { "last_affected" => "1.0.0+1" })),
+      ])
+
+      expect(v.range_status("PyPI", "requests", "2.0.0"))
+        .to have_attributes(state: :fixed, fixed_in: nil)
+    end
+
+    it "does not report a limit boundary as fixed_in" do
+      v = vuln("id" => "CVE-1", "affected" => [
+        affected("PyPI", "requests",
+                 range("ECOSYSTEM", { "introduced" => "0" }, { "limit" => "2.0" })),
+      ])
+
+      expect(v.range_status("PyPI", "requests", "2.0"))
+        .to have_attributes(state: :fixed, fixed_in: nil)
+    end
+
+    it "suppresses fixed_in for conflicting equal terminal boundaries regardless of entry order" do
+      fixed = affected("PyPI", "requests",
+                       range("ECOSYSTEM", { "introduced" => "0" }, { "fixed" => "2.0" }))
+      last_affected = affected("PyPI", "requests",
+                               range("ECOSYSTEM", { "introduced" => "0" }, { "last_affected" => "2.0" }))
+
+      [[fixed, last_affected], [last_affected, fixed]].each do |entries|
+        v = vuln("id" => "CVE-1", "affected" => entries)
+        expect(v.range_status("PyPI", "requests", "3.0"))
+          .to have_attributes(state: :fixed, fixed_in: nil)
+      end
     end
 
     it "picks the fixed boundary of the interval containing the target across disjoint branches" do

--- a/Library/Homebrew/vulns/advisory_overrides.rb
+++ b/Library/Homebrew/vulns/advisory_overrides.rb
@@ -1,0 +1,121 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "yaml"
+
+module Homebrew
+  module Vulns
+    # Reviewed, candidate-specific corrections for advisory matching. These are
+    # intentionally keyed by formula and upstream advisory identifier so a bad
+    # upstream range cannot silently change unrelated matches.
+    class AdvisoryOverrides
+      class Error < RuntimeError; end
+
+      class Entry < T::Struct
+        const :state, T.nilable(Symbol)
+        const :fixed_in, T.nilable(String)
+        const :fixed_in_overridden, T::Boolean
+      end
+
+      VALID_STATES = [:affected, :fixed, :not_applicable].freeze
+      private_constant :VALID_STATES
+
+      sig { params(path: Pathname).returns(AdvisoryOverrides) }
+      def self.from_file(path)
+        new(YAML.safe_load(path.read, permitted_classes: [], permitted_symbols: [], aliases: false))
+      rescue Psych::Exception => e
+        raise Error, "Failed to parse advisory overrides at #{path}: #{e.message}"
+      end
+
+      sig { params(data: T.untyped).void }
+      def initialize(data)
+        @skipped_formulae = T.let({}, T::Hash[String, T::Boolean])
+        @advisories = T.let({}, T::Hash[String, T::Hash[String, Entry]])
+
+        root = hash(data, "top level")
+        root.each do |formula_name, raw_formula|
+          raise Error, "Formula names must be strings" unless formula_name.is_a?(String)
+
+          formula = hash(raw_formula, formula_name)
+          reject_unknown_keys(formula, %w[skip advisories], formula_name)
+
+          skip = formula.fetch("skip", false)
+          raise Error, "#{formula_name}.skip must be true or false" unless [true, false].include?(skip)
+
+          @skipped_formulae[formula_name] = true if skip
+          next unless formula.key?("advisories")
+
+          raw_advisories = hash(formula.fetch("advisories"), "#{formula_name}.advisories")
+          parsed = T.let({}, T::Hash[String, Entry])
+          raw_advisories.each do |identifier, raw_entry|
+            raise Error, "#{formula_name} advisory identifiers must be strings" unless identifier.is_a?(String)
+
+            entry = hash(raw_entry, "#{formula_name}.advisories.#{identifier}")
+            reject_unknown_keys(entry, %w[range_state upstream_fixed_in],
+                                "#{formula_name}.advisories.#{identifier}")
+
+            state = T.let(nil, T.nilable(Symbol))
+            if entry.key?("range_state")
+              raw_state = entry.fetch("range_state")
+              state = raw_state.to_sym if raw_state.is_a?(String)
+              if state.nil? || VALID_STATES.exclude?(state)
+                raise Error, "#{formula_name}.advisories.#{identifier}.range_state must be " \
+                             "affected, fixed, or not_applicable"
+              end
+            end
+
+            fixed_in_overridden = entry.key?("upstream_fixed_in")
+            fixed_in = entry["upstream_fixed_in"]
+            if !fixed_in.nil? && !fixed_in.is_a?(String)
+              raise Error, "#{formula_name}.advisories.#{identifier}.upstream_fixed_in must be a string or null"
+            end
+            if state.nil? && !fixed_in_overridden
+              raise Error, "#{formula_name}.advisories.#{identifier} must override at least one field"
+            end
+
+            parsed[identifier] = Entry.new(state:, fixed_in:, fixed_in_overridden:)
+          end
+          @advisories[formula_name] = parsed.freeze
+        end
+        @skipped_formulae.freeze
+        @advisories.freeze
+      end
+
+      sig { params(formula_name: String).returns(T::Boolean) }
+      def skip_formula?(formula_name)
+        @skipped_formulae.key?(formula_name)
+      end
+
+      sig { params(formula_name: String, identifiers: T::Array[String]).returns(T.nilable(Entry)) }
+      def advisory_override(formula_name, identifiers)
+        formula = @advisories[formula_name]
+        return unless formula
+
+        identifiers.each do |identifier|
+          override = formula[identifier]
+          return override if override
+        end
+        nil
+      end
+
+      private
+
+      sig { params(value: T.untyped, location: String).returns(T::Hash[T.untyped, T.untyped]) }
+      def hash(value, location)
+        return value if value.is_a?(Hash)
+
+        raise Error, "#{location} must be a mapping"
+      end
+
+      sig {
+        params(value: T::Hash[T.untyped, T.untyped], allowed: T::Array[String], location: String).void
+      }
+      def reject_unknown_keys(value, allowed, location)
+        unknown = value.keys - allowed
+        return if unknown.empty?
+
+        raise Error, "#{location} has unknown key(s): #{unknown.join(", ")}"
+      end
+    end
+  end
+end

--- a/Library/Homebrew/vulns/match.rb
+++ b/Library/Homebrew/vulns/match.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "formula_versions"
+require "vulns/advisory_overrides"
 require "vulns/cpan_sec"
 require "vulns/identify"
 require "vulns/osv"
@@ -115,10 +116,14 @@ module Homebrew
         end
       end
 
-      sig { params(repology: T.nilable(Repology), cpan_sec: T.nilable(CPANSec), bulk: T::Boolean).void }
-      def initialize(repology: nil, cpan_sec: nil, bulk: false)
+      sig {
+        params(repology: T.nilable(Repology), cpan_sec: T.nilable(CPANSec),
+               overrides: T.nilable(AdvisoryOverrides), bulk: T::Boolean).void
+      }
+      def initialize(repology: nil, cpan_sec: nil, overrides: nil, bulk: false)
         @repology = repology
         @cpan_sec = cpan_sec
+        @overrides = overrides
         @bulk = bulk
         @vuln_cache = T.let({}, T::Hash[String, T.nilable(Vulnerability)])
         @formula_versions = T.let({}, T::Hash[String, FormulaVersions])
@@ -179,7 +184,12 @@ module Homebrew
       }
       def each_advisory_batch(formulae, &_blk)
         formulae.each_slice(BULK_CHUNK) do |chunk|
-          identities = chunk.map { |f| [f, identify(f)] }
+          identities = T.let({}, T::Hash[Formula, Identity])
+          chunk.each do |formula|
+            next if @overrides&.skip_formula?(formula.name)
+
+            identities[formula] = identify(formula)
+          end
           labelled = T.let([], T::Array[[OSV::Package, [Formula, Evidence]]])
           identities.each do |f, identity|
             next unless identity.identifiable?
@@ -200,8 +210,9 @@ module Homebrew
 
           prefetch_vulnerabilities(by_formula.each_value.flat_map(&:keys))
 
-          identities.each do |f, identity|
-            next yield f, [] unless identity.identifiable?
+          chunk.each do |f|
+            identity = identities[f]
+            next yield f, [] unless identity&.identifiable?
 
             yield f, hits_from(by_formula[f] || {}, identity)
           end
@@ -450,17 +461,27 @@ module Homebrew
       # chosen (used by {#first_fixed_version} and for the emitted record's
       # resource attribution), or `nil` if no evidence produced a checkable
       # answer.
-      sig { params(hit: Hit).returns(T.nilable([Vulnerability::RangeStatus, Evidence])) }
-      def range_status(hit)
+      sig {
+        params(hit: Hit, formula_name: T.nilable(String))
+          .returns(T.nilable([Vulnerability::RangeStatus, Evidence]))
+      }
+      def range_status(hit, formula_name: nil)
         results = hit.evidence.filter_map do |ev|
           status = evidence_range_status(ev, ev.subject_version)
           [status, ev] if status
         end
-        return if results.empty?
+        selected = results.find { |s, _| s.affected? } ||
+                   results.find { |s, _| s.fixed? } ||
+                   results.first
+        override = @overrides&.advisory_override(formula_name, hit.identifiers) if formula_name
+        return selected unless override
 
-        results.find { |s, _| s.affected? } ||
-          results.find { |s, _| s.fixed? } ||
-          results.first
+        status, evidence = selected || [nil, hit.primary_evidence]
+        state = override.state || status&.state
+        return selected unless state
+
+        fixed_in = override.fixed_in_overridden ? override.fixed_in : status&.fixed_in
+        [Vulnerability::RangeStatus.new(state:, fixed_in:).freeze, evidence]
       end
 
       sig {
@@ -498,7 +519,7 @@ module Homebrew
       def to_brew_record(formula, hit, first_fixed: nil, first_reintroduced: nil, now: Time.now.utc)
         vuln = hit.vulnerability
         timestamp = now.strftime("%Y-%m-%dT%H:%M:%SZ")
-        status, status_evidence = range_status(hit)
+        status, status_evidence = range_status(hit, formula_name: formula.name)
 
         fixed = first_fixed
         fixed ||= formula.pkg_version.to_s if status&.fixed?
@@ -601,7 +622,7 @@ module Homebrew
       # The rev-list and per-revision loads are cached per formula.
       sig { params(formula: Formula, hit: Hit).returns(T.nilable(T.any(String, Symbol))) }
       def first_fixed_version(formula, hit)
-        return unless range_status(hit)&.first&.fixed?
+        return unless range_status(hit, formula_name: formula.name)&.first&.fixed?
 
         fv = @formula_versions[formula.name] ||= FormulaVersions.new(formula)
         revs = @formula_rev_lists[formula.name] ||=
@@ -636,7 +657,7 @@ module Homebrew
       # revision could not be loaded or compared safely.
       sig { params(formula: Formula, hit: Hit).returns(T.nilable(T.any(String, Symbol))) }
       def first_reintroduced_version(formula, hit)
-        return unless range_status(hit)&.first&.affected?
+        return unless range_status(hit, formula_name: formula.name)&.first&.affected?
 
         fv = @formula_versions[formula.name] ||= FormulaVersions.new(formula)
         revs = @formula_rev_lists[formula.name] ||=

--- a/Library/Homebrew/vulns/vulnerability.rb
+++ b/Library/Homebrew/vulns/vulnerability.rb
@@ -18,6 +18,9 @@ module Homebrew
         const :fix, T.nilable(String)
       end
 
+      Comparator = T.type_alias { T.proc.params(a: String, b: String).returns(Integer) }
+      private_constant :Comparator
+
       CVSS_TYPE_PRIORITY = T.let(
         { "CVSS_V4" => 4, "CVSS_V3" => 3, "CVSS_V2" => 2 }.freeze,
         T::Hash[String, Integer],
@@ -114,9 +117,10 @@ module Homebrew
       # `state` is `:affected` (in an interval), `:fixed` (past the closing
       # boundary of at least one interval), or `:not_applicable` (below the
       # `introduced` of every interval; the vulnerability never applied to this
-      # version). `fixed_in` is the boundary that closed the containing
-      # interval (`:affected`) or the highest boundary at-or-below the version
-      # (`:fixed`).
+      # version). `fixed_in` is the explicit upstream `fixed` event that closes
+      # the containing interval (`:affected`) or the highest such event at-or-
+      # below the version (`:fixed`). Inclusive `last_affected` boundaries and
+      # exclusive `limit` boundaries never populate `fixed_in`.
       RangeStatus = Struct.new(:state, :fixed_in, keyword_init: true) do
         sig { returns(T::Boolean) }
         def affected? = state == :affected
@@ -146,7 +150,7 @@ module Homebrew
 
         target = normalize_version(version)
         checked = T.let(false, T::Boolean)
-        past_fixes = T.let([], T::Array[String])
+        past_terminals = T.let([], T::Array[[String, T.nilable(String), Comparator]])
 
         entries.each do |entry|
           Array(entry["ranges"]).each do |range|
@@ -158,14 +162,15 @@ module Homebrew
               inside = in_interval?(target, interval.lower, interval.upper, interval.upper_inclusive, cmp)
               checked = true
               if inside
-                fixed_in = interval.upper_inclusive ? nil : interval.upper
-                return RangeStatus.new(state: :affected, fixed_in:).freeze
+                return RangeStatus.new(state: :affected, fixed_in: interval.fix).freeze
               end
+
               upper = interval.upper
               next unless upper
 
               rel = cmp.call(target, upper)
-              past_fixes << upper if interval.upper_inclusive ? rel.positive? : rel >= 0
+              past = interval.upper_inclusive ? rel.positive? : rel >= 0
+              past_terminals << [upper, interval.fix, cmp] if past
             rescue Uncomparable
               next
             end
@@ -182,8 +187,31 @@ module Homebrew
 
         return unless checked
 
-        state = past_fixes.any? ? :fixed : :not_applicable
-        RangeStatus.new(state:, fixed_in: past_fixes.max_by { |v| Version.new(v) }).freeze
+        # Conflicting entries can end at the same version with `fixed` and
+        # `last_affected`/`limit`. Prefer the non-fix terminal on a tie so
+        # upstream entry ordering cannot turn an inclusive affected boundary
+        # into a reported fix version. `Version` ranks terminals across ranges
+        # of differing types, but each range's own comparator also settles
+        # ties: SemVer ignores build metadata, so `1.0.0+1` and `1.0.0+2` are
+        # one boundary there and `Version` alone would miss the tie.
+        latest_terminal = past_terminals.max_by do |upper, fix, _|
+          [Version.new(upper), fix.nil? ? 1 : 0]
+        end
+        return RangeStatus.new(state: :not_applicable, fixed_in: nil).freeze unless latest_terminal
+
+        boundary, fixed_in, cmp = latest_terminal
+        shadowed = past_terminals.any? do |other, other_fix, other_cmp|
+          other_fix.nil? &&
+            (same_boundary?(boundary, other, cmp) || same_boundary?(boundary, other, other_cmp))
+        end
+        RangeStatus.new(state: :fixed, fixed_in: (fixed_in unless shadowed)).freeze
+      end
+
+      sig { params(left: String, right: String, cmp: Comparator).returns(T::Boolean) }
+      def same_boundary?(left, right, cmp)
+        cmp.call(left, right).zero?
+      rescue Uncomparable
+        false
       end
 
       sig { params(ecosystem: String, name: String).returns(T::Array[T::Hash[String, T.untyped]]) }

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -347,6 +347,7 @@ _brew_advisory_match() {
       --new-history
       --no-history
       --output
+      --overrides
       --quiet
       --repology
       --verbose

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -342,6 +342,7 @@ __fish_brew_complete_arg 'advisory-match' -l json -d 'Output candidate records a
 __fish_brew_complete_arg 'advisory-match' -l new-history -d 'Walk `FormulaVersions` only for records whose reviewed ranges are not already in directory'
 __fish_brew_complete_arg 'advisory-match' -l no-history -d 'Skip the `FormulaVersions` walk for the `fixed` boundary; use the current `pkg_version` instead'
 __fish_brew_complete_arg 'advisory-match' -l output -d 'Write each record to directory as `BREW-formula-id.json`, preserving existing `published`/`ranges` fields'
+__fish_brew_complete_arg 'advisory-match' -l overrides -d 'Load reviewed formula and advisory matching overrides from file'
 __fish_brew_complete_arg 'advisory-match' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'advisory-match' -l repology -d 'Load the formula to distro-package index from file instead of the published `data/repology.json`'
 __fish_brew_complete_arg 'advisory-match' -l verbose -d 'Make some output more verbose'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -445,6 +445,7 @@ _brew_advisory_match() {
     '(--no-history)--new-history[Walk `FormulaVersions` only for records whose reviewed ranges are not already in directory]' \
     '(--new-history)--no-history[Skip the `FormulaVersions` walk for the `fixed` boundary; use the current `pkg_version` instead]' \
     '(--index)--output[Write each record to directory as `BREW-formula-id.json`, preserving existing `published`/`ranges` fields]' \
+    '--overrides[Load reviewed formula and advisory matching overrides from file]' \
     '--quiet[Make some output more quiet]' \
     '--repology[Load the formula to distro-package index from file instead of the published `data/repology.json`]' \
     '--verbose[Make some output more verbose]' \


### PR DESCRIPTION
`brew advisory-match` treated any interval's upper bound as the upstream fix version. Only an explicit `fixed` event is one: `last_affected` is an inclusive affected boundary and `limit` is an exclusive terminator. `Vulnerability#range_status` now sets `fixed_in` from `fixed` events only. This currently makes 19 `BREW-*` records in Homebrew/advisory-database report `upstream_fixed_in: 4.0.0` for CVE-2026-44405, a paramiko version that was never a fix.

The new `--overrides=<file>` flag loads reviewed corrections keyed by formula plus upstream advisory id: `range_state`, `upstream_fixed_in` (an explicit null suppresses a bad upstream value), and formula-level `skip: true`. The schema fails closed. Overrides apply only when the flag is passed; advisory-database starts passing it in a follow-up.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the fix and pass with it, and ran `brew lgtm --online` plus targeted `vulns` and `advisory-match` specs.

-----
