### PR TITLE
services: default to canonical macOS service labels

### DIFF
--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -80,7 +80,7 @@ module Homebrew
 
     sig { returns(String) }
     def default_plist_name
-      legacy_plist_name
+      canonical_plist_name
     end
 
     sig { returns(String) }
@@ -735,7 +735,7 @@ module Homebrew
     sig { returns(T::Hash[Symbol, T.untyped]) }
     def to_hash
       name_params = {
-        macos: (plist_name if plist_name != default_plist_name),
+        macos: (plist_name if @plist_name_explicitly_set),
         linux: (service_name if service_name != default_service_name),
       }.compact
 

--- a/Library/Homebrew/services/cli.rb
+++ b/Library/Homebrew/services/cli.rb
@@ -53,11 +53,30 @@ module Homebrew
 
       sig { params(service: Services::FormulaWrapper, running_status: String).returns(T::Boolean) }
       def self.report_service_running_or_loaded?(service, running_status:)
-        status = if service.pid?
+        running = service.pid?
+        loaded_name = if System.launchctl?
+          if running
+            service.active_service_name
+          else
+            service.loaded_service_names.find { |name| name != service.service_name }
+          end
+        end
+
+        if loaded_name.present? && loaded_name != service.service_name
+          if service.service_file_generated? && service.service_names.include?(loaded_name)
+            puts "Service `#{service.name}` is already loaded as `#{loaded_name}`; " \
+                 "a service label migration is pending. Use `#{bin} restart #{service.name}` " \
+                 "to migrate to `#{service.service_name}`."
+          else
+            status = running ? running_status : "loaded"
+            puts "Service `#{service.name}` already #{status} " \
+                 "(label: #{loaded_name}), use `#{bin} restart #{service.name}` to restart."
+          end
+          return true
+        end
+
+        status = if running
           running_status
-        elsif System.launchctl? &&
-              (loaded_name = service.loaded_service_names.find { |name| name != service.service_name })
-          "loaded as `#{loaded_name}`"
         end
         return false if status.nil?
 
@@ -87,8 +106,12 @@ module Homebrew
       sig { returns(T::Array[String]) }
       def self.remove_unused_service_files
         cleaned = []
+        running_services = running
         System.path.glob("{homebrew.*,sh.brew.*}.{plist,service,timer}").each do |file|
-          next if running.include?(File.basename(file).sub(/\.(plist|service|timer)$/i, ""))
+          label = FormulaWrapper.service_file_label(file) if file.extname.casecmp?(".plist")
+          service_name = label || File.basename(file).sub(/\.(plist|service|timer)$/i, "")
+          next if running_services.include?(service_name)
+          next if label && System.launchctl? && System.launchctl_service_running?(label)
 
           puts "Removing unused service file: #{file}"
           rm file
@@ -208,6 +231,7 @@ module Homebrew
           end
 
           systemctl_args = []
+          loaded_service_names = T.let([], T::Array[String])
           if no_wait
             systemctl_args << "--no-block"
             puts "Stopping `#{service.name}`..."
@@ -251,17 +275,23 @@ module Homebrew
                     exit_status = $CHILD_STATUS.exitstatus
                   end
                 end
-                quiet_system System.launchctl, "stop", "#{domain_target}/#{service_name}" if
+                quiet_system System.launchctl, "stop", service_name if
                   System.launchctl_service_running?(service_name)
               end
             end
             service.reset_cache!
           end
 
+          service_still_loaded = if System.systemctl?
+            service.loaded? || service.pid?
+          else # System.launchctl?
+            loaded_service_names.any? { |service_name| System.launchctl_service_running?(service_name) }
+          end
+
           unless keep
             if System.systemctl?
               rm service.dest if service.dest.exist?
-            else # System.launchctl?
+            elsif !service_still_loaded # System.launchctl?
               service.destinations.each { |destination| rm destination if destination.exist? }
             end
             rm service.timer_dest if System.systemctl? && service.timed? && service.timer_dest.exist?
@@ -274,7 +304,7 @@ module Homebrew
           else # System.launchctl?
             loaded_service_names.presence || service.service_names
           end
-          if service.loaded? || service.pid?
+          if service_still_loaded
             opoo "Unable to stop `#{service.name}` (label: #{labels.join(", ")})"
           else
             ohai "Successfully stopped `#{service.name}` (label: #{labels.join(", ")})"
@@ -298,9 +328,7 @@ module Homebrew
             elsif System.launchctl?
               killed_service_names = service.loaded_service_names
               killed_service_names.each do |service_name|
-                System.candidate_domain_targets.each do |domain_target|
-                  break if quiet_system System.launchctl, "stop", "#{domain_target}/#{service_name}"
-                end
+                quiet_system System.launchctl, "stop", service_name
               end
               service.reset_cache!
             end
@@ -388,11 +416,13 @@ module Homebrew
           service: Services::FormulaWrapper,
           file:    T.nilable(T.any(String, Pathname)),
           enable:  T::Boolean,
-        ).void
+        ).returns(String)
       }
       def self.launchctl_load(service, file:, enable:)
-        safe_system System.launchctl, "enable", "#{System.domain_target}/#{service.service_name}" if enable
+        service_name = FormulaWrapper.service_file_label(file) || service.service_name
+        safe_system System.launchctl, "enable", "#{System.domain_target}/#{service_name}" if enable
         safe_system System.launchctl, "bootstrap", System.domain_target, file
+        service_name
       end
 
       sig { params(service: Services::FormulaWrapper, enable: T::Boolean).void }
@@ -419,10 +449,11 @@ module Homebrew
           odie "Cannot #{function} `#{service.name}` as `#{service_user}` is not a user!"
         end
 
