### PR TITLE
Add Formula#python3 for the direct Python dependency

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -910,6 +910,26 @@ class Formula
   # @api public
   delegate deps: :active_spec
 
+  # The stable path to the executable provided by this formula's direct Python 3 dependency.
+  #
+  # @raise [RuntimeError] if the formula does not have exactly one `python@3.x` dependency
+  # @api public
+  sig { returns(Pathname) }
+  def python3
+    python_deps = deps.filter_map do |dep|
+      name = Utils.name_from_full_name(dep.name)
+      name if name.match?(/\Apython@3\.\d+\z/)
+    end.uniq
+
+    if python_deps.length != 1
+      found = python_deps.empty? ? "none" : python_deps.join(", ")
+      raise "`#{full_name}` must have exactly one `python@3.x` dependency to use `python3`; found #{found}."
+    end
+
+    python_dep = python_deps.fetch(0)
+    formula_opt_bin(python_dep)/python_dep.delete("@")
+  end
+
   # The declared {Dependency}s for the currently active {SoftwareSpec} (i.e. including those provided by macOS).
   delegate declared_deps: :active_spec
 

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -157,6 +157,61 @@ RSpec.describe Formula do
     end
   end
 
+  describe "#python3" do
+    it "returns the stable executable for a direct Python dependency" do
+      f = formula "python-runtime-dependent" do
+        url "foo-1.0"
+        depends_on "python@3.14"
+      end
+
+      expect(f.python3).to eq HOMEBREW_PREFIX/"opt/python@3.14/bin/python3.14"
+    end
+
+    it "includes build and test dependencies" do
+      f = formula "python-build-test-dependent" do
+        url "foo-1.0"
+        depends_on "python@3.13" => [:build, :test]
+      end
+
+      expect(f.python3).to eq HOMEBREW_PREFIX/"opt/python@3.13/bin/python3.13"
+    end
+
+    it "de-duplicates the same Python dependency declared with separate tags" do
+      f = formula "python-split-tags" do
+        url "foo-1.0"
+        depends_on "python@3.14" => :build
+        depends_on "python@3.14" => :test
+      end
+
+      expect(f.python3).to eq HOMEBREW_PREFIX/"opt/python@3.14/bin/python3.14"
+    end
+
+    it "fails when there is no direct Python dependency" do
+      f = formula "no-python-dependency" do
+        url "foo-1.0"
+        depends_on "boost-python3"
+      end
+
+      expect { f.python3 }
+        .to raise_error(RuntimeError,
+                        "`no-python-dependency` must have exactly one `python@3.x` dependency to use `python3`; " \
+                        "found none.")
+    end
+
+    it "fails when there are multiple direct Python dependencies" do
+      f = formula "multiple-python-dependencies" do
+        url "foo-1.0"
+        depends_on "python@3.13" => [:build, :test]
+        depends_on "python@3.14" => [:build, :test]
+      end
+
+      expect { f.python3 }
+        .to raise_error(RuntimeError,
+                        "`multiple-python-dependencies` must have exactly one `python@3.x` dependency to use " \
+                        "`python3`; found python@3.13, python@3.14.")
+    end
+  end
+
   describe "#versioned_formulae" do
     let(:f) do
       formula "foo" do


### PR DESCRIPTION
Adds `Formula#python3`, which returns the stable `opt` path to the interpreter of a formula's single direct `python@3.x` dependency, e.g. `/opt/homebrew/opt/python@3.14/bin/python3.14`. It is derived only from the declared dependency list, including build and test dependencies, and never runs Python, searches `PATH` or walks transitive dependencies. It raises when the formula declares zero or multiple distinct `python@3.x` dependencies.

This is the dependency-derived approach suggested in the #23479 review, mirroring how `detected_python_shebang` already picks its interpreter, and is meant as a more incremental route than autocorrecting to a probed executable. `python_major_minor_version` from #23481 works on the result for formulae that also need the version. Nothing in brew calls the new method yet and no cop is added, so this lands on its own; homebrew/core formulae migrate by deleting their existing `def python3` overrides (139 today, most returning a hardcoded `"python3.14"`), and a cop or autocorrect can follow once that is underway.

Same-name dependencies are de-duplicated before counting because API-loaded formulae split a `[:build, :test]` dependency into separate `:build` and `:test` entries, and `on_linux` re-declarations (e.g. `gdcm`) do the same on Linux.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Fable 5.1) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the change and pass with it, and ran `brew lgtm --online` plus targeted specs.

-----
