### PR TITLE
shared_audits: check homepage domain age via RDAP

### DIFF
--- a/Library/Homebrew/test/utils/shared_audits_spec.rb
+++ b/Library/Homebrew/test/utils/shared_audits_spec.rb
@@ -30,10 +30,13 @@ RSpec.describe SharedAudits do
     JSON
   end
 
-  def mock_curl_output(stdout: "", success: true)
+  def command_result(stdout, success: true)
     status = instance_double(Process::Status, success?: success)
-    curl_output = instance_double(SystemCommand::Result, stdout:, status:)
-    allow(Utils::Curl).to receive(:curl_output).and_return curl_output
+    instance_double(SystemCommand::Result, stdout:, status:)
+  end
+
+  def mock_curl_output(stdout: "", success: true)
+    allow(Utils::Curl).to receive(:curl_output).and_return command_result(stdout, success:)
   end
 
   describe "::homepage_browsed_recently?" do
@@ -75,12 +78,17 @@ RSpec.describe SharedAudits do
   end
 
   describe "::new_domain_problem" do
+    let(:rdap_bootstrap) { { "services" => [[["dev"], ["https://rdap.example/"]]] } }
+    let(:rdap_registration) do
+      { "events" => [{ "eventAction" => "registration", "eventDate" => "2026-07-01T15:50:45Z" }] }
+    end
     let(:whois_output) do
       <<~WHOIS
         % IANA WHOIS server
         domain:       SH
         created:      1997-09-23
 
+        # whois.nic.sh
         Domain Name: brew.sh
         Creation Date: 2026-07-01T15:50:45Z
       WHOIS
@@ -89,26 +97,108 @@ RSpec.describe SharedAudits do
     before do
       allow(Date).to receive(:today).and_return(Date.new(2026, 7, 26))
       allow(described_class).to receive(:which).with("whois").and_return(Pathname("/usr/bin/whois"))
+      described_class.rdap_services = nil
+      mock_rdap
+    end
+
+    def mock_rdap(responses = {})
+      allow(Utils::Curl).to receive(:curl_output) do |*args, **_options|
+        url = args.fetch(-1)
+        if url == SharedAudits::RDAP_BOOTSTRAP_URL
+          command_result(rdap_bootstrap.to_json)
+        else
+          status, body = responses.fetch(url.delete_prefix("https://rdap.example/domain/"), [404, {}])
+          command_result("HTTP/2 #{status}\r\ncontent-type: application/rdap+json\r\n\r\n#{body.to_json}")
+        end
+      end
     end
 
     def mock_whois(stdout:, success: true)
-      status = instance_double(Process::Status, success?: success)
-      result = instance_double(SystemCommand::Result, stdout:, status:)
-      allow(SystemCommand).to receive(:run).and_return(result)
+      allow(SystemCommand).to receive(:run).and_return(command_result(stdout, success:))
     end
 
-    # The IANA record for the TLD is always ancient, so parsing must use the newest date.
-    it "reports domains registered less than 30 days ago, ignoring the IANA record for the TLD" do
+    it "reports domains registered less than 30 days ago according to RDAP" do
+      mock_rdap "brew.dev" => [200, rdap_registration]
+
+      expect(described_class.new_domain_problem("https://www.brew.dev/foo"))
+        .to include("`homepage` domain `brew.dev` was registered on 2026-07-01")
+    end
+
+    it "ignores domains registered at least 30 days ago according to RDAP" do
+      rdap_registration["events"].first["eventDate"] = "2026-06-26T15:50:45Z"
+      mock_rdap "brew.dev" => [200, rdap_registration]
+
+      expect(described_class.new_domain_problem("https://brew.dev")).to be_nil
+    end
+
+    it "walks up from a subdomain to the registered domain" do
+      mock_rdap "docs.brew.dev" => [400, {}], "brew.dev" => [200, rdap_registration]
+
+      expect(described_class.new_domain_problem("https://docs.brew.dev"))
+        .to include("`homepage` domain `brew.dev` was registered on 2026-07-01")
+    end
+
+    it "falls back to `whois` when the registry publishes no registration date over RDAP" do
+      mock_rdap "brew.dev" => [200, { "events" => [{ "eventAction" => "last changed" }] }]
+      mock_whois stdout: whois_output
+
+      expect(described_class.new_domain_problem("https://brew.dev"))
+        .to include("`homepage` domain `brew.dev` was registered on 2026-07-01")
+    end
+
+    it "falls back to `whois` when the RDAP server fails" do
+      mock_rdap "brew.dev" => [503, {}]
+      mock_whois stdout: whois_output
+
+      expect(described_class.new_domain_problem("https://brew.dev"))
+        .to include("`homepage` domain `brew.dev` was registered on 2026-07-01")
+    end
+
+    it "ignores domains neither the RDAP server nor `whois` knows" do
+      mock_whois stdout: "No match for domain \"BREW.DEV\".\n"
+
+      expect(described_class.new_domain_problem("https://brew.dev")).to be_nil
+    end
+
+    it "falls back to `whois` when the RDAP bootstrap cannot be fetched" do
+      mock_curl_output success: false
+      mock_whois stdout: whois_output
+
+      expect(described_class.new_domain_problem("https://brew.dev"))
+        .to include("`homepage` domain `brew.dev` was registered on 2026-07-01")
+    end
+
+    it "reports domains registered less than 30 days ago according to `whois`" do
       mock_whois stdout: whois_output
 
       expect(described_class.new_domain_problem("https://www.brew.sh/foo"))
         .to include("`homepage` domain `brew.sh` was registered on 2026-07-01")
     end
 