+        loaded_service_name = service.service_name
         if System.launchctl?
           file ||= enable ? service.dest : service.source_service_file
           service.path_dirs.each(&:mkpath)
-          launchctl_load(service, file:, enable:)
+          loaded_service_name = launchctl_load(service, file:, enable:)
         elsif System.systemctl?
           # Systemctl loads based upon location so only install service
           # file when it is not installed. Used with the `run` command.
@@ -432,7 +463,7 @@ module Homebrew
         end
 
         function = enable ? "started" : "ran"
-        ohai("Successfully #{function} `#{service.name}` (label: #{service.service_name})")
+        ohai("Successfully #{function} `#{service.name}` (label: #{loaded_service_name})")
       end
 
       sig { params(service: Services::FormulaWrapper, file: T.nilable(Pathname)).void }

--- a/Library/Homebrew/services/formula_wrapper.rb
+++ b/Library/Homebrew/services/formula_wrapper.rb
@@ -32,6 +32,31 @@ module Homebrew
         end
       end
 
+      sig { params(file: T.nilable(T.any(Pathname, String))).returns(T.nilable(String)) }
+      def self.service_file_label(file)
+        return if file.nil? || !File.file?(file)
+
+        require "plist"
+        plist = begin
+          Plist.parse_xml(file, marshal: false)
+        rescue
+          nil
+        end
+        if plist.nil? && File.binread(file, 8) == "bplist00"
+          require "system_command"
+          result = SystemCommand.run(
+            "/usr/bin/plutil",
+            args:         ["-convert", "xml1", "-o", "-", file],
+            print_stderr: false,
+          )
+          plist = result.plist if result.success?
+        end
+        label = plist["Label"] if plist
+        label if label.is_a?(String) && label.present?
+      rescue
+        nil
+      end
+
       # Initialize a new `Service` instance with supplied formula.
       sig { params(formula: Formula, service_name: T.nilable(String)).void }
       def initialize(formula, service_name: nil)
@@ -79,6 +104,11 @@ module Homebrew
         return [] unless service?
 
         load_service.path_dirs
+      end
+
+      sig { returns(T::Boolean) }
+      def service_file_generated?
+        service? && load_service.command?
       end
 
       # service_name delegates with formula.plist_name or formula.service_name
@@ -214,7 +244,7 @@ module Homebrew
         return [service_name] if System.systemctl? && loaded?
         return [] unless System.launchctl?
 
-        service_names.select { |name| System.launchctl_service_running?(name) }
+        launchctl_service_names.select { |name| System.launchctl_service_running?(name) }
       end
 
       sig { returns(String) }
@@ -330,7 +360,7 @@ module Homebrew
       # service block does not define a command.
       sig { returns(String) }
       def service_contents
-        if !service? || !load_service.command?
+        if !service_file_generated?
           source_service_file.read
         elsif System.launchctl?
           load_service.to_plist
@@ -351,11 +381,26 @@ module Homebrew
         formula.service
       end
 
+      sig { returns(T::Array[String]) }
+      def launchctl_service_names
+        return service_names if @service_name_override
+
+        source_files = service_files
+        files = source_files + destinations
+        source_dir = service_file.dirname
+        if source_files.none?(&:exist?) && source_dir.directory? && (package_file = source_dir.glob("*.plist").first)
+          files << package_file
+        end
+        file_labels = files.uniq.filter_map { |file| self.class.service_file_label(file) }
+
+        (service_names + file_labels).uniq
+      end
+
       sig { returns(StatusOutputSuccessType) }
       def status_output_success_type
         @status_output_success_type ||= if System.launchctl?
           result = T.let(nil, T.nilable(StatusOutputSuccessType))
-          service_names.each do |name|
+          launchctl_service_names.each do |name|
             output, success, type = System.launchctl_find_service(name)
             next unless success
 

--- a/Library/Homebrew/test/bundle/brew_services_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_services_spec.rb
@@ -138,8 +138,8 @@ RSpec.describe Homebrew::Bundle::Brew::Services do
         name:         "fooformula",
         version:      "1.0",
         rack:         HOMEBREW_CELLAR/"fooformula",
-        plist_name:   "homebrew.mxcl.fooformula",
-        plist_names:  ["homebrew.mxcl.fooformula", "sh.brew.fooformula"],
+        plist_name:   "sh.brew.fooformula",
+        plist_names:  ["sh.brew.fooformula", "homebrew.mxcl.fooformula"],
         service_name: "fooformula",
       )
     end
@@ -173,8 +173,8 @@ RSpec.describe Homebrew::Bundle::Brew::Services do
 
         prefix = foo.rack/foo.version
         prefix.mkpath
-        service_file = prefix/"sh.brew.fooformula.plist"
-        (prefix/"homebrew.mxcl.fooformula.plist").unlink if (prefix/"homebrew.mxcl.fooformula.plist").exist?
+        service_file = prefix/"homebrew.mxcl.fooformula.plist"
+        (prefix/"sh.brew.fooformula.plist").unlink if (prefix/"sh.brew.fooformula.plist").exist?
         service_file.write("service")
 
         expect(described_class.versioned_service_file(foo.name)).to eq(service_file)

