### PR TITLE
Fix two dead links in the docs

### DIFF
--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -1524,7 +1524,7 @@ Details of software names and brands will inevitably be lost in the conversion t
 
 * If the result of this process is a generic term, such as “Macintosh Installer”, try prepending the name of the vendor or developer, followed by a hyphen. If that doesn’t work, then just create the best name you can, based on the vendor’s web page.
 
-* If the result conflicts with the name of an existing cask or Homebrew/homebrew-core formula, make yours unique by prepending the name of the vendor or developer, followed by a hyphen. Example: [unison.rb](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/u/unison.rb) and [panic-unison.rb](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/p/panic-unison.rb).
+* If the result conflicts with the name of an existing cask or Homebrew/homebrew-core formula, make yours unique by prepending the name of the vendor or developer, followed by a hyphen. Example: [caffeine.rb](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/c/caffeine.rb) and [domzilla-caffeine.rb](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/d/domzilla-caffeine.rb).
 
 * If the result still conflicts with the name of an existing Homebrew/homebrew-core formula, adjust the name to better describe the difference by e.g. appending `-app`. Example: `appium` formula and `appium-desktop` cask, `angband` formula and `angband-app` cask.
 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -27,7 +27,7 @@ Search the tracker responsible for the failing component:
 - The tap's own tracker for a formula, cask or command from a non-Homebrew tap
 
 Also search [Homebrew Discussions](https://github.com/orgs/Homebrew/discussions) for support and related reports.
-The [Discourse archive](https://discourse.brew.sh/) is read-only historical material and will contain outdated instructions.
+The Discourse archive is no longer online; anything you find quoted from it is historical material and will contain outdated instructions.
 
 ## Collect diagnostic information
 


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

## What these changes do

Two dead links in `docs/`, found by requesting every URL in that directory.

**`docs/Cask-Cookbook.md`** illustrates "if the result conflicts with an existing cask or formula, prepend the name of the vendor or developer" with `Casks/u/unison.rb` and `Casks/p/panic-unison.rb`. Both return 404 from the GitHub contents API on `HEAD`. `unison` was renamed to `unison-app` — `cask_renames.json` carries `{"unison": "unison-app"}` — which is the *following* bullet's rule (append `-app` for a formula clash), and `panic-unison` no longer exists at all. So the example demonstrated neither half of the rule it was attached to, and its surviving half now demonstrates a different rule.

Replaced with `caffeine` and `domzilla-caffeine`. Both are live, both are named exactly "Caffeine", and their homepages are different vendors (`intelliscapesolutions.com` and `caffeine-app.net`), so the pair shows a real name clash resolved by prepending the developer. I chose it by listing all 7,721 tokens from `formulae.brew.sh/api/cask.json` and keeping pairs where both `vendor-name` and `name` exist and the display names match.

**`docs/Troubleshooting.md`** sent readers to the Discourse archive as "read-only historical material". `discourse.brew.sh` is NXDOMAIN — the Google and Cloudflare resolvers both return no record, while `docs.brew.sh` resolves — so there is nothing there to search. The sentence now says the archive is offline and keeps the warning that quoted material is outdated, which is still useful when it surfaces in an old thread. The GitHub Discussions link on the line above is untouched and returns 200.

## Why I would like them included

Both links sit in the paths people are sent to when they are already stuck: the cookbook rule a first-time cask author reads, and the troubleshooting page. A 404 there costs the reader the example that was supposed to explain the rule.

## On the three unticked boxes

- Not a bug fix in code, so there are no `brew` commands to reproduce it. The reproduction is requesting the two URLs, both of which I re-verified through the contents API and `nslookup` rather than the HTML pages.
- Documentation prose only, so no tests.
- I could not run `brew lgtm`. `brew bundle exec bundle install` in `docs/` fails on this machine with `Could not find 'bundler' (4.0.16)` against the system Ruby 2.6, and I did not want to install a Ruby toolchain to check a two-line prose change. `brew lgtm` covers Ruby style, Sorbet and RSpec, none of which this diff touches; CI owns the docs build.

I also left `last_review_date` alone in both files. It records that a maintainer reviewed the page, and I touched two lines, so bumping it would claim more than I did.

## AI/LLM disclosure

Claude (Opus), via Claude Code, ran the link sweep, searched the cask API for a replacement pair and drafted this description. I reviewed the diff and the claims. No commit is attributed to AI: there is no `Assisted-by` or `Co-developed-by` trailer, per the rule in CONTRIBUTING.md. Every URL claim was re-verified through the GitHub contents API because github.com rate-limited the bulk sweep, and a 429 is indistinguishable from a 404 in a bulk check — `domzilla-caffeine.rb` looked dead for exactly that reason and was not. This is my only AI-assisted PR open here, per the one-at-a-time rule. I will answer review comments myself.

Apologies for the first version of this description: I annotated three of the checkbox lines with parentheses instead of leaving them verbatim and explaining below, which is what tripped the template check.
