### PR TITLE
keg: fix remove_oldname_opt_records to avoid early return

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -581,7 +581,7 @@ class Keg
   sig { void }
   def remove_oldname_opt_records
     oldname_opt_records.reject! do |record|
-      return false if record.resolved_path != path
+      next false if record.resolved_path != path
 
       record.unlink
       record.parent.rmdir_if_possible

--- a/Library/Homebrew/test/keg_spec.rb
+++ b/Library/Homebrew/test/keg_spec.rb
@@ -63,15 +63,42 @@ RSpec.describe Keg do
     expect(keg.oldname_opt_records).to eq([oldname_opt_record])
   end
 
-  specify "#remove_oldname_opt_records" do
-    oldname_opt_record = HOMEBREW_PREFIX/"opt/oldfoo"
-    oldname_opt_record.make_relative_symlink(HOMEBREW_CELLAR/"foo/2.0")
-    keg.remove_oldname_opt_records
-    expect(oldname_opt_record).to be_a_symlink
-    oldname_opt_record.unlink
-    oldname_opt_record.make_relative_symlink(HOMEBREW_CELLAR/"foo/1.0")
-    keg.remove_oldname_opt_records
-    expect(oldname_opt_record).not_to be_a_symlink
+  describe "#remove_oldname_opt_records" do
+    let(:oldname_opt_record) { HOMEBREW_PREFIX/"opt/oldfoo" }
+
+    before { setup_test_keg("foo", "2.0") }
+
+    it "does not modify an opt record for a different keg" do
+      oldname_opt_record.make_relative_symlink(HOMEBREW_CELLAR/"foo/2.0")
+      keg.remove_oldname_opt_records
+      expect(oldname_opt_record).to be_a_symlink
+    end
+
+    it "removes an opt record for the specified keg" do
+      oldname_opt_record.make_relative_symlink(HOMEBREW_CELLAR/"foo/1.0")
+      keg.remove_oldname_opt_records
+      expect(oldname_opt_record).not_to be_a_symlink
+    end
+
+    it "handles multiple opt records correctly" do
+      related_records = [
+        oldname_opt_record,
+        HOMEBREW_PREFIX/"opt/oldfoo@1",
+        HOMEBREW_PREFIX/"opt/related",
+      ]
+      unrelated_records = [
+        HOMEBREW_PREFIX/"opt/oldfoo2",
+        HOMEBREW_PREFIX/"opt/oldfoo@2",
+        HOMEBREW_PREFIX/"opt/unrelated",
+      ]
+      related_records.each { |record| record.make_relative_symlink(HOMEBREW_CELLAR/"foo/1.0") }
+      unrelated_records.each { |record| record.make_relative_symlink(HOMEBREW_CELLAR/"foo/2.0") }
+
+      keg.remove_oldname_opt_records
+
+      expect(related_records).not_to include(be_a_symlink)
+      expect(unrelated_records).to all be_a_symlink
+    end
   end
 
   describe "#link" do

--- a/Library/Homebrew/test/keg_spec.rb
+++ b/Library/Homebrew/test/keg_spec.rb
@@ -93,6 +93,7 @@ RSpec.describe Keg do
       ]
       related_records.each { |record| record.make_relative_symlink(HOMEBREW_CELLAR/"foo/1.0") }
       unrelated_records.each { |record| record.make_relative_symlink(HOMEBREW_CELLAR/"foo/2.0") }
+      allow(keg).to receive(:oldname_opt_records).and_return(unrelated_records + related_records)
 
       keg.remove_oldname_opt_records
 


### PR DESCRIPTION
Minor fix for something I noticed when debugging another issue.

The methods seems to be intended for removing all records that symlink to keg given it is only used during uninstall. However, the previous logic would stop on first symlink for another keg in same rack.

Test case added that would fail on original logic.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

n/a

-----