--- a/Library/Homebrew/test/cmd/bundle/exec_subcommand_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle/exec_subcommand_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe Homebrew::Cmd::Bundle::ExecSubcommand do
         allow(nginx).to receive_messages(
           any_version_installed?:   true,
           any_installed_prefix:     HOMEBREW_PREFIX/"opt/nginx",
-          plist_name:               "homebrew.mxcl.nginx",
+          plist_name:               "sh.brew.nginx",
           service_name:             "nginx",
           versioned_formulae_names: [],
           conflicts:                [instance_double(Formula::FormulaConflict, name: "httpd")],
@@ -207,7 +207,7 @@ RSpec.describe Homebrew::Cmd::Bundle::ExecSubcommand do
         allow(redis).to receive_messages(
           any_version_installed?:   true,
           any_installed_prefix:     HOMEBREW_PREFIX/"opt/redis",
-          plist_name:               "homebrew.mxcl.redis",
+          plist_name:               "sh.brew.redis",
           service_name:             "redis",
           versioned_formulae_names: ["redis@6.2"],
           conflicts:                [],

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -1656,8 +1656,11 @@ RSpec.describe FormulaInstaller do
         installer.install_service
       end.not_to output(/Error: Failed to install service files/).to_stderr
 
-      expect(launchd_service_path).to exist
-      expect(service_path).to exist
+      expect([
+        launchd_service_path.basename.to_s,
+        launchd_service_path.exist?,
+        service_path.exist?,
+      ]).to eq(["sh.brew.testball.plist", true, true])
     end
 
     it "works if timed service is set" do

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1501,6 +1501,33 @@ RSpec.describe Formula do
       expect(f.service.to_hash.keys).to contain_exactly(:name)
     end
 
+    specify "explicit default and compatible macOS service names remain explicit when serialized" do
+      canonical_formula = formula "canonical_name" do
+        url "https://brew.sh/canonical-1.0.tbz"
+        service do
+          name macos: "sh.brew.canonical_name"
+        end
+      end
+      legacy_formula = formula "legacy_name" do
+        url "https://brew.sh/legacy-1.0.tbz"
+        service do
+          name macos: "homebrew.mxcl.legacy_name"
+        end
+      end
+
+      expect([
+        canonical_formula.service.to_hash,
+        canonical_formula.plist_names,
+        legacy_formula.service.to_hash,
+        legacy_formula.plist_names,
+      ]).to eq([
+        { name: { macos: "sh.brew.canonical_name" } },
+        ["sh.brew.canonical_name"],
+        { name: { macos: "homebrew.mxcl.legacy_name" } },
+        ["homebrew.mxcl.legacy_name"],
+      ])
+    end
+
     specify "service with an overridden plist_name" do
       f = formula do
         T.bind(self, T.class_of(Formula))
@@ -1520,13 +1547,13 @@ RSpec.describe Formula do
         url "https://brew.sh/test-1.0.tbz"
       end
 
-      expect(f.plist_name).to eq("homebrew.mxcl.formula_name")
-      expect(f.plist_names).to eq(["homebrew.mxcl.formula_name", "sh.brew.formula_name"])
+      expect(f.plist_name).to eq("sh.brew.formula_name")
+      expect(f.plist_names).to eq(["sh.brew.formula_name", "homebrew.mxcl.formula_name"])
       expect(f.service_name).to eq("homebrew.formula_name")
-      expect(f.launchd_service_path).to eq(HOMEBREW_PREFIX/"opt/formula_name/homebrew.mxcl.formula_name.plist")
+      expect(f.launchd_service_path).to eq(HOMEBREW_PREFIX/"opt/formula_name/sh.brew.formula_name.plist")
       expect(f.launchd_service_paths).to eq([
-        HOMEBREW_PREFIX/"opt/formula_name/homebrew.mxcl.formula_name.plist",
         HOMEBREW_PREFIX/"opt/formula_name/sh.brew.formula_name.plist",
+        HOMEBREW_PREFIX/"opt/formula_name/homebrew.mxcl.formula_name.plist",
       ])
       expect(f.systemd_service_path).to eq(HOMEBREW_PREFIX/"opt/formula_name/homebrew.formula_name.service")
       expect(f.systemd_timer_path).to eq(HOMEBREW_PREFIX/"opt/formula_name/homebrew.formula_name.timer")

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -555,7 +555,7 @@ RSpec.describe Homebrew::Service do
         \t<key>KeepAlive</key>
         \t<true/>
         \t<key>Label</key>
-        \t<string>homebrew.mxcl.formula_name</string>
+        \t<string>sh.brew.formula_name</string>
         \t<key>LaunchOnlyOnce</key>
         \t<true/>
         \t<key>LegacyTimers</key>
@@ -606,7 +606,7 @@ RSpec.describe Homebrew::Service do
         <plist version="1.0">
         <dict>
         \t<key>Label</key>
-        \t<string>homebrew.mxcl.formula_name</string>
+        \t<string>sh.brew.formula_name</string>
         \t<key>LimitLoadToSessionType</key>
         \t<array>
         \t\t<string>Aqua</string>
@@ -662,7 +662,7 @@ RSpec.describe Homebrew::Service do
         <plist version="1.0">
         <dict>
         \t<key>Label</key>
-        \t<string>homebrew.mxcl.formula_name</string>
+        \t<string>sh.brew.formula_name</string>
         \t<key>LimitLoadToSessionType</key>
         \t<array>
         \t\t<string>Aqua</string>
@@ -721,7 +721,7 @@ RSpec.describe Homebrew::Service do
         <plist version="1.0">
         <dict>
         \t<key>Label</key>
-        \t<string>homebrew.mxcl.formula_name</string>
+        \t<string>sh.brew.formula_name</string>
         \t<key>LimitLoadToSessionType</key>
         \t<array>
         \t\t<string>Aqua</string>
@@ -759,7 +759,7 @@ RSpec.describe Homebrew::Service do
         <plist version="1.0">
         <dict>
         \t<key>Label</key>
-        \t<string>homebrew.mxcl.formula_name</string>
+        \t<string>sh.brew.formula_name</string>
         \t<key>LimitLoadToSessionType</key>
         \t<array>
         \t\t<string>Aqua</string>
@@ -797,7 +797,7 @@ RSpec.describe Homebrew::Service do
         <plist version="1.0">
         <dict>
         \t<key>Label</key>
-        \t<string>homebrew.mxcl.formula_name</string>
+        \t<string>sh.brew.formula_name</string>
         \t<key>LimitLoadToSessionType</key>
         \t<array>
         \t\t<string>Aqua</string>
@@ -837,7 +837,7 @@ RSpec.describe Homebrew::Service do
         <plist version="1.0">
         <dict>
         \t<key>Label</key>
-        \t<string>homebrew.mxcl.formula_name</string>
+        \t<string>sh.brew.formula_name</string>
         \t<key>LimitLoadToSessionType</key>
         \t<array>
         \t\t<string>Aqua</string>
@@ -886,7 +886,7 @@ RSpec.describe Homebrew::Service do
         \t\t<false/>
         \t</dict>
         \t<key>Label</key>
-        \t<string>homebrew.mxcl.formula_name</string>
+        \t<string>sh.brew.formula_name</string>
         \t<key>LimitLoadToSessionType</key>
         \t<array>
         \t\t<string>Aqua</string>
@@ -928,7 +928,7 @@ RSpec.describe Homebrew::Service do
         \t\t<true/>
         \t</dict>
         \t<key>Label</key>
-        \t<string>homebrew.mxcl.formula_name</string>
+        \t<string>sh.brew.formula_name</string>
         \t<key>LimitLoadToSessionType</key>
         \t<array>
         \t\t<string>Aqua</string>
@@ -970,7 +970,7 @@ RSpec.describe Homebrew::Service do
         \t\t<string>#{HOMEBREW_PREFIX}/opt/formula_name/share/formula_name/test-path</string>
         \t</dict>
         \t<key>Label</key>
-        \t<string>homebrew.mxcl.formula_name</string>
+        \t<string>sh.brew.formula_name</string>
         \t<key>LimitLoadToSessionType</key>
         \t<array>
         \t\t<string>Aqua</string>
@@ -1007,7 +1007,7 @@ RSpec.describe Homebrew::Service do
         <plist version="1.0">
         <dict>
         \t<key>Label</key>
-        \t<string>homebrew.mxcl.formula_name</string>
+        \t<string>sh.brew.formula_name</string>
         \t<key>LimitLoadToSessionType</key>
         \t<array>
         \t\t<string>Aqua</string>

--- a/Library/Homebrew/test/services/cli_spec.rb
+++ b/Library/Homebrew/test/services/cli_spec.rb
@@ -121,6 +121,48 @@ RSpec.describe Homebrew::Services::Cli do
       expect(active_service).to exist
       expect(stale_service).not_to exist
     end
+
+    it "keeps a loaded macOS service file whose internal label differs from its filename" do
+      path = mktmpdir
+      active_service = path/"sh.brew.name.plist"
+      active_service.write <<~XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+          <key>Label</key>
+          <string>homebrew.mxcl.name</string>
+        </dict>
+        </plist>
+      XML
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: true, path:)
+      allow(services_cli).to receive(:running).and_return(["homebrew.mxcl.name"])
+
+      expect(services_cli.remove_unused_service_files).to be_empty
+      expect(active_service).to exist
+    end
+
+    it "keeps a loaded macOS service file with an arbitrary internal label" do
+      path = mktmpdir
+      active_service = path/"sh.brew.name.plist"
+      active_service.write <<~XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+          <key>Label</key>
+          <string>org.example.package</string>
+        </dict>
+        </plist>
+      XML
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: true, path:)
+      allow(services_cli).to receive(:running).and_return([])
+      expect(Homebrew::Services::System).to receive(:launchctl_service_running?)
+        .with("org.example.package").and_return(true)
+
+      expect(services_cli.remove_unused_service_files).to be_empty
+      expect(active_service).to exist
+    end
   end
 
   describe "#run" do
