### PR TITLE
pkg: reset installer Git config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,6 +155,18 @@ jobs:
             echo "Privileged Git repository operations must use \`git_no_hooks\`."
             exit 1
           fi
+          # `core.hooksPath` does not cover config-specified programs such as
+          # `core.fsmonitor`, and Git reads both `.gitconfig` and, with
+          # `XDG_CONFIG_HOME` unset, `.config/git/config`, so a repository's Git
+          # configuration must go with its hooks.
+          if awk '/rm -rf .*\.git\/hooks/ && !(/\.gitconfig/ && /\.config\/git/) {
+                    print FILENAME ":" FNR ": " $0; found = 1
+                  }
+                  END { exit !found }' brew/package/scripts/postinstall
+          then
+            echo "Removing \`.git/hooks\` must also remove \`.gitconfig\` and \`.config/git\`."
+            exit 1
+          fi
 
       - name: Open macOS keychain
         run: security list-keychain -d user -s "${RUNNER_TEMP}/${TEMPORARY_KEYCHAIN_FILE}"

--- a/package/scripts/postinstall
+++ b/package/scripts/postinstall
@@ -44,7 +44,7 @@ git_no_hooks() {
 
 # reset Git repository
 cd "${homebrew_directory}"
-rm -rf "${homebrew_directory}/.git/hooks"
+rm -rf "${homebrew_directory}/.git/hooks" "${homebrew_directory}/.gitconfig" "${homebrew_directory}/.config/git"
 git config --global --add safe.directory "${homebrew_directory}"
 latest_tag="$(git_no_hooks -C "${homebrew_directory}" tag --list --sort="-version:refname" | head -n1)"
 git_no_hooks -C "${homebrew_directory}" checkout --force -B stable
@@ -61,7 +61,7 @@ then
     mv "${homebrew_directory}/cache_api" "/usr/local/Homebrew/"
 
     export HOME="/usr/local/Homebrew"
-    rm -rf "/usr/local/Homebrew/.git/hooks"
+    rm -rf "/usr/local/Homebrew/.git/hooks" "/usr/local/Homebrew/.gitconfig" "/usr/local/Homebrew/.config/git"
     git config --global --add safe.directory "/usr/local/Homebrew"
     git_no_hooks -C "/usr/local/Homebrew" checkout --force -B stable
     git_no_hooks -C "/usr/local/Homebrew" reset --hard


### PR DESCRIPTION
`postinstall` points `HOME` at the Homebrew directory before its privileged `git` calls, so Git reads that directory's `.gitconfig` and, with `XDG_CONFIG_HOME` unset, its `.config/git/config` as global config. The prefix is writable by the install user, so whatever sits there is chosen by an unprivileged account and then honoured by Git running as root. #22081 cleared both files before those calls for that reason. #22090 dropped `.gitconfig` from that `rm -rf` when it added the `git_no_hooks` wrapper, and `core.hooksPath` only disables hooks, not config keys that name a program to run.

Clearing both config paths again, for the prefix and for `/usr/local/Homebrew`, means the privileged `git` calls read only configuration the installer itself wrote. Requiring both in the `release.yml` installer Git safety check keeps them from drifting apart again, which is how the first one was lost. `brew doctor` already reports Git hooks and a repository-local `.gitconfig` together as things Homebrew does not use.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug? No `brew` command is involved, as this is on the `.pkg` installer path.
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code with Opus 5, with local review and testing.

-----