-    it "ignores domains registered at least 30 days ago" do
+    it "ignores domains registered at least 30 days ago according to `whois`" do
       mock_whois stdout: whois_output.sub("2026-07-01T15:50:45Z", "2026-06-26T15:50:45Z")
 
       expect(described_class.new_domain_problem("https://brew.sh")).to be_nil
+    end
+
+    it "reports domains registered less than 30 days ago according to Linux `whois`" do
+      mock_whois stdout: whois_output.sub("# whois.nic.sh", "Found a referral to whois.nic.sh.")
+
+      expect(described_class.new_domain_problem("https://brew.sh"))
+        .to include("`homepage` domain `brew.sh` was registered on 2026-07-01")
+    end
+
+    it "ignores the IANA record for the TLD when the registry publishes no date" do
+      mock_whois stdout: "#{whois_output.lines.take(5).join}Domain: brew.sh\nStatus: connect\n"
+
+      expect(described_class.new_domain_problem("https://brew.sh")).to be_nil
+    end
+
+    it "tolerates invalid UTF-8 in `whois` output" do
+      mock_whois stdout: "#{whois_output}Registrant: \xFF\n"
+
+      expect(described_class.new_domain_problem("https://brew.sh"))
+        .to include("`homepage` domain `brew.sh` was registered on 2026-07-01")
     end
 
     it "ignores domains with no parseable creation date" do
@@ -147,7 +237,8 @@ RSpec.describe SharedAudits do
       https://foo.github.io/bar
       https://sr.ht/~foo/bar
     ]) do |homepage|
-      it "does not run `whois` for the git forge homepage #{homepage}" do
+      it "does not look up the git forge homepage #{homepage}" do
+        expect(Utils::Curl).not_to receive(:curl_output)
         expect(SystemCommand).not_to receive(:run)
         expect(described_class.new_domain_problem(homepage)).to be_nil
       end

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -816,8 +816,6 @@ module Utils
       base_url
     end
 
-    private
-
     # Parses HTTP response text from `curl` output into a hash containing the
     # information from the status line (status code and, optionally,
     # descriptive text) and headers.

--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -26,9 +26,20 @@ module SharedAudits
   WHOIS_TIMEOUT_SECONDS = 5
   WHOIS_CREATION_DATE_REGEX = /^\s*(?:creation\s+date|created(?:\s+on)?|registered(?:\s+on)?|
                                 registration\s+(?:date|time))\s*:\s*(\S+)/ix
+  # RDAP is the IETF successor to WHOIS: ICANN requires every gTLD registry to serve it
+  # and IANA's bootstrap file lists the server for each TLD (gTLD or ccTLD) that does.
+  RDAP_BOOTSTRAP_URL = "https://data.iana.org/rdap/dns.json"
+  RDAP_TIMEOUT_SECONDS = 10
+  RdapServices = T.type_alias { T::Array[[T::Array[String], T::Array[String]]] }
   @pull_request_author = T.let(nil, T.nilable(String))
   @pull_request_author_computed = T.let(false, T::Boolean)
   @self_submission_cache = T.let({}, T::Hash[String, T::Boolean])
+  @rdap_services = T.let(nil, T.nilable(RdapServices))
+
+  class << self
+    sig { params(rdap_services: T.nilable(RdapServices)).returns(T.nilable(RdapServices)) }
+    attr_writer :rdap_services
+  end
 
   sig { params(browsed: T.nilable(Date)).returns(T::Boolean) }
   def self.homepage_browsed_recently?(browsed)
@@ -47,31 +58,85 @@ module SharedAudits
     end
     return if host.blank?
 
-    domain = host.delete_prefix("www.")
+    domain = host.downcase.delete_prefix("www.")
     return if GIT_FORGE_DOMAINS.any? { |forge| domain == forge || domain.end_with?(".#{forge}") }
-    return if which("whois").nil?
 
