### PR TITLE
services: recognize both macOS service labels

### DIFF
--- a/Library/Homebrew/bundle/brew_services.rb
+++ b/Library/Homebrew/bundle/brew_services.rb
@@ -90,6 +90,17 @@ module Homebrew
             )
           end
 
+          sig { params(formula: Formula, prefix: Pathname).returns(T.nilable(Pathname)) }
+          def service_file_for(formula, prefix)
+            service_files = if Homebrew::Services::System.launchctl?
+              formula.plist_names.map { |name| prefix/"#{name}.plist" }
+            else
+              [prefix/"#{formula.service_name}.service"]
+            end
+
+            service_files.find(&:file?)
+          end
+
           sig { params(name: String).returns(T.nilable(Pathname)) }
           def versioned_service_file(name)
             env_version = Bundle.formula_versions_from_env(name)
@@ -99,13 +110,7 @@ module Homebrew
             prefix = formula.rack/env_version
             return unless prefix.directory?
 
-            service_file = if Homebrew::Services::System.launchctl?
-              prefix/"#{formula.plist_name}.plist"
-            else
-              prefix/"#{formula.service_name}.service"
-            end
-
-            service_file if service_file.file?
+            service_file_for(formula, prefix)
           end
         end
 

--- a/Library/Homebrew/bundle/subcommand/exec.rb
+++ b/Library/Homebrew/bundle/subcommand/exec.rb
@@ -356,18 +356,14 @@ module Homebrew
           entries_formulae.filter_map do |entry, formula|
             service_file = Homebrew::Bundle::Brew::Services.versioned_service_file(entry.name)
 
-            unless service_file&.file?
+            if service_file.nil?
               prefix = formula.any_installed_prefix
               next if prefix.nil?
 
-              service_file = if Homebrew::Services::System.launchctl?
-                prefix/"#{formula.plist_name}.plist"
-              else
-                prefix/"#{formula.service_name}.service"
-              end
+              service_file = Homebrew::Bundle::Brew::Services.service_file_for(formula, prefix)
             end
 
-            next unless service_file.file?
+            next if service_file.nil?
 
             info = services_info.find { |candidate| candidate["name"] == formula.name }
             conflicting_services = services_info.select do |candidate|

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1468,13 +1468,28 @@ class Formula
   sig { returns(String) }
   def plist_name = service.plist_name
 
+  # The generated launchd {.plist} service names, including compatible defaults.
+  sig { returns(T::Array[String]) }
+  def plist_names
+    return [plist_name] if plist_name != service.plist_name
+
+    service.plist_names
+  end
+
   # The generated service name.
   sig { returns(String) }
   def service_name = service.service_name
 
-  # The generated launchd {.service} file path.
+  # The generated launchd {.plist} file path.
   sig { returns(Pathname) }
-  def launchd_service_path = (any_installed_prefix || opt_prefix)/"#{plist_name}.plist"
+  def launchd_service_path = launchd_service_paths.fetch(0)
+
+  # The generated launchd {.plist} file paths, including compatible defaults.
+  sig { returns(T::Array[Pathname]) }
+  def launchd_service_paths
+    prefix = any_installed_prefix || opt_prefix
+    plist_names.map { |name| prefix/"#{name}.plist" }
+  end
 
   # The generated systemd {.service} file path.
   sig { returns(Pathname) }

--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -49,6 +49,7 @@ module Homebrew
       @macos_legacy_timers = T.let(false, T::Boolean)
       @nice = T.let(nil, T.nilable(Integer))
       @plist_name = T.let(default_plist_name, String)
+      @plist_name_explicitly_set = T.let(false, T::Boolean)
       @process_type = T.let(nil, T.nilable(Symbol))
       @require_root = T.let(false, T::Boolean)
       @restart_delay = T.let(nil, T.nilable(Integer))
@@ -79,7 +80,24 @@ module Homebrew
 
     sig { returns(String) }
     def default_plist_name
+      legacy_plist_name
+    end
+
+    sig { returns(String) }
+    def legacy_plist_name
       "homebrew.mxcl.#{@formula.name}"
+    end
+
+    sig { returns(String) }
+    def canonical_plist_name
+      "sh.brew.#{@formula.name}"
+    end
+
+    sig { returns(T::Array[String]) }
+    def plist_names
+      return [plist_name] if @plist_name_explicitly_set
+
+      [plist_name, canonical_plist_name, legacy_plist_name].uniq
     end
 
     sig { returns(String) }
@@ -96,7 +114,10 @@ module Homebrew
     def name(macos: nil, linux: nil)
       raise TypeError, "Service#name expects at least one String" if [macos, linux].none?(String)
 
-      @plist_name = macos if macos
+      if macos
+        @plist_name = macos
+        @plist_name_explicitly_set = true
+      end
       @service_name = linux if linux
     end
 

--- a/Library/Homebrew/services/cli.rb
+++ b/Library/Homebrew/services/cli.rb
@@ -39,7 +39,7 @@ module Homebrew
                                        "--no-pager",
                                        "--no-legend")
         end.chomp.split("\n").filter_map do |svc|
-          svc[/homebrew(?>\.mxcl)?\.([\w+-.@]+)/]&.delete_suffix(".service")
+          svc[/(?:homebrew(?>\.mxcl)?|sh\.brew)\.([\w+-.@]+)/]&.delete_suffix(".service")
         end
       end
 
@@ -48,6 +48,20 @@ module Homebrew
       def self.check!(targets)
         raise UsageError, "Formula(e) missing, please provide a formula name or use `--all`." if targets.empty?
 
+        true
+      end
+
+      sig { params(service: Services::FormulaWrapper, running_status: String).returns(T::Boolean) }
+      def self.report_service_running_or_loaded?(service, running_status:)
+        status = if service.pid?
+          running_status
+        elsif System.launchctl? &&
+              (loaded_name = service.loaded_service_names.find { |name| name != service.service_name })
+          "loaded as `#{loaded_name}`"
+        end
+        return false if status.nil?
+
+        puts "Service `#{service.name}` already #{status}, use `#{bin} restart #{service.name}` to restart."
         true
       end
 
@@ -73,7 +87,7 @@ module Homebrew
       sig { returns(T::Array[String]) }
       def self.remove_unused_service_files
         cleaned = []
-        System.path.glob("homebrew.*.{plist,service,timer}").each do |file|
+        System.path.glob("{homebrew.*,sh.brew.*}.{plist,service,timer}").each do |file|
           next if running.include?(File.basename(file).sub(/\.(plist|service|timer)$/i, ""))
 
           puts "Removing unused service file: #{file}"
@@ -99,10 +113,9 @@ module Homebrew
         end
 
         targets.each do |service|
-          if service.pid?
-            puts "Service `#{service.name}` already running, use `#{bin} restart #{service.name}` to restart."
-            next
-          elsif System.root?
+          next if report_service_running_or_loaded?(service, running_status: "running")
+
+          if System.root?
             puts "Service `#{service.name}` cannot be run (but can be started) as root."
             next
           end
