### PR TITLE
bump: avoid overwriting skip message with autobump

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -190,7 +190,7 @@ module Homebrew
       sig {
         params(formula_or_cask: T.any(Formula, Cask::Cask)).returns(T::Boolean)
       }
-      def skip_ineligible_formulae!(formula_or_cask)
+      def skip_ineligible_package!(formula_or_cask)
         if formula_or_cask.is_a?(Formula)
           skip = formula_or_cask.disabled? || formula_or_cask.head_only?
           name = formula_or_cask.name
@@ -887,7 +887,7 @@ module Homebrew
         consecutive_github_api_errors = 0
         formulae_and_casks.each_with_index do |formula_or_cask, i|
           puts if i.positive?
-          next if skip_ineligible_formulae!(formula_or_cask)
+          next if skip_ineligible_package!(formula_or_cask)
 
           use_full_name = args.full_name? || ambiguous_names.include?(formula_or_cask)
           name = Livecheck.package_or_resource_name(formula_or_cask, full_name: use_full_name)

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -204,7 +204,7 @@ module Homebrew
             "Cask uses `version :latest` so `brew bump` cannot check it.\n"
           end
         end
-        if (tap = formula_or_cask.tap) && !tap.allow_bump?(name)
+        if !skip && (tap = formula_or_cask.tap) && !tap.allow_bump?(name)
           skip = true
           text = "#{text.split.first} is autobumped so will have bump PRs opened by BrewTestBot every ~3 hours.\n"
         end

--- a/Library/Homebrew/test/dev-cmd/bump_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump_spec.rb
@@ -15,6 +15,23 @@ RSpec.describe Homebrew::DevCmd::Bump do
       url "https://brew.sh/test-1.2.3.tgz"
     end
   end
+  let(:f_disabled) do
+    formula("disabled_formula") do
+      T.bind(self, T.class_of(Formula))
+      desc "Disabled formula"
+      url "https://brew.sh/test-1.2.3.tgz"
+
+      disable! date: "2020-01-01", because: "Testing"
+    end
+  end
+  let(:f_head_only) do
+    formula("head_only_formula") do
+      T.bind(self, T.class_of(Formula))
+      desc "HEAD-only formula"
+      head "https://github.com/Homebrew/brew.git", branch: "main"
+    end
+  end
+
   let(:c_basic) do
     Cask::CaskLoader.load(+<<-RUBY)
       cask "basic_cask" do
@@ -22,6 +39,18 @@ RSpec.describe Homebrew::DevCmd::Bump do
 
         name "Basic Cask"
         desc "Basic cask"
+      end
+    RUBY
+  end
+  let(:c_disabled) do
+    Cask::CaskLoader.load(+<<-RUBY)
+      cask "disabled_cask" do
+        version "1.2.3"
+
+        name "Disabled Cask"
+        desc "Disabled cask"
+
+        disable! date: "2020-01-01", because: "Testing"
       end
     RUBY
   end
@@ -65,9 +94,51 @@ RSpec.describe Homebrew::DevCmd::Bump do
   end
 
   describe "::skip_ineligible_package!" do
-    it "prints a legible message for casks using `version :latest`" do
+    it "prints a message for disabled formulae" do
+      expect { expect(bump.skip_ineligible_package!(f_disabled)).to be(true) }
+        .to output(/Formula is disabled so not accepting updates\./).to_stdout
+        .and not_to_output.to_stderr
+    end
+
+    it "prints a message for HEAD-only formulae" do
+      expect { expect(bump.skip_ineligible_package!(f_head_only)).to be(true) }
+        .to output(/Formula is HEAD-only so not accepting updates\./).to_stdout
+        .and not_to_output.to_stderr
+    end
+
+    it "prints a message for disabled casks" do
+      expect { expect(bump.skip_ineligible_package!(c_disabled)).to be(true) }
+        .to output(/Cask is disabled so not accepting updates\./).to_stdout
+        .and not_to_output.to_stderr
+    end
+
+    it "prints a message for casks using `version :latest`" do
       expect { expect(bump.skip_ineligible_package!(c_latest)).to be(true) }
         .to output(/Cask uses `version :latest` so `brew bump` cannot check it\./).to_stdout
+        .and not_to_output.to_stderr
+    end
+
+    it "prints a message for autobumped packages" do
+      allow(f_basic).to receive(:tap).and_return(instance_double(Tap, allow_bump?: false))
+
+      expect { expect(bump.skip_ineligible_package!(f_basic)).to be(true) }
+        .to output(/Formula is autobumped so will have bump PRs opened by BrewTestBot/).to_stdout
+        .and not_to_output.to_stderr
+    end
+
+    it "doesn't overwrite an existing skip message with the autobump message" do
+      allow(f_disabled).to receive(:tap).and_return(instance_double(Tap, allow_bump?: false))
+
+      expect { expect(bump.skip_ineligible_package!(f_disabled)).to be(true) }
+        .to output(/Formula is disabled so not accepting updates\./).to_stdout
+        .and not_to_output.to_stderr
+    end
+
+    it "returns false for an eligible package" do
+      allow(f_basic).to receive(:tap).and_return(instance_double(Tap, allow_bump?: true))
+
+      expect { expect(bump.skip_ineligible_package!(f_basic)).to be(false) }
+        .to not_to_output.to_stdout
         .and not_to_output.to_stderr
     end
   end

--- a/Library/Homebrew/test/dev-cmd/bump_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump_spec.rb
@@ -64,9 +64,9 @@ RSpec.describe Homebrew::DevCmd::Bump do
       .to raise_error(UsageError, /`--tap` requires `--auto` for official taps/)
   end
 
-  describe "::skip_ineligible_formulae!" do
+  describe "::skip_ineligible_package!" do
     it "prints a legible message for casks using `version :latest`" do
-      expect { expect(bump.skip_ineligible_formulae!(c_latest)).to be(true) }
+      expect { expect(bump.skip_ineligible_package!(c_latest)).to be(true) }
         .to output(/Cask uses `version :latest` so `brew bump` cannot check it\./).to_stdout
         .and not_to_output.to_stderr
     end


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

I wrote tests for `skip_ineligible_package!` to cover the existing logic and then used Claude Code (Opus 5, high) to write some additional tests to finish what I started (bringing the method to 100% coverage in the end). I reviewed and tested the changes (confirming it's what I would have written myself) and tweaked some small things. I could have done it manually but I wanted to see how the AI-produced version would compare.

-----

`brew bump` will skip formulae if they're disabled or HEAD-only and skip casks if they're disabled or use `version :latest`. However, if a package is set to be autobumped, the autobump skip message will overwrite any previously-set skip message. bump (and thusly autobump) skips disabled packages, so giving an error message about autobump is less relevant and can be confusing to users. The aforementioned skip conditions should take precedence over autobump status, so this modifies the autobump skip logic to ensure it won't overwrite an existing skip.

Output on `main` with a disabled cask that was previously autobumped:

```
$ brew bump olympus
==> olympus
Cask is autobumped so will have bump PRs opened by BrewTestBot every ~3 hours.
```

Output using this PR:

```
$ brew bump olympus
==> olympus
Cask is disabled so not accepting updates.
```

In the process, I renamed the `skip_ineligible_formulae!` method to `skip_ineligible_package!`, which makes it more clear that it's not a formula-only method. I also expanded the test coverage to 100% for the method, as the existing test only covered one of the possible skip scenarios (a `version :latest` cask).