### PR TITLE
sandbox: allow writing xcrun db

### DIFF
--- a/Library/Homebrew/extend/os/mac/sandbox.rb
+++ b/Library/Homebrew/extend/os/mac/sandbox.rb
@@ -55,6 +55,7 @@ module OS
       sig { void }
       def allow_write_xcode
         home_write_paths.each { |path| allow_write_path path }
+        allow_write path: "^/private/var/folders/[^/]+/[^/]+/T/xcrun_db(-[^/]+)?$", type: :regex
       end
 
       module ClassMethods

--- a/Library/Homebrew/test/sandbox_spec.rb
+++ b/Library/Homebrew/test/sandbox_spec.rb
@@ -138,4 +138,32 @@ RSpec.describe Sandbox, :needs_macos do
       end
     end
   end
+
+  describe "#allow_write_xcode" do
+    let(:home) { mktmpdir }
+
+    before do
+      allow(Dir).to receive(:home).with(ENV.fetch("USER")).and_return(home)
+    end
+
+    it "allows writing to directories used by Xcode" do
+      developer = (home/"Library/Developer").mkpath
+      swiftpm = (home/"Library/Caches/org.swift.swiftpm").mkpath
+
+      sandbox.allow_write_xcode
+
+      allow_rules = sandbox.profile.rules.select { |rule| rule.operation == "file-write*" }
+      allow_paths = allow_rules.map { |rule| rule.filter&.path }
+      expect(allow_paths).to eq [
+        developer.to_s,
+        swiftpm.to_s,
+        "^/private/var/folders/[^/]+/[^/]+/T/xcrun_db(-[^/]+)?$",
+      ]
+
+      # Skipping xcrun_db regex as we cannot mock the path
+      expect { sandbox.run "touch", developer/"foo" }.not_to raise_error
+      expect { sandbox.run "touch", swiftpm/"foo" }.not_to raise_error
+      expect { sandbox.run "touch", home/"foo" }.to raise_error(ErrorDuringExecution)
+    end
+  end
 end


### PR DESCRIPTION
Without permission, clang outputs multiple errors like:
```
clang: error: couldn't create cache file '/var/folders/*/*/T/xcrun_db-*' (errno=Operation not permitted)
```

Formula in following PR can reproduce this behavior
- https://github.com/Homebrew/homebrew-core/pull/301831
- https://github.com/Homebrew/homebrew-core/actions/runs/33590971181/job/100125992369?pr=301831#step:4:70

Sometimes these are non-impacting, but other times they will fail the build. One example is building nokogiri gem which fails with
```
gumbo.c:32:10: fatal error: 'nokogiri_gumbo.h' file not found
   32 | #include "nokogiri_gumbo.h"
      |          ^~~~~~~~~~~~~~~~~~
```

This had been covered by following regex when not using `def fetch`
https://github.com/Homebrew/brew/blob/a8820d02e41d63fd63a46e1e116b1be7505c9585/Library/Homebrew/extend/os/mac/sandbox.rb#L50

For now, went with more restrictive regex to avoid unnecessary permissions until someone confirms it is needed.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