@@ -128,14 +141,11 @@ module Homebrew
         end
 
         targets.each do |service|
-          if service.pid?
-            puts "Service `#{service.name}` already started, use `#{bin} restart #{service.name}` to restart."
-            next
-          end
+          next if report_service_running_or_loaded?(service, running_status: "started")
 
           odie "Formula `#{service.name}` is not installed." unless service.installed?
 
-          file ||= if service.service_file.exist? || System.systemctl?
+          file ||= if service.source_service_file.exist? || System.systemctl?
             nil
           elsif service.formula.opt_prefix.exist? &&
                 (keg = Keg.for service.formula.opt_prefix) &&
@@ -175,7 +185,11 @@ module Homebrew
         targets.each do |service|
           unless service.loaded?
             unless keep
-              rm service.dest if service.dest.exist? # get rid of installed service file anyway, dude
+              if System.systemctl?
+                rm service.dest if service.dest.exist?
+              else # System.launchctl?
+                service.destinations.each { |destination| rm destination if destination.exist? }
+              end
               rm service.timer_dest if System.systemctl? && service.timed? && service.timer_dest.exist?
             end
             if service.service_file_present?
@@ -183,9 +197,10 @@ module Homebrew
                 Service `#{service.name}` is started as `#{service.owner}`. Try:
                   #{"sudo " unless System.root?}#{bin} stop #{service.name}
               EOS
-            elsif System.launchctl? &&
-                  quiet_system(System.launchctl, "bootout", "#{System.domain_target}/#{service.service_name}")
-              ohai "Successfully stopped `#{service.name}` (label: #{service.service_name})"
+            elsif System.launchctl? && (stopped_name = service.service_names.find do |name|
+              quiet_system(System.launchctl, "bootout", "#{System.domain_target}/#{name}")
+            end)
+              ohai "Successfully stopped `#{service.name}` (label: #{stopped_name})"
             else
               opoo "Service `#{service.name}` is not started."
             end
@@ -211,44 +226,58 @@ module Homebrew
               System::Systemctl.quiet_run(*systemctl_args, "disable", "--now", service.service_name)
             end
           elsif System.launchctl?
+            loaded_service_names = service.loaded_service_names
             dont_wait_statuses = [
               Errno::ESRCH::Errno,
               System::LAUNCHCTL_DOMAIN_ACTION_NOT_SUPPORTED,
             ]
-            System.candidate_domain_targets.each do |domain_target|
-              break unless service.loaded?
+            loaded_service_names.each do |service_name|
+              System.candidate_domain_targets.each do |domain_target|
+                break unless System.launchctl_service_running?(service_name)
 
-              quiet_system System.launchctl, "bootout", "#{domain_target}/#{service.service_name}"
-              unless no_wait
-                time_slept = 0
-                sleep_time = 1
-                max_wait = T.must(max_wait)
-                exit_status = $CHILD_STATUS.exitstatus
-                while dont_wait_statuses.exclude?(exit_status) &&
-                      (exit_status == Errno::EINPROGRESS::Errno || service.loaded?) &&
-                      (max_wait.zero? || time_slept < max_wait)
-                  sleep(sleep_time)
-                  time_slept += sleep_time
-                  quiet_system System.launchctl, "bootout", "#{domain_target}/#{service.service_name}"
+                quiet_system System.launchctl, "bootout", "#{domain_target}/#{service_name}"
+                unless no_wait
+                  time_slept = 0
+                  sleep_time = 1
+                  max_wait = T.must(max_wait)
                   exit_status = $CHILD_STATUS.exitstatus
+                  while dont_wait_statuses.exclude?(exit_status) &&
+                        (exit_status == Errno::EINPROGRESS::Errno ||
+                         System.launchctl_service_running?(service_name)) &&
+                        (max_wait.zero? || time_slept < max_wait)
+                    sleep(sleep_time)
+                    time_slept += sleep_time
+                    quiet_system System.launchctl, "bootout", "#{domain_target}/#{service_name}"
+                    exit_status = $CHILD_STATUS.exitstatus
+                  end
                 end
+                quiet_system System.launchctl, "stop", "#{domain_target}/#{service_name}" if
+                  System.launchctl_service_running?(service_name)
               end
-              service.reset_cache!
-              quiet_system System.launchctl, "stop", "#{domain_target}/#{service.service_name}" if service.pid?
             end
+            service.reset_cache!
           end
 
           unless keep
-            rm service.dest if service.dest.exist?
+            if System.systemctl?
+              rm service.dest if service.dest.exist?
+            else # System.launchctl?
+              service.destinations.each { |destination| rm destination if destination.exist? }
+            end
             rm service.timer_dest if System.systemctl? && service.timed? && service.timer_dest.exist?
             # Run daemon-reload on systemctl to finish unloading stopped and deleted service.
             System::Systemctl.run(*systemctl_args, "daemon-reload") if System.systemctl?
           end
 
+          labels = if System.systemctl?
+            [service.service_name]
+          else # System.launchctl?
+            loaded_service_names.presence || service.service_names
+          end
           if service.loaded? || service.pid?
-            opoo "Unable to stop `#{service.name}` (label: #{service.service_name})"
+            opoo "Unable to stop `#{service.name}` (label: #{labels.join(", ")})"
           else
-            ohai "Successfully stopped `#{service.name}` (label: #{service.service_name})"
+            ohai "Successfully stopped `#{service.name}` (label: #{labels.join(", ")})"
           end
         end
       end
@@ -263,21 +292,24 @@ module Homebrew
             puts "Service `#{service.name}` is set to automatically restart and can't be killed."
           else
             puts "Killing `#{service.name}`... (might take a while)"
+            killed_service_names = [service.service_name]
             if System.systemctl?
               System::Systemctl.quiet_run("stop", service.service_name)
             elsif System.launchctl?
-              System.candidate_domain_targets.each do |domain_target|
-                break unless service.pid?
-
-                quiet_system System.launchctl, "stop", "#{domain_target}/#{service.service_name}"
-                service.reset_cache!
+              killed_service_names = service.loaded_service_names
+              killed_service_names.each do |service_name|
+                System.candidate_domain_targets.each do |domain_target|
+                  break if quiet_system System.launchctl, "stop", "#{domain_target}/#{service_name}"
+                end
               end
+              service.reset_cache!
             end
 
+            labels = killed_service_names.presence || [service.service_name]
             if service.pid?
-              opoo "Unable to kill `#{service.name}` (label: #{service.service_name})"
+              opoo "Unable to kill `#{service.name}` (label: #{labels.join(", ")})"
             else
-              ohai "Successfully killed `#{service.name}` (label: #{service.service_name})"
+              ohai "Successfully killed `#{service.name}` (label: #{labels.join(", ")})"
             end
           end
         end