@@ -138,6 +180,7 @@ RSpec.describe Homebrew::Services::Cli do
     end
 
     it "checks if target service is already running and suggests restart instead" do
+      allow(Homebrew::Services::System).to receive(:launchctl?).and_return(false)
       expected_output = "Service `example_service` already running, " \
                         "use `brew services restart example_service` to restart.\n"
       service = instance_double(service_string, name: "example_service", pid?: true)
@@ -150,16 +193,18 @@ RSpec.describe Homebrew::Services::Cli do
       allow(Homebrew::Services::System).to receive(:launchctl?).and_return(true)
       service = instance_double(
         service_string,
-        name:                 "name",
-        service_name:         "homebrew.mxcl.name",
-        loaded_service_names: ["sh.brew.name"],
-        pid?:                 false,
+        name:                    "name",
+        service_name:            "sh.brew.name",
+        service_file_generated?: true,
+        service_names:           ["sh.brew.name", "homebrew.mxcl.name"],
+        loaded_service_names:    ["homebrew.mxcl.name"],
+        pid?:                    false,
       )
       expect(services_cli).not_to receive(:service_load)
 
       expect do
         services_cli.run([service])
-      end.to output(/already loaded as `sh.brew.name`/).to_stdout
+      end.to output(/already loaded as `homebrew.mxcl.name`/).to_stdout
     end
   end
 
@@ -178,6 +223,7 @@ RSpec.describe Homebrew::Services::Cli do
     end
 
     it "checks if target service has already been started and suggests restart instead" do
+      allow(Homebrew::Services::System).to receive(:launchctl?).and_return(false)
       expected_output = "Service `example_service` already started, " \
                         "use `brew services restart example_service` to restart.\n"
       service = instance_double(service_string, name: "example_service", pid?: true)
