### PR TITLE
bump-formula-pr: render added version stanzas as string literals

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -288,7 +288,7 @@ module Homebrew
             if formula_ast.stable_stanza?(:version)
               formula_ast.replace_stable_stanza_value(:version, T.must(new_version))
             else
-              stanzas_to_add << [:version, T.must(new_version)]
+              stanzas_to_add << [:version, "version #{new_version.inspect}"]
             end
           elsif forced_version && new_version == "0"
             formula_ast.remove_stable_stanza(:version) if formula_ast.stable_stanza?(:version)
@@ -782,7 +782,7 @@ module Homebrew
           if formula_ast.resource_stanza?(resource_name, :version)
             formula_ast.replace_resource_stanza_value(resource_name, :version, new_version)
           else
-            formula_ast.add_stanzas_after(:sha256, [[:version, new_version]],
+            formula_ast.add_stanzas_after(:sha256, [[:version, "version #{new_version.inspect}"]],
                                           parent: formula_ast.resource(resource_name))
           end
         end

--- a/Library/Homebrew/test/dev-cmd/bump-formula-pr_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-formula-pr_spec.rb
@@ -75,6 +75,50 @@ RSpec.describe Homebrew::DevCmd::BumpFormulaPr do
       expect(formula_path.read).to include "  mirror #{updated_mirror.inspect}\n  " \
                                            "sha256 #{resource_path.sha256.inspect}\n"
     end
+
+    it "adds a forced version as a string literal" do
+      # An upstream version string shaped like a `version` stanza would otherwise
+      # be spliced into the formula as Ruby source rather than as data. The
+      # interpolation is escaped, and inert if it were ever evaluated.
+      payload = "version \"1.0\#{RUBY_VERSION}\""
+      formula_path = CoreTap.instance.new_formula_path("versionball")
+      formula_path.dirname.mkpath
+      formula_path.write <<~RUBY
+        class Versionball < Formula
+          url "https://brew.sh/versionball-1.0.tar.gz"
+          sha256 "#{"a" * 64}"
+        end
+      RUBY
+      CoreTap.instance.clear_cache
+      Formulary.clear_cache
+      Formula.clear_cache
+      formula = Formulary.from_contents("versionball", formula_path, formula_path.read)
+
+      resource_path = mktmpdir/"versionball-2.0.tar.gz"
+      resource_path.write("versionball")
+      command = described_class.new(["--write-only", "--no-audit", "--version=#{payload}", "versionball"])
+
+      allow(Homebrew).to receive(:install_bundler_gems!)
+      allow(CoreTap.instance).to receive_messages(allow_bump?: true, git?: true,
+                                                  remote_repository: "Homebrew/homebrew-core")
+      allow(command).to receive(:check_new_version)
+      allow(command).to receive(:fetch_resource_and_forced_version).and_return([resource_path, true])
+      allow(command).to receive_messages(run_audit: false, update_matching_version_resources!: {})
+      allow(PyPI).to receive(:update_python_resources!)
+      allow(Utils::Tar).to receive(:validate_file).with(resource_path)
+      allow(command.args.named).to receive(:to_formulae).and_return([formula])
+      allow(Formula).to receive(:[]).with("versionball").and_return(formula)
+
+      expect_any_instance_of(Utils::AST::FormulaAST)
+        .to receive(:add_stable_stanzas_after) do |_formula_ast, name, stanzas|
+        expect(name).to eq(:url)
+        expect(stanzas).to include([:version, "version #{payload.inspect}"])
+      end
+
+      # Substituting the version into the URL makes the formula invalid, so the
+      # run cannot finish; this example covers how the stanza value is rendered.
+      expect { command.run }.to raise_error(FormulaValidationError)
+    end
   end
 
   describe "::check_throttle" do
@@ -253,6 +297,38 @@ RSpec.describe Homebrew::DevCmd::BumpFormulaPr do
       resource_versions = { "foo" => { current_version: "1.2.3", latest_version: version } }
       expect(bump_formula_pr).to receive(:update_resource_block!).with(f, r, version).and_return(:success)
       expect(bump_formula_pr.update_resources!(f, resource_versions:)).to eq({ "foo" => :success })
+    end
+
+    it "adds a forced resource version as a string literal" do
+      # As for the formula stanza, a resource version shaped like a `version`
+      # stanza would otherwise be spliced in as Ruby source.
+      payload = "version \"1.0\#{RUBY_VERSION}\""
+      formula_path = CoreTap.instance.new_formula_path("resourceball")
+      formula_path.dirname.mkpath
+      formula_path.write <<~RUBY
+        class Resourceball < Formula
+          url "https://brew.sh/resourceball-1.0.tar.gz"
+
+          resource "foo" do
+            url "https://brew.sh/foo-1.2.3.tar.gz"
+            sha256 "#{"b" * 64}"
+          end
+        end
+      RUBY
+      CoreTap.instance.clear_cache
+      Formulary.clear_cache
+      Formula.clear_cache
+      formula = Formulary.from_contents("resourceball", formula_path, formula_path.read)
+
+      resource_path = mktmpdir/"foo.tar.gz"
+      resource_path.write("foo")
+      allow(bump_formula_pr).to receive(:fetch_resource_and_forced_version).and_return([resource_path, true])
+      allow(Utils::Tar).to receive(:validate_file).with(resource_path)
+
+      resource_versions = { "foo" => { current_version: "1.2.3", latest_version: payload } }
+      bump_formula_pr.update_resources!(formula, resource_versions:)
+
+      expect(formula_path.read).to include("version #{payload.inspect}")
     end
 
     it "downgrades to requested version" do


### PR DESCRIPTION
`brew bump` takes its new version from a livecheck result, so that value originates upstream. `bump-formula-pr` pushed the string into the stanza list it hands to `add_stable_stanzas_after`, which renders each entry with `Utils::AST.stanza_text`, and that returns a bare string verbatim when it parses as the stanza being added. A version shaped like a `version` stanza was therefore written into the formula as Ruby source and evaluated on the next load instead of being treated as data. Rendering the value first, as the neighbouring `mirror` stanza already does, means an upstream string can only ever land in a formula as a quoted literal. The same applies to the resource insertion path, and the replacement paths were already safe because they go through `ruby_literal`.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug? Reproduction needs a crafted `--version` value, covered by the added spec instead.
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code with Opus 5, with local review and testing.

-----