@@ -388,7 +420,7 @@ module Homebrew
         end
 
         if System.launchctl?
-          file ||= enable ? service.dest : service.service_file
+          file ||= enable ? service.dest : service.source_service_file
           service.path_dirs.each(&:mkpath)
           launchctl_load(service, file:, enable:)
         elsif System.systemctl?
@@ -407,7 +439,7 @@ module Homebrew
       def self.install_service_file(service, file)
         raise UsageError, "Formula `#{service.name}` is not installed." unless service.installed?
 
-        unless service.service_file.exist?
+        unless service.source_service_file.exist?
           raise UsageError,
                 "Formula `#{service.name}` has not implemented #plist, #service or provided a locatable service file."
         end
@@ -431,7 +463,7 @@ module Homebrew
         end
         temp.flush
 
-        rm service.dest if service.dest.exist?
+        service.destinations.each { |destination| rm destination if destination.exist? }
         service.dest_dir.mkpath unless service.dest_dir.directory?
         cp T.must(temp.path), service.dest
 

--- a/Library/Homebrew/services/formula_wrapper.rb
+++ b/Library/Homebrew/services/formula_wrapper.rb
@@ -17,19 +17,26 @@ module Homebrew
       # Create a new `Service` instance from either a path or label.
       sig { params(path_or_label: T.any(Pathname, String)).returns(T.nilable(FormulaWrapper)) }
       def self.from(path_or_label)
-        return unless path_or_label =~ path_or_label_regex
+        label = path_or_label.to_s.sub(/\.(plist|service)\z/, "")
+        match = label.match(path_or_label_regex)
+        return unless match
+
+        service_name = match[1]
+        formula_name = match[2]
+        return if service_name.nil? || formula_name.nil?
 
         begin
-          new(Formulary.factory(T.must(Regexp.last_match(1))))
+          new(Formulary.factory(formula_name), service_name:)
         rescue
           nil
         end
       end
 
       # Initialize a new `Service` instance with supplied formula.
-      sig { params(formula: Formula).void }
-      def initialize(formula)
+      sig { params(formula: Formula, service_name: T.nilable(String)).void }
+      def initialize(formula, service_name: nil)
         @formula = formula
+        @service_name_override = service_name
         @status_output_success_type = T.let(nil, T.nilable(StatusOutputSuccessType))
 
         return if System.launchctl? || System.systemctl?
@@ -80,23 +87,46 @@ module Homebrew
       def service_name
         @service_name ||= T.let(
           if System.launchctl?
-            formula.plist_name
+            @service_name_override || formula.plist_name
           else # System.systemctl?
-            formula.service_name
+            @service_name_override || formula.service_name
           end, T.nilable(String)
+        )
+      end
+
+      sig { returns(T::Array[String]) }
+      def service_names
+        @service_names ||= T.let(
+          if @service_name_override
+            [@service_name_override]
+          elsif System.launchctl?
+            formula.plist_names
+          else # System.systemctl?
+            [formula.service_name]
+          end, T.nilable(T::Array[String])
         )
       end
 
       # service_file delegates with formula.launchd_service_path or formula.systemd_service_path for systemd.
       sig { returns(Pathname) }
       def service_file
-        @service_file ||= T.let(
+        service_files.fetch(0)
+      end
+
+      sig { returns(T::Array[Pathname]) }
+      def service_files
+        @service_files ||= T.let(
           if System.launchctl?
-            formula.launchd_service_path
+            formula.launchd_service_paths
           else # System.systemctl?
-            formula.systemd_service_path
-          end, T.nilable(Pathname)
+            [formula.systemd_service_path]
+          end, T.nilable(T::Array[Pathname])
         )
+      end
+
+      sig { returns(Pathname) }
+      def source_service_file
+        service_files.find(&:exist?) || service_file
       end
 
       sig { returns(Pathname) }
@@ -135,7 +165,26 @@ module Homebrew
       # Path to destination service. If run as root, it's in `boot_path`, else `user_path`.
       sig { returns(Pathname) }
       def dest
-        dest_dir + service_file.basename
+        destinations.fetch(0)
+      end
+
+      sig { returns(T::Array[Pathname]) }
+      def destinations
+        if System.launchctl?
+          service_names.map { |name| dest_dir/service_file_basename(name) }
+        else
+          [dest_dir/service_file.basename]
+        end
+      end
+
+      sig { returns(Pathname) }
+      def registered_destination
+        if System.launchctl?
+          active_destination = dest_dir/service_file_basename(active_service_name)
+          return active_destination if active_destination.exist?
+        end
+
+        destinations.find(&:exist?) || dest
       end
 
       # Returns `true` if any version of the formula is installed.
@@ -160,6 +209,19 @@ module Homebrew
         end
       end
 
+      sig { returns(T::Array[String]) }
+      def loaded_service_names
+        return [service_name] if System.systemctl? && loaded?
+        return [] unless System.launchctl?
+
+        service_names.select { |name| System.launchctl_service_running?(name) }
+      end
+
+      sig { returns(String) }
+      def active_service_name
+        status_output_success_type.service_name
+      end
+
       # Returns `true` if service is present (e.g. .plist is present in boot or user service path), else `false`
       # Accepts `type` with values `:root` for boot path or `:user` for user path.
       sig { params(type: T.nilable(Symbol)).returns(T::Boolean) }
@@ -176,11 +238,11 @@ module Homebrew
 
       sig { returns(T.nilable(String)) }
       def owner
-        if System.launchctl? && dest.exist?
+        if System.launchctl? && registered_destination.exist?
           # read the username from the plist file
           require "plist"
           plist = begin
-            Plist.parse_xml(dest.read, marshal: false)
+            Plist.parse_xml(registered_destination.read, marshal: false)
           rescue
             nil
           end
@@ -232,7 +294,7 @@ module Homebrew
       def to_hash
         hash = {
           name:,
-          service_name:,
+          service_name: active_service_name,
           running:      pid?,
           loaded:       loaded?(cached: true),
           schedulable:  timed?,
@@ -240,7 +302,7 @@ module Homebrew
           exit_code:,
           user:         owner,
           status:       status_symbol,
-          file:         service_file_present? ? dest : service_file,
+          file:         service_file_present? ? registered_destination : source_service_file,
           registered:   service_file_present?,
           loaded_file:,
         }
@@ -269,7 +331,7 @@ module Homebrew
       sig { returns(String) }
       def service_contents
         if !service? || !load_service.command?
-          service_file.read
+          source_service_file.read
         elsif System.launchctl?
           load_service.to_plist
         else
@@ -292,15 +354,32 @@ module Homebrew
       sig { returns(StatusOutputSuccessType) }
       def status_output_success_type
         @status_output_success_type ||= if System.launchctl?
-          output, success, type = System.launchctl_find_service(service_name)
-          StatusOutputSuccessType.new(output, success, type)
+          result = T.let(nil, T.nilable(StatusOutputSuccessType))
+          service_names.each do |name|
+            output, success, type = System.launchctl_find_service(name)
+            next unless success
+
+            candidate = StatusOutputSuccessType.new(output, success, type, name)
+            result ||= candidate
+            if status_pid(candidate)&.positive?
+              result = candidate
+              break
+            end
+          end
+          result || StatusOutputSuccessType.new("", false, :launchctl_list, service_name)
         else # System.systemctl?
           cmd = ["status", service_name]
           output = System::Systemctl.popen_read(*cmd).chomp
           success = T.cast($CHILD_STATUS.present? && $CHILD_STATUS.success? && output.present?, T::Boolean)
           odebug [System::Systemctl.executable, System::Systemctl.scope, *cmd].join(" "), output
-          StatusOutputSuccessType.new(output, success, :systemctl)
+          StatusOutputSuccessType.new(output, success, :systemctl, service_name)
         end
+      end
+
+      sig { params(result: StatusOutputSuccessType).returns(T.nilable(Integer)) }
+      def status_pid(result)
+        match = result.output.match(pid_regex(result.type))
+        match[1].to_i if match
       end
 
       sig { returns(String) }
@@ -374,7 +453,7 @@ module Homebrew
         boot_path = System.boot_path
         return false if boot_path.blank?
 
-        (boot_path + service_file.basename).exist?
+        service_names.any? { |name| (boot_path/service_file_basename(name)).exist? }
       end
 
       sig { returns(T::Boolean) }
@@ -382,12 +461,18 @@ module Homebrew
         user_path = System.user_path
         return false if user_path.blank?
 
-        (user_path + service_file.basename).exist?
+        service_names.any? { |name| (user_path/service_file_basename(name)).exist? }
+      end
+
+      sig { params(name: String).returns(String) }
+      def service_file_basename(name)
+        extension = System.launchctl? ? ".plist" : ".service"
+        "#{name}#{extension}"
       end
 
       sig { returns(Regexp) }
       private_class_method def self.path_or_label_regex
-        /homebrew(?>\.mxcl)?\.([\w+-.@]+)(\.plist|\.service)?\z/
+        /((?:homebrew(?>\.mxcl)?|sh\.brew)\.([\w+-.@]+))\z/
       end
 
       class StatusOutputSuccessType
@@ -400,11 +485,15 @@ module Homebrew
         sig { returns(Symbol) }
         attr_reader :type
 
-        sig { params(output: String, success: T::Boolean, type: Symbol).void }
-        def initialize(output, success, type)
+        sig { returns(String) }
+        attr_reader :service_name
+
+        sig { params(output: String, success: T::Boolean, type: Symbol, service_name: String).void }
+        def initialize(output, success, type, service_name)
           @output = output
           @success = success
           @type = type
+          @service_name = service_name
         end
       end
     end

--- a/Library/Homebrew/test/bundle/brew_services_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_services_spec.rb
@@ -139,6 +139,7 @@ RSpec.describe Homebrew::Bundle::Brew::Services do
         version:      "1.0",
         rack:         HOMEBREW_CELLAR/"fooformula",
         plist_name:   "homebrew.mxcl.fooformula",
+        plist_names:  ["homebrew.mxcl.fooformula", "sh.brew.fooformula"],
         service_name: "fooformula",
       )
     end
