### PR TITLE
Report invalid formulae in pr-pull

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -521,11 +521,7 @@ module Homebrew
             opoo "Can't check if updated bottles are necessary as `$HOMEBREW_DISABLE_LOAD_FORMULA` is set!"
             break []
           end
-          begin
-            Formulary.resolve(name)
-          rescue FormulaUnavailableError
-            nil
-          end
+          Formulary.resolve(name)
         end
         casks = Utils.popen_read("git", "-C", tap.path, "diff-tree",
                                  "-r", "--name-only", "--diff-filter=AM",

--- a/Library/Homebrew/test/dev-cmd/pr-pull_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-pull_spec.rb
@@ -101,6 +101,48 @@ RSpec.describe Homebrew::DevCmd::PrPull do
     end
   end
 
+  describe "#run" do
+    let(:third_party_tap) { Tap.fetch("someone", "foo") }
+
+    after { FileUtils.rm_rf(third_party_tap.path.parent) }
+
+    it "reports an invalid changed formula in a third-party tap" do
+      third_party_formula = third_party_tap.formula_dir/"foo.rb"
+      third_party_formula.dirname.mkpath
+      third_party_formula.write(formula)
+
+      cd third_party_tap.path do
+        safe_system Utils::Git.git, "init"
+        safe_system Utils::Git.git, "add", third_party_formula
+        safe_system Utils::Git.git, "commit", "-m", "foo 1.0 (new formula)"
+        original_hash = Utils.safe_popen_read("git", "rev-parse", "HEAD").chomp
+        third_party_formula.write <<~RUBY
+          class Foo < Formula
+            url "https://brew.sh/foo-2.0.tgz"
+            no_autobump! because: "some reason"
+          end
+        RUBY
+        safe_system Utils::Git.git, "commit", third_party_formula, "-m", "foo 2.0"
+        Formulary.clear_cache
+
+        allow(Homebrew::Trust).to receive(:trusted_tap?).with(third_party_tap).and_return(true)
+        allow(Tap).to receive(:from_path).and_return(third_party_tap)
+        allow(Utils::Git).to receive(:set_name_email!)
+        allow(Utils::Git).to receive(:setup_gpg!)
+        allow(GitHub).to receive_messages(pull_request_labels: [], issues: [], get_workflow_run: [],
+                                          get_artifact_urls: [])
+        ENV["GITHUB_SHA"] = original_hash
+
+        expect do
+          described_class.new([
+            "1", "--tap=#{third_party_tap.name}", "--head-sha=#{third_party_tap.git_head}",
+            "--no-commit", "--no-upload"
+          ]).run
+        end.to raise_error(TapFormulaUnreadableError, /no_autobump! can only be used in official Homebrew taps/)
+      end
+    end
+  end
+
   describe "#autosquash!" do
     it "squashes a formula or cask correctly" do
       secondary_author = "Someone Else <me@example.com>"


### PR DESCRIPTION
- Let changed formula load errors reach users instead of skipping artifacts.
- Cover third-party `no_autobump!` use with a regression test.

Fixes #23740

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Codex with GPT 5.6-sol at Extra High effort, with local review and testing.

-----