### PR TITLE
cask/audit: skip the signing audit for Intel macOS

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -616,6 +616,11 @@ module Cask
         return
       end
 
+      if Homebrew::SimulateSystem.current_arch == :intel
+        odebug "Intel macOS is Tier 3, skipping signing audit"
+        return
+      end
+
       odebug "Auditing signing"
       is_in_skiplist = cask.tap&.audit_exception(:signing_audit_skiplist, cask.token,
                                                  Homebrew::SimulateSystem.current_arch.to_s) ||

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -594,6 +594,30 @@ RSpec.describe Cask::Audit, :cask do
           expect(run).not_to error_with(/Signature verification failed/)
         end
       end
+
+      context "when auditing for Intel" do
+        let(:cask) do
+          tmp_cask "signing-cask-test", <<~RUBY
+            cask 'signing-cask-test' do
+              version '1.0'
+              url "https://brew.sh/"
+              app 'Audit.app'
+            end
+          RUBY
+        end
+
+        before do
+          allow(cask).to receive(:tap).and_return(tap)
+          allow(Cask::Quarantine).to receive(:available?).and_return(true)
+          allow(Homebrew::SimulateSystem).to receive(:current_arch).and_return(:intel)
+        end
+
+        it "skips signing audit" do
+          expect(audit).not_to receive(:extract_artifacts)
+          expect(audit).to receive(:odebug).with("Intel macOS is Tier 3, skipping signing audit")
+          expect(run).not_to error_with(/Signature verification failed/)
+        end
+      end
     end
 
     describe "homepage domain age" do


### PR DESCRIPTION
This PR adjusts `brew audit` for casks, to skip the signing audit for Intel.
We have seen an increasing rate of flakiness on the `macos-15-intel` runner specifically with this audit, which may well be a case of Sequoia having different Gatekeeper requirements.

In any case, intel macOS is now a tier 3 configuration, so the easiest way forward in my mind, is to skip the audit there.

Further deprecations will be required when we fully remove intel support, but this keeps us moving for now.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