@@ -191,7 +237,7 @@ RSpec.describe Homebrew::Services::Cli do
         instance_double(
           Homebrew::Services::FormulaWrapper,
           name:                 "name",
-          service_name:         "homebrew.mxcl.name",
+          service_name:         "sh.brew.name",
           loaded_service_names: [],
           pid?:                 false,
           installed?:           true,
@@ -204,14 +250,41 @@ RSpec.describe Homebrew::Services::Cli do
         allow(services_cli).to receive(:install_service_file)
       end
 
-      it "does not load a service already loaded under the compatible label" do
+      it "reports a pending migration for a running service using the legacy label" do
         allow(Homebrew::Services::System).to receive(:launchctl?).and_return(true)
-        allow(service).to receive(:loaded_service_names).and_return(["sh.brew.name"])
+        allow(service).to receive_messages(
+          active_service_name:     "homebrew.mxcl.name",
+          loaded_service_names:    ["homebrew.mxcl.name"],
+          service_file_generated?: true,
+          service_names:           ["sh.brew.name", "homebrew.mxcl.name"],
+          pid?:                    true,
+        )
         expect(services_cli).not_to receive(:install_service_file)
 
+        expected_output = "Service `name` is already loaded as `homebrew.mxcl.name`; " \
+                          "a service label migration is pending. Use `brew services restart name` " \
+                          "to migrate to `sh.brew.name`.\n"
         expect do
           services_cli.start([service])
-        end.to output(/already loaded as `sh.brew.name`/).to_stdout
+        end.to output(expected_output).to_stdout
+      end
+
+      it "does not promise to migrate a package-provided legacy label" do
+        allow(Homebrew::Services::System).to receive(:launchctl?).and_return(true)
+        allow(service).to receive_messages(
+          active_service_name:     "homebrew.mxcl.name",
+          loaded_service_names:    ["homebrew.mxcl.name"],
+          service_file_generated?: false,
+          service_names:           ["sh.brew.name", "homebrew.mxcl.name"],
+          pid?:                    true,
+        )
+        expect(services_cli).not_to receive(:install_service_file)
+
+        expected_output = "Service `name` already started (label: homebrew.mxcl.name), " \
+                          "use `brew services restart name` to restart.\n"
+        expect do
+          services_cli.start([service])
+        end.to output(expected_output).to_stdout
       end
 
       it "loads service for root" do
@@ -316,23 +389,23 @@ RSpec.describe Homebrew::Services::Cli do
         candidate_domain_targets: ["gui/501"],
       )
       allow(Homebrew::Services::System).to receive(:launchctl_service_running?)
-        .with("homebrew.mxcl.name").and_return(true, false)
-      allow(Homebrew::Services::System).to receive(:launchctl_service_running?)
         .with("sh.brew.name").and_return(true, false)
-      expect(services_cli).to receive(:quiet_system)
-        .with(Pathname("/bin/launchctl"), "bootout", "gui/501/homebrew.mxcl.name")
+      allow(Homebrew::Services::System).to receive(:launchctl_service_running?)
+        .with("homebrew.mxcl.name").and_return(true, false)
       expect(services_cli).to receive(:quiet_system)
         .with(Pathname("/bin/launchctl"), "bootout", "gui/501/sh.brew.name")
+      expect(services_cli).to receive(:quiet_system)
+        .with(Pathname("/bin/launchctl"), "bootout", "gui/501/homebrew.mxcl.name")
 
       dest_dir = mktmpdir
-      destinations = [dest_dir/"homebrew.mxcl.name.plist", dest_dir/"sh.brew.name.plist"]
+      destinations = [dest_dir/"sh.brew.name.plist", dest_dir/"homebrew.mxcl.name.plist"]
       destinations.each { |destination| destination.write("service") }
       service = instance_double(
         Homebrew::Services::FormulaWrapper,
         name:                 "name",
-        service_name:         "homebrew.mxcl.name",
-        service_names:        ["homebrew.mxcl.name", "sh.brew.name"],
-        loaded_service_names: ["homebrew.mxcl.name", "sh.brew.name"],
+        service_name:         "sh.brew.name",
+        service_names:        ["sh.brew.name", "homebrew.mxcl.name"],
+        loaded_service_names: ["sh.brew.name", "homebrew.mxcl.name"],
         destinations:,
         pid?:                 false,
       )
@@ -343,6 +416,36 @@ RSpec.describe Homebrew::Services::Cli do
         services_cli.stop([service], no_wait: true)
       end.to output(/Successfully stopped `name`/).to_stdout
       expect(destinations).not_to include(an_object_satisfying(&:exist?))
+    end
+
+    it "reports and preserves a package plist when its label remains loaded" do
+      allow(Homebrew::Services::System).to receive_messages(
+        launchctl?:                 true,
+        systemctl?:                 false,
+        launchctl:                  Pathname("/bin/launchctl"),
+        candidate_domain_targets:   ["gui/501"],
+        launchctl_service_running?: true,
+      )
+      allow(services_cli).to receive(:quiet_system).and_return(false)
+
+      destination = mktmpdir/"sh.brew.name.plist"
+      destination.write("service")
+      service = instance_double(
+        Homebrew::Services::FormulaWrapper,
+        name:                 "name",
+        service_name:         "sh.brew.name",
+        service_names:        ["sh.brew.name", "homebrew.mxcl.name"],
+        loaded_service_names: ["org.example.package"],
+        destinations:         [destination],
+        pid?:                 false,
+      )
+      allow(service).to receive(:loaded?) { destination.exist? }
+      allow(service).to receive(:reset_cache!)
+
+      expect do
+        services_cli.stop([service], no_wait: true)
+      end.to output(/Unable to stop `name` \(label: org\.example\.package\)/).to_stderr
+      expect(destination).to exist
     end
   end
 