@@ -149,12 +150,9 @@ RSpec.describe Homebrew::Bundle::Brew::Services do
         expect(Homebrew::Bundle).to receive(:formula_versions_from_env).with(foo.name).and_return(foo.version)
 
         prefix = foo.rack/"1.0"
-        allow(FileTest).to receive(:directory?).and_call_original
-        expect(FileTest).to receive(:directory?).with(prefix.to_s).and_return(true)
-
+        prefix.mkpath
         service_file = prefix/service_basename
-        allow(FileTest).to receive(:file?).and_call_original
-        expect(FileTest).to receive(:file?).with(service_file.to_s).and_return(true)
+        service_file.write("service")
 
         expect(described_class.versioned_service_file(foo.name)).to eq(service_file)
       end
@@ -168,6 +166,19 @@ RSpec.describe Homebrew::Bundle::Brew::Services do
       let(:service_basename) { "#{foo.plist_name}.plist" }
 
       include_examples "returns the versioned service file"
+
+      it "returns the compatible versioned service file" do
+        expect(Formula).to receive(:[]).with(foo.name).and_return(foo)
+        expect(Homebrew::Bundle).to receive(:formula_versions_from_env).with(foo.name).and_return(foo.version)
+
+        prefix = foo.rack/foo.version
+        prefix.mkpath
+        service_file = prefix/"sh.brew.fooformula.plist"
+        (prefix/"homebrew.mxcl.fooformula.plist").unlink if (prefix/"homebrew.mxcl.fooformula.plist").exist?
+        service_file.write("service")
+
+        expect(described_class.versioned_service_file(foo.name)).to eq(service_file)
+      end
     end
 
     context "with systemd" do

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1496,8 +1496,22 @@ RSpec.describe Formula do
       end
 
       expect(f.plist_name).to eq("custom.macos.beanstalkd")
+      expect(f.plist_names).to eq(["custom.macos.beanstalkd"])
       expect(f.service_name).to eq("custom.linux.beanstalkd")
       expect(f.service.to_hash.keys).to contain_exactly(:name)
+    end
+
+    specify "service with an overridden plist_name" do
+      f = formula do
+        T.bind(self, T.class_of(Formula))
+        url "https://brew.sh/test-1.0.tbz"
+
+        def plist_name = "custom.override.name"
+      end
+
+      expect(f.plist_name).to eq("custom.override.name")
+      expect(f.plist_names).to eq(["custom.override.name"])
+      expect(f.launchd_service_paths).to eq([HOMEBREW_PREFIX/"opt/formula_name/custom.override.name.plist"])
     end
 
     specify "service helpers return data" do
@@ -1507,8 +1521,13 @@ RSpec.describe Formula do
       end
 
       expect(f.plist_name).to eq("homebrew.mxcl.formula_name")
+      expect(f.plist_names).to eq(["homebrew.mxcl.formula_name", "sh.brew.formula_name"])
       expect(f.service_name).to eq("homebrew.formula_name")
       expect(f.launchd_service_path).to eq(HOMEBREW_PREFIX/"opt/formula_name/homebrew.mxcl.formula_name.plist")
+      expect(f.launchd_service_paths).to eq([
+        HOMEBREW_PREFIX/"opt/formula_name/homebrew.mxcl.formula_name.plist",
+        HOMEBREW_PREFIX/"opt/formula_name/sh.brew.formula_name.plist",
+      ])
       expect(f.systemd_service_path).to eq(HOMEBREW_PREFIX/"opt/formula_name/homebrew.formula_name.service")
       expect(f.systemd_timer_path).to eq(HOMEBREW_PREFIX/"opt/formula_name/homebrew.formula_name.timer")
     end

