### PR TITLE
mcp_server: test that the cask loader stays behind the guard

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -76,6 +76,18 @@ module Cask
 
         content = ref.to_str
 
+        # Anything this matches is `instance_eval`ed as Ruby by `#load` below, so
+        # `Homebrew::McpServer::INLINE_CASK_DSL_REGEX` must reject everything this
+        # accepts. That guard exists because the MCP server forwards a "name"
+        # argument here verbatim. The two patterns are separate, so widening this
+        # one without widening that one re-opens arbitrary code execution through
+        # tools that advertise themselves as read-only.
+        #
+        # In particular, do not make this accept a leading comment to fix
+        # `brew bump --open-pr` on casks whose file starts with one. Callers that
+        # know they hold cask source should use `FromContentLoader.new` directly,
+        # as `bump-cask-pr` does.
+        #
         # Cache compiled regex
         @regex ||= T.let(
           begin

--- a/Library/Homebrew/mcp_server.rb
+++ b/Library/Homebrew/mcp_server.rb
@@ -20,6 +20,10 @@ module Homebrew
     ERROR_CODE = -32601
 
     # Reject inline `cask ... do`/`cask(...) {}` blocks the cask loader would eval as Ruby.
+    #
+    # Must match everything `Cask::CaskLoader::FromContentLoader.try_new` accepts,
+    # since that is what would be `instance_eval`ed. `cask_loader_spec.rb` locks
+    # that relationship down.
     INLINE_CASK_DSL_REGEX = /\A\s*cask\s*['"(]/
 
     SERVER_INFO = T.let({

--- a/Library/Homebrew/test/mcp_server_spec.rb
+++ b/Library/Homebrew/test/mcp_server_spec.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "mcp_server"
+require "cask/cask_loader"
 require "stringio"
 require "timeout"
 
@@ -181,6 +182,53 @@ RSpec.describe Homebrew::McpServer do
       }
       result = server.handle_request(request)
       expect(result).to eq({ jsonrpc:, id:, error: { message: "Invalid formula or cask argument", code: } })
+    end
+
+    # `Cask::CaskLoader::FromContentLoader#load` runs its content through
+    # `instance_eval`, so whatever `try_new` accepts is what the cask loader will
+    # execute as Ruby. This server forwards `formula_or_cask` to `brew` verbatim
+    # and relies on `INLINE_CASK_DSL_REGEX` to reject that set before spawning
+    # anything.
+    #
+    # The two patterns live in different files, so nothing stops one from being
+    # widened on its own. These examples lock the relationship down: widen the
+    # loader without widening the guard and they fail, rather than silently
+    # restoring arbitrary code execution through tools documented as read-only.
+    it "rejects every inline cask definition the cask loader would evaluate" do
+      [
+        %Q(cask "token" do\n  version "1.0"\nend),
+        %Q(cask 'token' do\n  version "1.0"\nend),
+        'cask "token" do; version "1.0"; end',
+        'cask("token") { version "1.0" }',
+        %Q(\n\n  cask "token" do\n  version "1.0"\nend\n),
+      ].each do |content|
+        expect(Cask::CaskLoader::FromContentLoader.try_new(content)).not_to be_nil
+        expect(Homebrew::McpServer::INLINE_CASK_DSL_REGEX.match?(content)).to be(true), content.inspect
+      end
+    end
+
+    it "does not reject a plain cask token" do
+      token = "token"
+
+      expect(Cask::CaskLoader::FromContentLoader.try_new(token)).to be_nil
+      expect(Homebrew::McpServer::INLINE_CASK_DSL_REGEX.match?(token)).to be(false)
+    end
+
+    # The other half of the same invariant, and the half with teeth. A leading
+    # comment stops `INLINE_CASK_DSL_REGEX` from matching, so this content
+    # reaches `brew` — which is only safe for as long as the cask loader refuses
+    # to evaluate it.
+    #
+    # `brew bump --open-pr` used to fail on casks whose file starts with a
+    # comment for exactly this reason (Homebrew/discussions#7043), and the
+    # tempting fix is to let `try_new` accept one. Doing that without widening
+    # the guard in the same commit restores arbitrary code execution through the
+    # MCP server, so this example fails first.
+    it "keeps the cask loader from evaluating content the guard lets through" do
+      content = %Q(# a comment\ncask "token" do\n  version "1.0"\nend)
+
+      expect(Homebrew::McpServer::INLINE_CASK_DSL_REGEX.match?(content)).to be(false)
+      expect(Cask::CaskLoader::FromContentLoader.try_new(content)).to be_nil
     end
 
     it "responds to tools/call for unknown tool" do


### PR DESCRIPTION
`Cask::CaskLoader::FromContentLoader#load` runs its content through `instance_eval`, so the set of strings `try_new` accepts is the set of strings the cask loader will execute as Ruby. The MCP server forwards its `formula_or_cask` argument to `brew` verbatim and relies on `INLINE_CASK_DSL_REGEX` to reject that set before spawning anything, which is what #22875 fixed.

The two patterns sit in different files with nothing tying them together. Today the guard does cover the loader — I checked each accepted form — but #23735 makes widening the loader look like the obvious fix: `brew bump --open-pr` failed on casks whose file begins with a comment, and letting `try_new` accept a leading comment would appear to solve that. It would also put `# x` followed by a cask block past the guard and into `instance_eval`, through tools that advertise themselves as read-only. #23738 fixed the bump path the right way instead, but nothing stops the next attempt.

This adds examples for both directions:

- every inline form `try_new` accepts is matched by `INLINE_CASK_DSL_REGEX`
- content the guard does *not* match is content `try_new` refuses

and cross-references the two patterns in comments.

The second example is the one with teeth. Widening `try_new`'s regex to allow a leading comment while leaving the guard alone makes it fail; without it the suite stays green through that change. No behaviour change.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

I used Claude Code (Claude Opus) to investigate #7043, find this gap and draft the change. I reviewed the diff myself and verified it locally: `brew lgtm` passes, and I confirmed the new example fails when `try_new`'s regex is widened to accept a leading comment and `INLINE_CASK_DSL_REGEX` is left unchanged, then passes again once reverted. No commit is attributed to AI, and I will answer review comments myself. This is my only AI-assisted PR open.

-----