@@ -372,25 +475,24 @@ RSpec.describe Homebrew::Services::Cli do
       service = instance_double(
         service_string,
         name:                 "name",
-        service_name:         "homebrew.mxcl.name",
+        service_name:         "sh.brew.name",
         keep_alive?:          false,
-        loaded_service_names: ["sh.brew.name"],
+        loaded_service_names: ["homebrew.mxcl.name"],
       )
       allow(service).to receive(:pid?).and_return(true, false)
       allow(service).to receive(:reset_cache!)
       allow(Homebrew::Services::System).to receive_messages(
-        candidate_domain_targets:   ["gui/501", "user/501"],
         launchctl:                  "/bin/launchctl",
         launchctl?:                 true,
         launchctl_service_running?: true,
         systemctl?:                 false,
       )
       expect(services_cli).to receive(:quiet_system)
-        .with("/bin/launchctl", "stop", "gui/501/sh.brew.name").once.and_return(true)
+        .with("/bin/launchctl", "stop", "homebrew.mxcl.name").once.and_return(true)
 
       expect do
         services_cli.kill([service])
-      end.to output(/Successfully killed `name` \(label: sh\.brew\.name\)/).to_stdout
+      end.to output(/Successfully killed `name` \(label: homebrew\.mxcl\.name\)/).to_stdout
     end
   end
 
@@ -439,15 +541,15 @@ RSpec.describe Homebrew::Services::Cli do
       source_dir = mktmpdir
       dest_dir = mktmpdir
       service_file = source_dir/"homebrew.mxcl.name.plist"
-      primary_dest = dest_dir/"homebrew.mxcl.name.plist"
-      compatible_dest = dest_dir/"sh.brew.name.plist"
+      primary_dest = dest_dir/"sh.brew.name.plist"
+      compatible_dest = dest_dir/"homebrew.mxcl.name.plist"
       service_file.write("service")
       primary_dest.write("old service")
       compatible_dest.write("compatible service")
       service = instance_double(
         Homebrew::Services::FormulaWrapper,
         name:                "name",
-        service_name:        "homebrew.mxcl.name",
+        service_name:        "sh.brew.name",
         installed?:          true,
         source_service_file: service_file,
         service_contents:    "service",
@@ -620,7 +722,11 @@ RSpec.describe Homebrew::Services::Cli do
 
     it "checks non-enabling run" do
       with_env(PATH: bindir.to_s) do
-        services_cli.launchctl_load(instance_double(Homebrew::Services::FormulaWrapper), file: "a", enable: false)
+        services_cli.launchctl_load(
+          instance_double(Homebrew::Services::FormulaWrapper, service_name: "name"),
+          file:   "a",
+          enable: false,
+        )
       end
 
       expect(log.read).to eq("bootstrap #{Homebrew::Services::System.domain_target} a\n")
@@ -637,6 +743,36 @@ RSpec.describe Homebrew::Services::Cli do
         enable #{Homebrew::Services::System.domain_target}/name
         bootstrap #{Homebrew::Services::System.domain_target} a
       EOS
+    end
+
+    it "enables the label declared by a package-provided plist" do
+      service_file = bindir/"package.plist"
+      service_file.write <<~XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+          <key>Label</key>
+          <string>org.example.package</string>
+        </dict>
+        </plist>
+      XML
+
+      loaded_name = with_env(PATH: bindir.to_s) do
+        services_cli.launchctl_load(
+          instance_double(Homebrew::Services::FormulaWrapper, service_name: "sh.brew.package"),
+          file:   service_file,
+          enable: true,
+        )
+      end
+
+      expect([loaded_name, log.read]).to eq([
+        "org.example.package",
+        <<~EOS,
+          enable #{Homebrew::Services::System.domain_target}/org.example.package
+          bootstrap #{Homebrew::Services::System.domain_target} #{service_file}
+        EOS
+      ])
     end
   end
 
@@ -760,7 +896,7 @@ RSpec.describe Homebrew::Services::Cli do
       expect(Homebrew::Services::System).to receive(:launchctl?).once.and_return(true)
       expect(Homebrew::Services::System).not_to receive(:systemctl?)
       expect(Homebrew::Services::System).to receive(:root?).twice.and_return(false)
-      expect(described_class).to receive(:launchctl_load).once.and_return(true)
+      expect(described_class).to receive(:launchctl_load).once.and_return("service.name")
       expect do
         services_cli.service_load(
           instance_double(
@@ -780,13 +916,13 @@ RSpec.describe Homebrew::Services::Cli do
     it "runs a compatible macOS source service file" do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: true, root?: false, systemctl?: false)
 
-      service_file = mktmpdir/"homebrew.mxcl.name.plist"
-      source_service_file = mktmpdir/"sh.brew.name.plist"
+      service_file = mktmpdir/"sh.brew.name.plist"
+      source_service_file = mktmpdir/"homebrew.mxcl.name.plist"
       source_service_file.write("service")
       service = instance_double(
         Homebrew::Services::FormulaWrapper,
         name:                "name",
-        service_name:        "homebrew.mxcl.name",
+        service_name:        "sh.brew.name",
         service_startup?:    false,
         service_file:,
         source_service_file:,
@@ -794,10 +930,11 @@ RSpec.describe Homebrew::Services::Cli do
       )
       expect(services_cli).to receive(:launchctl_load)
         .with(service, file: source_service_file, enable: false)
+        .and_return("sh.brew.name")
 
       expect do
         services_cli.service_load(service, nil, enable: false)
-      end.to output("==> Successfully ran `name` (label: homebrew.mxcl.name)\n").to_stdout
+      end.to output("==> Successfully ran `name` (label: sh.brew.name)\n").to_stdout
     end
 
     it "creates service path directories before loading" do
@@ -811,6 +948,7 @@ RSpec.describe Homebrew::Services::Cli do
       ]
       expect(described_class).to receive(:launchctl_load).once do
         expect(path_dirs).to all(be_a_directory)
+        "service.name"
       end
 
       expect do

--- a/Library/Homebrew/test/services/formula_wrapper_spec.rb
+++ b/Library/Homebrew/test/services/formula_wrapper_spec.rb
@@ -42,6 +42,25 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
     ENV["HOME"] = "/tmp_home"
   end
 
+  describe ".service_file_label" do
+    it "reads the label from a binary plist", :needs_macos do
+      service_file = mktmpdir/"binary.plist"
+      service_file.write <<~XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+          <key>Label</key>
+          <string>org.example.binary</string>
+        </dict>
+        </plist>
+      XML
+      safe_system "/usr/bin/plutil", "-convert", "binary1", service_file
+
+      expect(described_class.service_file_label(service_file)).to eq("org.example.binary")
+    end
+  end
+
   describe "#service_file" do
     it "macOS - outputs the full service file path" do
       allow(Homebrew::Services::System).to receive(:launchctl?).and_return(true)
@@ -69,16 +88,16 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
 
     it "uses the compatible macOS service file when it is the only one present" do
       source_dir = mktmpdir
-      service_files = [source_dir/"homebrew.mxcl.mysql.plist", source_dir/"sh.brew.mysql.plist"]
+      service_files = [source_dir/"sh.brew.mysql.plist", source_dir/"homebrew.mxcl.mysql.plist"]
       service_files.last.write("service")
       allow(formula).to receive(:launchd_service_paths).and_return(service_files)
 
       expect(service.source_service_file).to eq(service_files.last)
     end
 
-    it "prefers the legacy macOS service file while it remains the write default" do
+    it "prefers the canonical macOS service file" do
       source_dir = mktmpdir
-      service_files = [source_dir/"homebrew.mxcl.mysql.plist", source_dir/"sh.brew.mysql.plist"]
+      service_files = [source_dir/"sh.brew.mysql.plist", source_dir/"homebrew.mxcl.mysql.plist"]
       service_files.each { |file| file.write("service") }
       allow(formula).to receive(:launchd_service_paths).and_return(service_files)
 
@@ -150,9 +169,9 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
   describe "#service_names" do
     it "includes both compatible default macOS labels" do
       allow(Homebrew::Services::System).to receive(:launchctl?).and_return(true)
-      allow(formula).to receive(:plist_names).and_return(["homebrew.mxcl.mysql", "sh.brew.mysql"])
+      allow(formula).to receive(:plist_names).and_return(["sh.brew.mysql", "homebrew.mxcl.mysql"])
 
-      expect(service.service_names).to eq(["homebrew.mxcl.mysql", "sh.brew.mysql"])
+      expect(service.service_names).to eq(["sh.brew.mysql", "homebrew.mxcl.mysql"])
     end
   end
 
@@ -216,36 +235,62 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
 
     it "finds a service loaded with the compatible macOS label" do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: true, systemctl?: false)