--- a/Library/Homebrew/test/services/cli_spec.rb
+++ b/Library/Homebrew/test/services/cli_spec.rb
@@ -24,12 +24,12 @@ RSpec.describe Homebrew::Services::Cli do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: true, systemctl?: false)
       allow(Utils).to receive(:popen_read).and_return <<~EOS
         77513   50  homebrew.mxcl.php
-        495     0   homebrew.mxcl.node_exporter
+        495     0   sh.brew.node_exporter
         1234    34  homebrew.mxcl.postgresql@14
       EOS
       expect(services_cli.running).to eq([
         "homebrew.mxcl.php",
-        "homebrew.mxcl.node_exporter",
+        "sh.brew.node_exporter",
         "homebrew.mxcl.postgresql@14",
       ])
     end
@@ -73,11 +73,12 @@ RSpec.describe Homebrew::Services::Cli do
     it "tries but is unable to kill a non existing service" do
       service = instance_double(
         service_string,
-        name:         "example_service",
-        service_name: "homebrew.example_service",
-        pid?:         true,
-        dest:         Pathname("this_path_does_not_exist"),
-        keep_alive?:  false,
+        name:                 "example_service",
+        service_name:         "homebrew.example_service",
+        pid?:                 true,
+        dest:                 Pathname("this_path_does_not_exist"),
+        keep_alive?:          false,
+        loaded_service_names: [],
       )
       allow(service).to receive(:reset_cache!)
       allow(Homebrew::Services::FormulaWrapper).to receive(:from).and_return(service)
@@ -104,6 +105,22 @@ RSpec.describe Homebrew::Services::Cli do
       expect(active_timer).to exist
       expect(stale_timer).not_to exist
     end
+
+    it "removes unused canonical macOS service files" do
+      path = mktmpdir
+      active_service = path/"sh.brew.name.plist"
+      stale_service = path/"sh.brew.stale.plist"
+      active_service.write("service")
+      stale_service.write("service")
+      allow(Homebrew::Services::System).to receive(:path).and_return(path)
+      allow(services_cli).to receive(:running).and_return(["sh.brew.name"])
+
+      expect do
+        expect(services_cli.remove_unused_service_files).to eq([stale_service.to_s])
+      end.to output("Removing unused service file: #{stale_service}\n").to_stdout
+      expect(active_service).to exist
+      expect(stale_service).not_to exist
+    end
   end
 
   describe "#run" do
@@ -127,6 +144,22 @@ RSpec.describe Homebrew::Services::Cli do
       expect do
         services_cli.run([service])
       end.to output(expected_output).to_stdout
+    end
+
+    it "does not run a service already loaded with the compatible macOS label" do
+      allow(Homebrew::Services::System).to receive(:launchctl?).and_return(true)
+      service = instance_double(
+        service_string,
+        name:                 "name",
+        service_name:         "homebrew.mxcl.name",
+        loaded_service_names: ["sh.brew.name"],
+        pid?:                 false,
+      )
+      expect(services_cli).not_to receive(:service_load)
+
+      expect do
+        services_cli.run([service])
+      end.to output(/already loaded as `sh.brew.name`/).to_stdout
     end
   end
 
@@ -157,15 +190,28 @@ RSpec.describe Homebrew::Services::Cli do
       let(:service) do
         instance_double(
           Homebrew::Services::FormulaWrapper,
-          name:         "name",
-          pid?:         false,
-          installed?:   true,
-          service_file: instance_double(Pathname, exist?: true),
+          name:                 "name",
+          service_name:         "homebrew.mxcl.name",
+          loaded_service_names: [],
+          pid?:                 false,
+          installed?:           true,
+          service_file:         instance_double(Pathname, exist?: true),
+          source_service_file:  instance_double(Pathname, exist?: true),
         )
       end
 
       before do
         allow(services_cli).to receive(:install_service_file)
+      end
+
+      it "does not load a service already loaded under the compatible label" do
+        allow(Homebrew::Services::System).to receive(:launchctl?).and_return(true)
+        allow(service).to receive(:loaded_service_names).and_return(["sh.brew.name"])
+        expect(services_cli).not_to receive(:install_service_file)
+
+        expect do
+          services_cli.start([service])
+        end.to output(/already loaded as `sh.brew.name`/).to_stdout
       end
 
       it "loads service for root" do
@@ -261,6 +307,43 @@ RSpec.describe Homebrew::Services::Cli do
       end.to output(/Successfully stopped `name`/).to_stdout
       expect(timer_dest).not_to exist
     end
+
+    it "stops and removes both compatible macOS service labels" do
+      allow(Homebrew::Services::System).to receive_messages(
+        launchctl?:               true,
+        systemctl?:               false,
+        launchctl:                Pathname("/bin/launchctl"),
+        candidate_domain_targets: ["gui/501"],
+      )
+      allow(Homebrew::Services::System).to receive(:launchctl_service_running?)
+        .with("homebrew.mxcl.name").and_return(true, false)
+      allow(Homebrew::Services::System).to receive(:launchctl_service_running?)
+        .with("sh.brew.name").and_return(true, false)
+      expect(services_cli).to receive(:quiet_system)
+        .with(Pathname("/bin/launchctl"), "bootout", "gui/501/homebrew.mxcl.name")
+      expect(services_cli).to receive(:quiet_system)
+        .with(Pathname("/bin/launchctl"), "bootout", "gui/501/sh.brew.name")
+
+      dest_dir = mktmpdir
+      destinations = [dest_dir/"homebrew.mxcl.name.plist", dest_dir/"sh.brew.name.plist"]
+      destinations.each { |destination| destination.write("service") }
+      service = instance_double(
+        Homebrew::Services::FormulaWrapper,
+        name:                 "name",
+        service_name:         "homebrew.mxcl.name",
+        service_names:        ["homebrew.mxcl.name", "sh.brew.name"],
+        loaded_service_names: ["homebrew.mxcl.name", "sh.brew.name"],
+        destinations:,
+        pid?:                 false,
+      )
+      allow(service).to receive(:loaded?).and_return(true, false)
+      allow(service).to receive(:reset_cache!)
+
+      expect do
+        services_cli.stop([service], no_wait: true)
+      end.to output(/Successfully stopped `name`/).to_stdout
+      expect(destinations).not_to include(an_object_satisfying(&:exist?))
+    end
   end
 
   describe "#kill" do
@@ -283,6 +366,31 @@ RSpec.describe Homebrew::Services::Cli do
       expect do
         services_cli.kill([service])
       end.to output(expected_output).to_stdout
