### PR TITLE
bump-cask-pr: load modified contents with FromContentLoader

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -353,7 +353,8 @@ module Homebrew
                 cask.languages
               end
               languages.each do |language|
-                new_cask        = Cask::CaskLoader.load(contents)
+                new_cask        = Cask::CaskLoader::FromContentLoader.new(contents)
+                                                                     .load(config: nil)
                 next unless new_cask.url
 
                 new_cask.config = if language.blank?

--- a/Library/Homebrew/test/dev-cmd/bump-cask-pr_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-cask-pr_spec.rb
@@ -317,6 +317,38 @@ RSpec.describe Homebrew::DevCmd::BumpCaskPr do
       end
     end
 
+    it "loads cask contents with a leading comment when calculating the checksum" do
+      contents = <<~RUBY
+        # leading comment
+        cask "foo" do
+          version "1.0"
+          sha256 "#{old_hash}"
+
+          url "https://brew.sh/foo-\#{version}.dmg"
+          name "Foo"
+        end
+      RUBY
+      cask = cask_from_contents(contents)
+      new_version = Homebrew::BumpVersionParser.new(general: "2.0")
+      download = mktmpdir/"foo.dmg"
+      download.write("download")
+      allow(Cask::Download).to receive(:new)
+        .and_return(instance_double(Cask::Download, fetch: download))
+      allow(Utils::Tar).to receive(:validate_file).with(download)
+
+      expect(bump_cask_pr.replace_version_and_checksum(cask, nil, new_version, contents))
+        .to eq <<~RUBY
+          # leading comment
+          cask "foo" do
+            version "2.0"
+            sha256 "#{download.sha256}"
+
+            url "https://brew.sh/foo-\#{version}.dmg"
+            name "Foo"
+          end
+        RUBY
+    end
+
     it "splits a root version and single checksum before replacing the ARM values" do
       contents = <<~RUBY
         cask "foo" do


### PR DESCRIPTION
`brew bump --open-pr` fails on any cask whose file begins with a comment, as reported in #23735. While recalculating checksums, `bump-cask-pr` reloads the modified cask source from a string via the generic `Cask::CaskLoader.load`. `FromContentLoader.try_new` only matches content whose first non-whitespace token is `cask`, so a leading comment makes it fall through to the remaining loaders and the tail of the source is misread as a cask token, producing `Error: Cask 'texstudio.savedstate", ] end ' is unavailable`.

Use `Cask::CaskLoader::FromContentLoader` explicitly at that boundary, matching the `tmp_cask` load a few lines above. That was the last string load in the command still going through the generic loader.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new test fails without the fix and passes with it, and ran `brew lgtm` + targeted specs.

-----