-      allow(formula).to receive(:plist_names).and_return(["homebrew.mxcl.mysql", "sh.brew.mysql"])
+      allow(formula).to receive(:plist_names).and_return(["sh.brew.mysql", "homebrew.mxcl.mysql"])
       allow(Homebrew::Services::System).to receive(:launchctl_find_service)
-        .with("homebrew.mxcl.mysql").and_return(["", false, :launchctl_list])
+        .with("sh.brew.mysql").and_return(["", false, :launchctl_list])
       allow(Homebrew::Services::System).to receive(:launchctl_find_service)
-        .with("sh.brew.mysql").and_return(["pid = 123", true, :launchctl_print])
+        .with("homebrew.mxcl.mysql").and_return(["pid = 123", true, :launchctl_print])
 
       expect(service.loaded?).to be(true)
       expect(service.pid).to eq(123)
-      expect(service.active_service_name).to eq("sh.brew.mysql")
+      expect(service.active_service_name).to eq("homebrew.mxcl.mysql")
+    end
+
+    it "finds a service loaded with a package-provided plist label" do
+      source_dir = mktmpdir
+      service_files = [source_dir/"sh.brew.mysql.plist", source_dir/"homebrew.mxcl.mysql.plist"]
+      package_file = source_dir/"vendor.mysql.plist"
+      package_file.write <<~XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+          <key>Label</key>
+          <string>org.example.mysql</string>
+        </dict>
+        </plist>
+      XML
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: true, systemctl?: false)
+      allow(formula).to receive(:launchd_service_paths).and_return(service_files)
+      allow(Homebrew::Services::System).to receive(:launchctl_find_service)
+        .with("sh.brew.mysql").and_return(["", false, :launchctl_list])
+      allow(Homebrew::Services::System).to receive(:launchctl_find_service)
+        .with("homebrew.mxcl.mysql").and_return(["", false, :launchctl_list])
+      allow(Homebrew::Services::System).to receive(:launchctl_find_service)
+        .with("org.example.mysql").and_return(["pid = 123", true, :launchctl_print])
+
+      expect([service.loaded?, service.active_service_name]).to eq([true, "org.example.mysql"])
     end
 
     it "stops probing compatible labels after finding a running service" do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: true, systemctl?: false)
-      allow(formula).to receive(:plist_names).and_return(["homebrew.mxcl.mysql", "sh.brew.mysql"])
+      allow(formula).to receive(:plist_names).and_return(["sh.brew.mysql", "homebrew.mxcl.mysql"])
       expect(Homebrew::Services::System).to receive(:launchctl_find_service)
-        .with("homebrew.mxcl.mysql").and_return(["pid = 123", true, :launchctl_print])
-      expect(Homebrew::Services::System).not_to receive(:launchctl_find_service).with("sh.brew.mysql")
+        .with("sh.brew.mysql").and_return(["pid = 123", true, :launchctl_print])
+      expect(Homebrew::Services::System).not_to receive(:launchctl_find_service).with("homebrew.mxcl.mysql")
 