+    end
+
+    it "reports the compatible macOS label that was killed and stops after success" do
+      service = instance_double(
+        service_string,
+        name:                 "name",
+        service_name:         "homebrew.mxcl.name",
+        keep_alive?:          false,
+        loaded_service_names: ["sh.brew.name"],
+      )
+      allow(service).to receive(:pid?).and_return(true, false)
+      allow(service).to receive(:reset_cache!)
+      allow(Homebrew::Services::System).to receive_messages(
+        candidate_domain_targets:   ["gui/501", "user/501"],
+        launchctl:                  "/bin/launchctl",
+        launchctl?:                 true,
+        launchctl_service_running?: true,
+        systemctl?:                 false,
+      )
+      expect(services_cli).to receive(:quiet_system)
+        .with("/bin/launchctl", "stop", "gui/501/sh.brew.name").once.and_return(true)
+
+      expect do
+        services_cli.kill([service])
+      end.to output(/Successfully killed `name` \(label: sh\.brew\.name\)/).to_stdout
     end
   end
 
@@ -312,9 +420,10 @@ RSpec.describe Homebrew::Services::Cli do
     it "checks service file exists" do
       service = instance_double(
         Homebrew::Services::FormulaWrapper,
-        name:         "name",
-        installed?:   true,
-        service_file: instance_double(Pathname, exist?: false),
+        name:                "name",
+        installed?:          true,
+        service_file:        instance_double(Pathname, exist?: false),
+        source_service_file: instance_double(Pathname, exist?: false),
       )
       expect do
         services_cli.install_service_file(service, nil)
@@ -322,6 +431,34 @@ RSpec.describe Homebrew::Services::Cli do
         UsageError,
         "Invalid usage: Formula `name` has not implemented #plist, #service or provided a locatable service file.",
       )
+    end
+
+    it "removes compatible macOS service files before installing" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: true, systemctl?: false)
+
+      source_dir = mktmpdir
+      dest_dir = mktmpdir
+      service_file = source_dir/"homebrew.mxcl.name.plist"
+      primary_dest = dest_dir/"homebrew.mxcl.name.plist"
+      compatible_dest = dest_dir/"sh.brew.name.plist"
+      service_file.write("service")
+      primary_dest.write("old service")
+      compatible_dest.write("compatible service")
+      service = instance_double(
+        Homebrew::Services::FormulaWrapper,
+        name:                "name",
+        service_name:        "homebrew.mxcl.name",
+        installed?:          true,
+        source_service_file: service_file,
+        service_contents:    "service",
+        dest:                primary_dest,
+        destinations:        [primary_dest, compatible_dest],
+        dest_dir:,
+      )
+
+      services_cli.install_service_file(service, nil)
+
+      expect([primary_dest.read, compatible_dest.exist?]).to eq(["service", false])
     end
 
     it "installs timed systemd timer files" do
@@ -336,16 +473,18 @@ RSpec.describe Homebrew::Services::Cli do
       timer_file.write("timer")
       service = instance_double(
         Homebrew::Services::FormulaWrapper,
-        name:             "name",
-        service_name:     "homebrew.name",
-        installed?:       true,
+        name:                "name",
+        service_name:        "homebrew.name",
+        installed?:          true,
         service_file:,
-        service_contents: "service",
-        dest:             dest_dir/service_file.basename,
+        source_service_file: service_file,
+        service_contents:    "service",
+        dest:                dest_dir/service_file.basename,
+        destinations:        [dest_dir/service_file.basename],
         dest_dir:,
-        timed?:           true,
+        timed?:              true,
         timer_file:,
-        timer_dest:       dest_dir/timer_file.basename,
+        timer_dest:          dest_dir/timer_file.basename,
       )
 
       services_cli.install_service_file(service, nil)
@@ -377,12 +516,14 @@ RSpec.describe Homebrew::Services::Cli do
         service_file.write(plist_xml)
         instance_double(
           Homebrew::Services::FormulaWrapper,
-          name:             "name",
-          service_name:     "homebrew.test",
-          installed?:       true,
+          name:                "name",
+          service_name:        "homebrew.test",
+          installed?:          true,
           service_file:,
-          service_contents: plist_xml,
-          dest:             dest_dir/"homebrew.test.plist",
+          source_service_file: service_file,
+          service_contents:    plist_xml,
+          dest:                dest_dir/"homebrew.test.plist",
+          destinations:        [dest_dir/"homebrew.test.plist"],
           dest_dir:,
         )
       end
@@ -603,11 +744,11 @@ RSpec.describe Homebrew::Services::Cli do
         services_cli.service_load(
           instance_double(
             Homebrew::Services::FormulaWrapper,
-            name:             "name",
-            service_name:     "service.name",
-            service_startup?: false,
-            service_file:     instance_double(Pathname, exist?: false),
-            path_dirs:        [],
+            name:                "name",
+            service_name:        "service.name",
+            service_startup?:    false,
+            source_service_file: instance_double(Pathname, exist?: false),
+            path_dirs:           [],
           ),
           nil,
           enable: true,
@@ -624,16 +765,39 @@ RSpec.describe Homebrew::Services::Cli do
         services_cli.service_load(
           instance_double(
             Homebrew::Services::FormulaWrapper,
-            name:             "name",
-            service_name:     "service.name",
-            service_startup?: false,
-            service_file:     instance_double(Pathname, exist?: false),
-            path_dirs:        [],
+            name:                "name",
+            service_name:        "service.name",
+            service_startup?:    false,
+            source_service_file: instance_double(Pathname, exist?: false),
+            path_dirs:           [],
           ),
           nil,
           enable: false,
         )
       end.to output("==> Successfully ran `name` (label: service.name)\n").to_stdout
+    end
+
+    it "runs a compatible macOS source service file" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: true, root?: false, systemctl?: false)
+
+      service_file = mktmpdir/"homebrew.mxcl.name.plist"
+      source_service_file = mktmpdir/"sh.brew.name.plist"
+      source_service_file.write("service")
+      service = instance_double(
+        Homebrew::Services::FormulaWrapper,
+        name:                "name",
+        service_name:        "homebrew.mxcl.name",
+        service_startup?:    false,
+        service_file:,
+        source_service_file:,
+        path_dirs:           [],
+      )
+      expect(services_cli).to receive(:launchctl_load)
+        .with(service, file: source_service_file, enable: false)
+
+      expect do
+        services_cli.service_load(service, nil, enable: false)
+      end.to output("==> Successfully ran `name` (label: homebrew.mxcl.name)\n").to_stdout
     end
 
     it "creates service path directories before loading" do