-    result = begin
-      SystemCommand.run("whois", args: [domain], print_stderr: false, timeout: WHOIS_TIMEOUT_SECONDS)
-    rescue Timeout::Error
-      nil
+    @rdap_services ||= begin
+      result = Utils::Curl.curl_output(RDAP_BOOTSTRAP_URL, max_time: RDAP_TIMEOUT_SECONDS)
+      (JSON.parse(result.stdout).fetch("services") if result.status.success?) || []
+    rescue JSON::ParserError, KeyError, TypeError
+      []
     end
-    return if result.nil? || !result.status.success?
 
-    # `whois` may concatenate the IANA record for the TLD (whose creation date is
-    # always ancient) with the registry record for the domain, so use the newest date.
-    registered_on = result.stdout.lines.filter_map do |line|
-      value = line[WHOIS_CREATION_DATE_REGEX, 1]
-      next if value.nil?
+    registered_domain = domain
+    registered_on = T.let(nil, T.nilable(Date))
+    tld = domain.split(".").last
+    rdap_urls = @rdap_services.find { |tlds, _| tlds.include?(tld) }&.fetch(1)
+    if rdap_urls.present?
+      rdap_base_url = (rdap_urls.find { |url| url.start_with?("https://") } || rdap_urls.fetch(0)).delete_suffix("/")
+      # Registries answer 4xx for subdomains, so walk up to the registered domain.
+      labels = domain.split(".")
+      while labels.length >= 2
+        candidate = labels.join(".")
+        result = Utils::Curl.curl_output(
+          "--include", "--location", "#{rdap_base_url}/domain/#{candidate}",
+          header: "Accept: application/rdap+json", max_time: RDAP_TIMEOUT_SECONDS
+        )
+        break unless result.status.success?
 
-      Date.parse(value)
-    rescue Date::Error
-      nil
-    end.max
+        parsed = Utils::Curl.parse_curl_output(result.stdout)
+        case parsed.fetch(:responses).last&.fetch(:status_code).to_i
+        when 200
+          registered_on = begin
+            events = JSON.parse(parsed.fetch(:body)).fetch("events", [])
+            registration = events.find { |event| event["eventAction"] == "registration" }
+            Date.parse(registration.fetch("eventDate")) unless registration.nil?
+          rescue JSON::ParserError, KeyError, TypeError, Date::Error
+            nil
+          end
+          registered_domain = candidate unless registered_on.nil?
+          break
+        when 400..499
+          labels.shift
+        else
+          break
+        end
+      end
+    end
+
+    if registered_on.nil? && which("whois")
+      whois = begin
+        SystemCommand.run("whois", args: [domain], print_stderr: false, timeout: WHOIS_TIMEOUT_SECONDS)
+      rescue Timeout::Error
+        nil
+      end
+      lines = if whois.nil? || !whois.status.success?
+        []
+      else
+        whois.stdout.scrub.lines
+      end
+      # `whois` may print the IANA record for the TLD (whose creation date is always ancient)
+      # before following its referral to the registry, so only look after the referral marker:
+      # `# whois.nic.sh` on macOS, `Found a referral to whois.nic.sh.` on Linux.
+      if lines.first&.start_with?("% IANA WHOIS server")
+        referral_index = lines.index { |line| line.start_with?("# whois.", "Found a referral to ") }
+        lines = referral_index ? lines.drop(referral_index + 1) : []
+      end
+
+      lines.each do |line|
+        value = line[WHOIS_CREATION_DATE_REGEX, 1]
+        next if value.nil?
+
+        registered_on = Date.parse(value)
+        break
+      rescue Date::Error
+        nil
+      end
+    end
     return if registered_on.nil?
     return if (Date.today - registered_on) >= NEW_DOMAIN_THRESHOLD_DAYS
 
-    "`homepage` domain `#{domain}` was registered on #{registered_on}: " \
+    "`homepage` domain `#{registered_domain}` was registered on #{registered_on}: " \
       "homepages should exist for at least #{NEW_DOMAIN_THRESHOLD_DAYS} days before inclusion"
   end
 


### PR DESCRIPTION
The `homepage` domain age audit does not work for all TLDs. The WHOIS spec was sunset by WHOIS in January 2025[^1], and has been replaced by a new spec RDAP[^2]. 

This PR changes the behaviour to try the RDAP lookup first, by checking IANA's official RDAP registry for the correct endpoint, before falling back to the existing `whois` lookup if necessary.

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

I used `claude-code` with Fable 5 Max to implement the fix, and research the correct RDAP approach.


[^1]: https://www.icann.org/en/announcements/details/icann-update-launching-rdap-sunsetting-whois-27-01-2025-en
[^2]: https://www.icann.org/en/contracted-parties/registry-operators/resources/registration-data-access-protocol