### PR TITLE
formula_creator: add deny network for cabal and zig

### DIFF
--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -225,7 +225,7 @@ module Homebrew
           # end
 
         <% end %>
-        <% if [:crystal, :node, :python, :ruby, :zig].exclude? @mode %>
+        <% if [:crystal, :node, :python, :ruby].exclude? @mode %>
           deny_network_access!
 
         <% end %>
@@ -243,6 +243,11 @@ module Homebrew
         <% elsif @mode == :rust %>
           def fetch
             system "cargo", "fetch", "--locked", "--target", "host-tuple"
+          end
+
+        <% elsif @mode == :zig %>
+          def fetch
+            system "zig", "build", "--fetch"
           end
 
         <% end %>

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -225,11 +225,17 @@ module Homebrew
           # end
 
         <% end %>
-        <% if [:autotools, :cmake, :go, :meson, :perl, :rust, nil].include? @mode %>
+        <% if [:crystal, :node, :python, :ruby, :zig].exclude? @mode %>
           deny_network_access!
 
         <% end %>
-        <% if @mode == :go %>
+        <% if @mode == :cabal %>
+          def fetch
+            system "cabal", "v2-update"
+            system "cabal", "v2-install", "--only-download", *std_cabal_v2_args
+          end
+
+        <% elsif @mode == :go %>
           def fetch
             system "go", "mod", "download"
           end
@@ -242,7 +248,6 @@ module Homebrew
         <% end %>
           def install
         <% if @mode == :cabal %>
-            system "cabal", "v2-update"
             system "cabal", "v2-install", *std_cabal_v2_args
         <% elsif @mode == :cmake %>
             system "cmake", "-S", ".", "-B", "build", *std_cmake_args

--- a/Library/Homebrew/test/formula_creator_spec.rb
+++ b/Library/Homebrew/test/formula_creator_spec.rb
@@ -98,6 +98,10 @@ RSpec.describe Homebrew::FormulaCreator do
                     includes: ["deny_network_access!", "std_configure_args", "unrecognized options"],
                     excludes: ['resource "']
 
+    it_behaves_like "expected", :cabal,
+                    includes: ["deny_network_access!", "std_cabal_v2_args", /"cabal".*"--only-download"/],
+                    excludes: ["unrecognized options", 'resource "']
+
     it_behaves_like "expected", :cmake,
                     includes: ["deny_network_access!", "std_cmake_args"],
                     excludes: ["unrecognized options", 'resource "']

--- a/Library/Homebrew/test/formula_creator_spec.rb
+++ b/Library/Homebrew/test/formula_creator_spec.rb
@@ -122,6 +122,10 @@ RSpec.describe Homebrew::FormulaCreator do
                     includes: ["deny_network_access!", "std_cargo_args", /"cargo".*"fetch"/],
                     excludes: ["unrecognized options", 'resource "']
 
+    it_behaves_like "expected", :zig,
+                    includes: ["deny_network_access!", "std_zig_args", "--fetch"],
+                    excludes: ["unrecognized options", 'resource "']
+
     it_behaves_like "expected", nil,
                     includes: ["deny_network_access!", "unrecognized options"],
                     excludes: ['resource "']


### PR DESCRIPTION
Continuing work on extending `deny_network_access!`.

For Cabal, using `std_cabal_v2_args` as that includes resolver arguments (e.g. backjumps) which are needed during fetch
- https://github.com/Homebrew/homebrew-core/pull/301832

For Zig, can default to plain `--fetch` (skip lazy deps) and switch to `--fetch=all` only when lazy deps are needed:
- https://github.com/Homebrew/homebrew-core/pull/301864

Also invert the list as shorter to list remaining modes. Still working on some issues with crystal (https://github.com/Homebrew/homebrew-core/pull/301831) ~~and zig (https://github.com/Homebrew/homebrew-core/pull/301796)~~ before we can update formulae.

Was also trying out Ruby `bundle cache` but working through some errors.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