-      expect(service.active_service_name).to eq("homebrew.mxcl.mysql")
+      expect(service.active_service_name).to eq("sh.brew.mysql")
     end
 
     it "prefers a running compatible label over an earlier loaded label" do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: true, systemctl?: false)
-      allow(formula).to receive(:plist_names).and_return(["homebrew.mxcl.mysql", "sh.brew.mysql"])
+      allow(formula).to receive(:plist_names).and_return(["sh.brew.mysql", "homebrew.mxcl.mysql"])
       allow(Homebrew::Services::System).to receive(:launchctl_find_service)
-        .with("homebrew.mxcl.mysql").and_return(["last exit code = 0", true, :launchctl_print])
+        .with("sh.brew.mysql").and_return(["last exit code = 0", true, :launchctl_print])
       allow(Homebrew::Services::System).to receive(:launchctl_find_service)
-        .with("sh.brew.mysql").and_return(["pid = 123", true, :launchctl_print])
+        .with("homebrew.mxcl.mysql").and_return(["pid = 123", true, :launchctl_print])
 
-      expect(service.active_service_name).to eq("sh.brew.mysql")
+      expect(service.active_service_name).to eq("homebrew.mxcl.mysql")
     end
 
     it "systemD - outputs if the service is loaded" do
@@ -331,15 +376,15 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
   describe "#registered_destination" do
     it "prefers the service file matching the active compatible label" do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: true, root?: false, systemctl?: false)
-      allow(formula).to receive(:plist_names).and_return(["homebrew.mxcl.mysql", "sh.brew.mysql"])
+      allow(formula).to receive(:plist_names).and_return(["sh.brew.mysql", "homebrew.mxcl.mysql"])
       allow(Homebrew::Services::System).to receive(:launchctl_find_service)
-        .with("homebrew.mxcl.mysql").and_return(["", false, :launchctl_list])
+        .with("sh.brew.mysql").and_return(["", false, :launchctl_list])
       allow(Homebrew::Services::System).to receive(:launchctl_find_service)
-        .with("sh.brew.mysql").and_return(["pid = 123", true, :launchctl_print])
+        .with("homebrew.mxcl.mysql").and_return(["pid = 123", true, :launchctl_print])
       allow(service).to receive(:dest_dir).and_return(mktmpdir)
       service.destinations.each { |destination| destination.write("service") }
 
-      expect(service.registered_destination.basename.to_s).to eq("sh.brew.mysql.plist")
+      expect(service.registered_destination.basename.to_s).to eq("homebrew.mxcl.mysql.plist")
     end
   end
 
@@ -353,6 +398,35 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
 
       expect(discovered_service.service_names).to eq(["sh.brew.mysql"])
       expect(discovered_service.dest).to eq(Pathname("/tmp_home/Library/LaunchAgents/sh.brew.mysql.plist"))
+    end
+
+    it "keeps status discovery scoped to the exact label it discovers" do
+      source_dir = mktmpdir
+      service_files = [source_dir/"sh.brew.mysql.plist", source_dir/"homebrew.mxcl.mysql.plist"]
+      service_files.zip(["sh.brew.mysql", "homebrew.mxcl.mysql"]).each do |file, label|
+        file.write <<~XML
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>Label</key>
+            <string>#{label}</string>
+          </dict>
+          </plist>
+        XML
+      end
+      allow(Homebrew::Services::System).to receive(:launchctl?).and_return(true)
+      allow(formula).to receive(:launchd_service_paths).and_return(service_files)
+      allow(Formulary).to receive(:factory).with("mysql").and_return(formula)
+      expect(Homebrew::Services::System).to receive(:launchctl_service_running?)
+        .with("sh.brew.mysql").and_return(false)
+      expect(Homebrew::Services::System).not_to receive(:launchctl_service_running?)
+        .with("homebrew.mxcl.mysql")
+
+      discovered_service = described_class.from("sh.brew.mysql")
+      raise "Expected service to be discovered" unless discovered_service
+
+      expect(discovered_service.loaded_service_names).to be_empty
     end
   end
 

--- a/Library/Homebrew/test/utils/service_spec.rb
+++ b/Library/Homebrew/test/utils/service_spec.rb
@@ -32,9 +32,9 @@ RSpec.describe Utils::Service do
       end
       allow(described_class).to receive(:launchctl?).and_return(true)
       expect(Homebrew::Services::System).to receive(:launchctl_service_running?)
-        .with("homebrew.mxcl.formula_name").and_return(false)
+        .with("sh.brew.formula_name").and_return(false)
       expect(Homebrew::Services::System).to receive(:launchctl_service_running?)
-        .with("sh.brew.formula_name").and_return(true)
+        .with("homebrew.mxcl.formula_name").and_return(true)
 
       expect(described_class.running?(f)).to be true
     end


### PR DESCRIPTION
Phase two of moving the default macOS service label from `homebrew.mxcl.<formula>` to `sh.brew.<formula>`, following #23741. Generated services now write the canonical label as both the plist filename and the internal launchd `Label`. Legacy services stay discoverable and controllable indefinitely, and Linux and systemd behavior is unchanged.

Migration is restart-only: `start` will not interrupt a running legacy job, it reports that a migration is pending and points at `brew services restart`. Labels are now read from the plist itself, so a package-provided plist is loaded, reported and stopped under its actual label. This also fixes `brew services kill`, which passed a domain-qualified target to `launchctl stop`; that form is parsed as a service name, so it never matched and the command did nothing.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the change and pass with it, and ran `brew lgtm --online`.

-----