@@ -653,10 +817,10 @@ RSpec.describe Homebrew::Services::Cli do
         services_cli.service_load(
           instance_double(
             Homebrew::Services::FormulaWrapper,
-            name:             "name",
-            service_name:     "service.name",
-            service_startup?: false,
-            service_file:     instance_double(Pathname, exist?: false),
+            name:                "name",
+            service_name:        "service.name",
+            service_startup?:    false,
+            source_service_file: instance_double(Pathname, exist?: false),
             path_dirs:,
           ),
           nil,

--- a/Library/Homebrew/test/services/formula_wrapper_spec.rb
+++ b/Library/Homebrew/test/services/formula_wrapper_spec.rb
@@ -11,9 +11,11 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
   let(:formula) do
     instance_double(Formula,
                     name:                   "mysql",
-                    plist_name:             "plist-mysql-test",
-                    service_name:           "plist-mysql-test",
-                    launchd_service_path:   Pathname.new("/usr/local/opt/mysql/homebrew.mysql.plist"),
+                    plist_name:             "sh.brew.mysql",
+                    plist_names:            ["sh.brew.mysql"],
+                    service_name:           "homebrew.mysql",
+                    launchd_service_path:   Pathname.new("/usr/local/opt/mysql/sh.brew.mysql.plist"),
+                    launchd_service_paths:  [Pathname.new("/usr/local/opt/mysql/sh.brew.mysql.plist")],
                     systemd_service_path:   Pathname.new("/usr/local/opt/mysql/homebrew.mysql.service"),
                     systemd_timer_path:     Pathname.new("/usr/local/opt/mysql/homebrew.mysql.timer"),
                     opt_prefix:             Pathname.new("/usr/local/opt/mysql"),
@@ -43,7 +45,7 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
   describe "#service_file" do
     it "macOS - outputs the full service file path" do
       allow(Homebrew::Services::System).to receive(:launchctl?).and_return(true)
-      expect(service.service_file.to_s).to eq("/usr/local/opt/mysql/homebrew.mysql.plist")
+      expect(service.service_file.to_s).to eq("/usr/local/opt/mysql/sh.brew.mysql.plist")
     end
 
     it "systemD - outputs the full service file path" do
@@ -57,6 +59,30 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
         service.service_file
       end.to raise_error(UsageError,
                          "Invalid usage: `brew services` is supported only on macOS or Linux (with systemd)!")
+    end
+  end
+
+  describe "#source_service_file" do
+    before do
+      allow(Homebrew::Services::System).to receive(:launchctl?).and_return(true)
+    end
+
+    it "uses the compatible macOS service file when it is the only one present" do
+      source_dir = mktmpdir
+      service_files = [source_dir/"homebrew.mxcl.mysql.plist", source_dir/"sh.brew.mysql.plist"]
+      service_files.last.write("service")
+      allow(formula).to receive(:launchd_service_paths).and_return(service_files)
+
+      expect(service.source_service_file).to eq(service_files.last)
+    end
+
+    it "prefers the legacy macOS service file while it remains the write default" do
+      source_dir = mktmpdir
+      service_files = [source_dir/"homebrew.mxcl.mysql.plist", source_dir/"sh.brew.mysql.plist"]
+      service_files.each { |file| file.write("service") }
+      allow(formula).to receive(:launchd_service_paths).and_return(service_files)
+
+      expect(service.source_service_file).to eq(service_files.first)
     end
   end
 
@@ -104,12 +130,12 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
   describe "#service_name" do
     it "macOS - outputs the service name" do
       allow(Homebrew::Services::System).to receive(:launchctl?).and_return(true)
-      expect(service.service_name).to eq("plist-mysql-test")
+      expect(service.service_name).to eq("sh.brew.mysql")
     end
 
     it "systemD - outputs the service name" do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
-      expect(service.service_name).to eq("plist-mysql-test")
+      expect(service.service_name).to eq("homebrew.mysql")
     end
 
     it "Other - raises an error" do
@@ -118,6 +144,15 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
         service.service_name
       end.to raise_error(UsageError,
                          "Invalid usage: `brew services` is supported only on macOS or Linux (with systemd)!")
+    end
+  end
+
+  describe "#service_names" do
+    it "includes both compatible default macOS labels" do
+      allow(Homebrew::Services::System).to receive(:launchctl?).and_return(true)
+      allow(formula).to receive(:plist_names).and_return(["homebrew.mxcl.mysql", "sh.brew.mysql"])
+
+      expect(service.service_names).to eq(["homebrew.mxcl.mysql", "sh.brew.mysql"])
     end
   end
 
@@ -157,7 +192,7 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
 
     it "macOS - outputs the destination for the service file" do
       allow(Homebrew::Services::System).to receive(:launchctl?).and_return(true)
-      expect(service.dest.to_s).to eq("/tmp_home/Library/LaunchAgents/homebrew.mysql.plist")
+      expect(service.dest.to_s).to eq("/tmp_home/Library/LaunchAgents/sh.brew.mysql.plist")
     end
 
     it "systemD - outputs the destination for the service file" do
@@ -177,6 +212,40 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: true, systemctl?: false)
       allow(Utils).to receive(:safe_popen_read)
       expect(service.loaded?).to be(false)
+    end
+
+    it "finds a service loaded with the compatible macOS label" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: true, systemctl?: false)
+      allow(formula).to receive(:plist_names).and_return(["homebrew.mxcl.mysql", "sh.brew.mysql"])
+      allow(Homebrew::Services::System).to receive(:launchctl_find_service)
+        .with("homebrew.mxcl.mysql").and_return(["", false, :launchctl_list])
+      allow(Homebrew::Services::System).to receive(:launchctl_find_service)
+        .with("sh.brew.mysql").and_return(["pid = 123", true, :launchctl_print])
+
+      expect(service.loaded?).to be(true)
+      expect(service.pid).to eq(123)
+      expect(service.active_service_name).to eq("sh.brew.mysql")
+    end
+
+    it "stops probing compatible labels after finding a running service" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: true, systemctl?: false)
+      allow(formula).to receive(:plist_names).and_return(["homebrew.mxcl.mysql", "sh.brew.mysql"])
+      expect(Homebrew::Services::System).to receive(:launchctl_find_service)
+        .with("homebrew.mxcl.mysql").and_return(["pid = 123", true, :launchctl_print])
+      expect(Homebrew::Services::System).not_to receive(:launchctl_find_service).with("sh.brew.mysql")
+
+      expect(service.active_service_name).to eq("homebrew.mxcl.mysql")
+    end
+
+    it "prefers a running compatible label over an earlier loaded label" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: true, systemctl?: false)
+      allow(formula).to receive(:plist_names).and_return(["homebrew.mxcl.mysql", "sh.brew.mysql"])
+      allow(Homebrew::Services::System).to receive(:launchctl_find_service)
+        .with("homebrew.mxcl.mysql").and_return(["last exit code = 0", true, :launchctl_print])
+      allow(Homebrew::Services::System).to receive(:launchctl_find_service)
+        .with("sh.brew.mysql").and_return(["pid = 123", true, :launchctl_print])
+
+      expect(service.active_service_name).to eq("sh.brew.mysql")
     end
 
     it "systemD - outputs if the service is loaded" do
@@ -256,6 +325,34 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
     it "macOS - outputs if the service file is present for user" do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: true, systemctl?: false)
       expect(service.service_file_present?(type: :user)).to be(false)
