### PR TITLE
keg_relocate: contain text relocation to the keg

### DIFF
--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -235,7 +235,7 @@ class Keg
     files ||= text_files | libtool_files
 
     changed_files = T.let([], T::Array[Pathname])
-    files.map { path.join(it) }.group_by { |f| f.stat.ino }.each_value do |first, *rest|
+    keg_files(files).group_by { |f| f.stat.ino }.each_value do |first, *rest|
       first = T.must(first)
       s = first.open("rb", &:read)
 
@@ -428,13 +428,16 @@ class Keg
 
   # The regular files the keg-relative paths recorded in bottle metadata refer
   # to. Metadata may come from a mirror, so paths that would escape the keg
-  # (absolute or via `..`) are ignored rather than followed.
+  # (absolute, via `..` or through a symlinked parent) are ignored rather than
+  # followed.
   sig { params(relative_paths: T::Array[Pathname]).returns(T::Array[Pathname]) }
   def keg_files(relative_paths)
+    keg_realpath = path.realpath
     relative_paths.filter_map do |relative_path|
       file = (path/relative_path).cleanpath
       next unless file.to_s.start_with?("#{path}/")
       next if file.symlink? || !file.file?
+      next unless file.realpath.to_s.start_with?("#{keg_realpath}/")
 
       file
     end

--- a/Library/Homebrew/test/keg_relocate/text_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/text_spec.rb
@@ -6,12 +6,12 @@ require "keg_relocate"
 RSpec.describe Keg do
   subject(:keg) { described_class.new(HOMEBREW_CELLAR/"foo/1.0.0") }
 
-  let(:dir) { mktmpdir }
+  let(:dir) { HOMEBREW_CELLAR/"foo/1.0.0" }
   let(:file) { dir/"file.txt" }
   let(:placeholder) { "@@PLACEHOLDER@@" }
 
   before do
-    (HOMEBREW_CELLAR/"foo/1.0.0").mkpath
+    dir.mkpath
   end
 
   def setup_file(placeholders: false)
@@ -78,6 +78,36 @@ RSpec.describe Keg do
         foo/bar:/foo#{dir}/file.txt
         #{dir}/bar.txt:#{dir}/baz.txt
       EOS
+    end
+
+    specify "ignores recorded paths that escape the keg" do
+      outside = dir.parent/"escape.txt"
+      outside.atomic_write "#{placeholder}/file.txt\n"
+
+      changed = keg.replace_text_in_files(setup_relocation(placeholders: true),
+                                          files: [Pathname("../escape.txt"), outside])
+
+      expect(outside.read).to eq "#{placeholder}/file.txt\n"
+      expect(changed).to be_empty
+    end
+
+    specify "ignores recorded paths that escape the keg through a symlinked parent" do
+      outside = dir.parent/"outside"
+      outside.mkpath
+      victim = outside/"victim.txt"
+      victim.atomic_write "#{placeholder}/file.txt\n"
+      FileUtils.ln_s outside, dir/"linked"
+
+      changed = keg.replace_text_in_files(setup_relocation(placeholders: true),
+                                          files: [Pathname("linked/victim.txt")])
+
+      expect(victim.read).to eq "#{placeholder}/file.txt\n"
+      expect(changed).to be_empty
+    end
+
+    specify "ignores recorded paths that do not exist" do
+      expect { keg.replace_text_in_files(setup_relocation, files: [Pathname("missing.txt")]) }
+        .not_to raise_error
     end
   end
 


### PR DESCRIPTION
The file list `Keg#replace_text_in_files` rewrites comes from bottle metadata, which the bottle checksum does not cover and which can come from a mirror. It joined those paths onto the keg with `path.join`, which accepts an absolute path and does not collapse a leading `..`, so a recorded path could name a file outside the keg and have its contents rewritten. `keg_files` already guards this input for `relocate_build_prefix` and `relocate_dynamic_linkage`, leaving the text path as the odd one out.

Routing the list through `keg_files` means metadata can only select regular files inside the keg, whichever entry point consumes it, and a stale entry is skipped rather than aborting a pour with `Errno::ENOENT`. `keg_files` itself compared paths with `cleanpath`, which left a symlinked parent looking contained while resolving outside the keg, and now compares resolved paths so all three entry points reject that as well.

The spec used a temporary directory outside the keg and asserted a path there was rewritten, so it now uses the keg directory like the binary relocation spec.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug? Not reachable through a `brew` command, so the added spec covers it instead.
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code with Opus 5, with local review and testing.

-----