+    end
+  end
+
+  describe "#registered_destination" do
+    it "prefers the service file matching the active compatible label" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: true, root?: false, systemctl?: false)
+      allow(formula).to receive(:plist_names).and_return(["homebrew.mxcl.mysql", "sh.brew.mysql"])
+      allow(Homebrew::Services::System).to receive(:launchctl_find_service)
+        .with("homebrew.mxcl.mysql").and_return(["", false, :launchctl_list])
+      allow(Homebrew::Services::System).to receive(:launchctl_find_service)
+        .with("sh.brew.mysql").and_return(["pid = 123", true, :launchctl_print])
+      allow(service).to receive(:dest_dir).and_return(mktmpdir)
+      service.destinations.each { |destination| destination.write("service") }
+
+      expect(service.registered_destination.basename.to_s).to eq("sh.brew.mysql.plist")
+    end
+  end
+
+  describe ".from" do
+    it "keeps the exact compatible label it discovers" do
+      allow(Homebrew::Services::System).to receive(:launchctl?).and_return(true)
+      allow(Formulary).to receive(:factory).with("mysql").and_return(formula)
+
+      discovered_service = described_class.from("/tmp/sh.brew.mysql.plist")
+      raise "Expected service to be discovered" unless discovered_service
+
+      expect(discovered_service.service_names).to eq(["sh.brew.mysql"])
+      expect(discovered_service.dest).to eq(Pathname("/tmp_home/Library/LaunchAgents/sh.brew.mysql.plist"))
     end
   end
 
@@ -417,7 +514,7 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
                                                                  service_file_present?: false)
       expected = {
         exit_code:    nil,
-        file:         Pathname.new("/usr/local/opt/mysql/homebrew.mysql.plist"),
+        file:         Pathname.new("/usr/local/opt/mysql/sh.brew.mysql.plist"),
         loaded:       false,
         loaded_file:  nil,
         name:         "mysql",
@@ -425,7 +522,7 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
         registered:   false,
         running:      false,
         schedulable:  false,
-        service_name: "plist-mysql-test",
+        service_name: "sh.brew.mysql",
         status:       :none,
         user:         nil,
       }
@@ -439,7 +536,7 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
       expect(service).to receive(:service_file_present?).twice.and_return(true)
       expected = {
         exit_code:    nil,
-        file:         Pathname.new("/tmp_home/Library/LaunchAgents/homebrew.mysql.plist"),
+        file:         Pathname.new("/tmp_home/Library/LaunchAgents/sh.brew.mysql.plist"),
         loaded:       false,
         loaded_file:  nil,
         name:         "mysql",
@@ -447,7 +544,7 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
         registered:   true,
         running:      false,
         schedulable:  false,
-        service_name: "plist-mysql-test",
+        service_name: "sh.brew.mysql",
         status:       :none,
         user:         nil,
       }
@@ -465,7 +562,7 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
         cron:           nil,
         error_log_path: nil,
         exit_code:      nil,
-        file:           Pathname.new("/tmp_home/Library/LaunchAgents/homebrew.mysql.plist"),
+        file:           Pathname.new("/tmp_home/Library/LaunchAgents/sh.brew.mysql.plist"),
         interval:       nil,
         loaded:         false,
         loaded_file:    nil,
@@ -476,7 +573,7 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
         root_dir:       nil,
         running:        false,
         schedulable:    false,
-        service_name:   "plist-mysql-test",
+        service_name:   "sh.brew.mysql",
         status:         :none,
         user:           nil,
         working_dir:    nil,

--- a/Library/Homebrew/test/utils/service_spec.rb
+++ b/Library/Homebrew/test/utils/service_spec.rb
@@ -25,6 +25,20 @@ RSpec.describe Utils::Service do
       expect(described_class.running?(f)).to be true
     end
 
+    it "checks the compatible macOS label when the current label is not running" do
+      f = formula do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      allow(described_class).to receive(:launchctl?).and_return(true)
+      expect(Homebrew::Services::System).to receive(:launchctl_service_running?)
+        .with("homebrew.mxcl.formula_name").and_return(false)
+      expect(Homebrew::Services::System).to receive(:launchctl_service_running?)
+        .with("sh.brew.formula_name").and_return(true)
+
+      expect(described_class.running?(f)).to be true
+    end
+
     it "uses systemctl is-active when systemctl is available" do
       f = formula do
         T.bind(self, T.class_of(Formula))
@@ -36,6 +50,22 @@ RSpec.describe Utils::Service do
         .with(instance_of(Pathname), "is-active", "--quiet", f.service_name)
         .and_return(true)
       expect(described_class.running?(f)).to be true
+    end
+  end
+
+  describe "::installed?" do
+    it "finds a compatible macOS service file" do
+      f = formula do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      allow(described_class).to receive(:launchctl?).and_return(true)
+      allow(f).to receive(:launchd_service_paths).and_return([
+        instance_double(Pathname, exist?: false),
+        instance_double(Pathname, exist?: true),
+      ])
+
+      expect(described_class.installed?(f)).to be(true)
     end
   end
 

--- a/Library/Homebrew/utils/service.rb
+++ b/Library/Homebrew/utils/service.rb
@@ -10,7 +10,9 @@ module Utils
     sig { params(formula: Formula).returns(T::Boolean) }
     def self.running?(formula)
       if launchctl?
-        Homebrew::Services::System.launchctl_service_running?(formula.plist_name)
+        formula.plist_names.any? do |name|
+          Homebrew::Services::System.launchctl_service_running?(name)
+        end
       elsif systemctl?
         quiet_system(systemctl, "is-active", "--quiet", formula.service_name)
       else
@@ -21,7 +23,7 @@ module Utils
     # Check if a service file is installed in the expected location.
     sig { params(formula: Formula).returns(T::Boolean) }
     def self.installed?(formula)
-      (launchctl? && formula.launchd_service_path.exist?) ||
+      (launchctl? && formula.launchd_service_paths.any?(&:exist?)) ||
         (systemctl? && formula.systemd_service_path.exist?)
     end
 


### PR DESCRIPTION
`brew services` assumes a macOS service is always labeled `homebrew.mxcl.<formula>`. This is phase one of moving that default to `sh.brew.<formula>`: discovery and control now accept either label, so both forms can coexist safely before the default is flipped. The label written to disk does not change here, and the formula API serialization is unchanged.

Formulae using the default macOS name expose both labels. An explicit `name macos:` stays single valued and gains no inferred alias, and a `Formula` subclass overriding `plist_name` keeps its custom identity. Status probes both labels and reports the one actually loaded; `stop` and `kill` act on the exact labels found; `start` will not bootstrap a second job when the alternate label is already registered; orphan cleanup stays pinned to the label it discovered, so it cannot kill a registered sibling. `brew bundle` version pinned lookup and `brew bundle exec` accept either plist filename. Linux and systemd behavior is unchanged.

This also fixes `Services::FormulaWrapper.from`, whose regex captured `foo.plist` as the formula name for any path or suffixed input, so it returned `nil` for every path passed to it.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the change and pass with it, and ran `brew lgtm --online`.

-----

