### PR TITLE
generate-cask-ci-matrix: drop macOS Intel CI

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-cask-ci-matrix.rb
+++ b/Library/Homebrew/dev-cmd/generate-cask-ci-matrix.rb
@@ -13,24 +13,15 @@ module Homebrew
       MAX_JOBS = 256
 
       # Weight for each arch must add up to 1.0.
-      X86_MACOS_RUNNERS = T.let({
-        { symbol: :sequoia, name: "macos-15-intel", arch: :intel } => 1.0,
-      }.freeze, T::Hash[T::Hash[Symbol, T.any(Symbol, String)], Float])
-      X86_LINUX_RUNNERS = T.let({
-        { symbol: :linux, name: "ubuntu-latest", arch: :intel } => 1.0,
-      }.freeze, T::Hash[T::Hash[Symbol, T.any(Symbol, String)], Float])
-      ARM_MACOS_RUNNERS = T.let({
+      MACOS_RUNNERS = T.let({
         { symbol: :sonoma,  name: "macos-14", arch: :arm } => 0.0,
         { symbol: :sequoia, name: "macos-15", arch: :arm } => 0.0,
         { symbol: :tahoe,   name: "macos-26", arch: :arm } => 1.0,
       }.freeze, T::Hash[T::Hash[Symbol, T.any(Symbol, String)], Float])
-      ARM_LINUX_RUNNERS = T.let({
+      LINUX_RUNNERS = T.let({
+        { symbol: :linux, name: "ubuntu-latest", arch: :intel }       => 1.0,
         { symbol: :linux, name: OS::LINUX_CI_ARM_RUNNER, arch: :arm } => 1.0,
       }.freeze, T::Hash[T::Hash[Symbol, T.any(Symbol, String)], Float])
-      MACOS_RUNNERS = T.let(X86_MACOS_RUNNERS.merge(ARM_MACOS_RUNNERS).freeze,
-                            T::Hash[T::Hash[Symbol, T.any(Symbol, String)], Float])
-      LINUX_RUNNERS = T.let(X86_LINUX_RUNNERS.merge(ARM_LINUX_RUNNERS).freeze,
-                            T::Hash[T::Hash[Symbol, T.any(Symbol, String)], Float])
       RUNNERS = T.let(MACOS_RUNNERS.merge(LINUX_RUNNERS).freeze,
                       T::Hash[T::Hash[Symbol, T.any(Symbol, String)], Float])
 
@@ -167,32 +158,7 @@ module Homebrew
         filtered_runners.merge(linux_runners)
       end
 
-      sig {
-        params(
-          runners:  T::Array[T::Hash[Symbol, T.any(Symbol, String)]],
-          multi_os: T::Boolean,
-        ).returns(T::Array[[T::Hash[Symbol, T.any(Symbol, String)], T.any(Symbol, String), T::Boolean]])
-      }
-      def runner_arch_pairs(runners:, multi_os:)
-        macos_archs = runners.reject { |r| r.fetch(:symbol) == :linux }.map { |r| r.fetch(:arch) }.uniq
-        linux_archs = runners.select { |r| r.fetch(:symbol) == :linux }.map { |r| r.fetch(:arch) }.uniq
-        product_archs = macos_archs | linux_archs
-        runners.product(product_archs).filter_map do |runner, arch|
-          native_runner_arch = arch == runner.fetch(:arch)
-          # we don't need to run simulated archs on Linux or macOS Sequoia
-          # because they exist as real GitHub hosted runners
-          next if runner.fetch(:symbol) == :linux && !native_runner_arch
-          next if runner.fetch(:symbol) == :sequoia && !native_runner_arch
-          # skip macOS runners simulating architectures not supported on macOS
-          next if runner.fetch(:symbol) != :linux && !native_runner_arch && macos_archs.exclude?(arch)
-          # if it's just a single OS test then we can just use the two real arch runners
-          next if !native_runner_arch && !multi_os
-
-          [runner, arch, native_runner_arch]
-        end
-      end
-
-      sig { params(cask: Cask::Cask).returns([T::Array[T::Hash[Symbol, T.any(Symbol, String)]], T::Boolean]) }
+      sig { params(cask: Cask::Cask).returns(T::Array[T::Hash[Symbol, T.any(Symbol, String)]]) }
       def runners(cask:)
         filtered_runners = filter_runners(cask)
 
@@ -200,18 +166,14 @@ module Homebrew
           cask.to_hash_with_variations["variations"].key?(runner.fetch(:symbol).to_sym)
         end
 
-        if filtered_macos_found
-          # If the cask varies on a MacOS version, test it on every possible macOS version.
-          [filtered_runners.keys, true]
-        else
-          macos_runners, linux_runners = filtered_runners.partition do |runner, _|
-            runner.fetch(:symbol) != :linux
-          end
-          selected_runners = macos_runners.group_by { |runner, _| runner.fetch(:arch) }.map do |_, runners|
-            random_runner(runners.to_h)
-          end + linux_runners.map(&:first)
-          [selected_runners, false]
+        # If the cask varies on a macOS version, test it on every possible macOS version.
+        return filtered_runners.keys if filtered_macos_found
+
+        macos_runners, linux_runners = filtered_runners.partition do |runner, _|
+          runner.fetch(:symbol) != :linux
         end
+        selected_runners = macos_runners.any? ? [random_runner(macos_runners.to_h)] : []
+        selected_runners + linux_runners.map(&:first)
       end
 
       private
@@ -238,7 +200,7 @@ module Homebrew
         params(available_runners: T::Hash[T::Hash[Symbol, T.any(Symbol, String)],
                                           Float]).returns(T::Hash[Symbol, T.any(Symbol, String)])
       }
-      def random_runner(available_runners = ARM_MACOS_RUNNERS)
+      def random_runner(available_runners = MACOS_RUNNERS)
         max_runner = available_runners.max_by { |(_, weight)| rand ** (1.0 / weight) }
         raise "unexpected nil max_runner" unless max_runner
 
@@ -311,19 +273,20 @@ module Homebrew
 
           cask = Cask::CaskLoader.load(path.expand_path)
 
-          runners, multi_os = runners(cask:)
-          runner_arch_pairs(runners:, multi_os:).map do |runner, arch, native_runner_arch|
-            arch_args = native_runner_arch ? [] : ["--arch=#{arch}"]
+          runners = runners(cask:)
+          puts "::warning file=#{path}::No CI runner supports this cask, so it will not be tested." if runners.empty?
+
+          runners.map do |runner|
             runner_output = {
-              name:         "test #{cask_token} (#{runner.fetch(:name)}, #{arch})",
+              name:         "test #{cask_token} (#{runner.fetch(:name)}, #{runner.fetch(:arch)})",
               tap:          tap.name,
               cask:         {
                 token: cask_token,
                 path:  "./#{path}",
               },
-              audit_args:   audit_args + arch_args,
-              fetch_args:   arch_args,
-              skip_install: labels.include?("ci-skip-install") || !native_runner_arch || skip_install,
+              audit_args:,
+              fetch_args:   [],
+              skip_install: labels.include?("ci-skip-install") || skip_install,
               runner:       runner.fetch(:name),
             }
 

--- a/Library/Homebrew/test/dev-cmd/generate-cask-ci-matrix_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-cask-ci-matrix_spec.rb
@@ -310,22 +310,20 @@ RSpec.describe Homebrew::DevCmd::GenerateCaskCiMatrix do
       it "returns an array including everything" do
         expect(generate_matrix.filter_runners(c))
           .to eq({
-            { arch: :arm, name: "macos-14", symbol: :sonoma }          => 0.0,
-            { arch: :arm, name: "macos-15", symbol: :sequoia }         => 0.0,
-            { arch: :arm, name: "macos-26", symbol: :tahoe }           => 1.0,
-            { arch: :arm, name: arm_linux_runner, symbol: :linux }     => 1.0,
-            { arch: :intel, name: "macos-15-intel", symbol: :sequoia } => 1.0,
-            { arch: :intel, name: "ubuntu-latest", symbol: :linux }    => 1.0,
+            { arch: :arm, name: "macos-14", symbol: :sonoma }       => 0.0,
+            { arch: :arm, name: "macos-15", symbol: :sequoia }      => 0.0,
+            { arch: :arm, name: "macos-26", symbol: :tahoe }        => 1.0,
+            { arch: :arm, name: arm_linux_runner, symbol: :linux }  => 1.0,
+            { arch: :intel, name: "ubuntu-latest", symbol: :linux } => 1.0,
           })
 
         expect(generate_matrix.filter_runners(c_app_only_macos))
           .to eq({
-            { arch: :arm, name: "macos-14", symbol: :sonoma }          => 0.0,
-            { arch: :arm, name: "macos-15", symbol: :sequoia }         => 0.0,
-            { arch: :arm, name: "macos-26", symbol: :tahoe }           => 1.0,
-            { arch: :arm, name: arm_linux_runner, symbol: :linux }     => 1.0,
-            { arch: :intel, name: "macos-15-intel", symbol: :sequoia } => 1.0,
-            { arch: :intel, name: "ubuntu-latest", symbol: :linux }    => 1.0,
+            { arch: :arm, name: "macos-14", symbol: :sonoma }       => 0.0,
+            { arch: :arm, name: "macos-15", symbol: :sequoia }      => 0.0,
+            { arch: :arm, name: "macos-26", symbol: :tahoe }        => 1.0,
+            { arch: :arm, name: arm_linux_runner, symbol: :linux }  => 1.0,
+            { arch: :intel, name: "ubuntu-latest", symbol: :linux } => 1.0,
           })
       end
     end
@@ -334,10 +332,9 @@ RSpec.describe Homebrew::DevCmd::GenerateCaskCiMatrix do
       it "returns an array including all macOS" do
         expect(generate_matrix.filter_runners(c_app))
           .to eq({
-            { arch: :arm, name: "macos-14", symbol: :sonoma }          => 0.0,
-            { arch: :arm, name: "macos-15", symbol: :sequoia }         => 0.0,
-            { arch: :arm, name: "macos-26", symbol: :tahoe }           => 1.0,
-            { arch: :intel, name: "macos-15-intel", symbol: :sequoia } => 1.0,
+            { arch: :arm, name: "macos-14", symbol: :sonoma }  => 0.0,
+            { arch: :arm, name: "macos-15", symbol: :sequoia } => 0.0,
+            { arch: :arm, name: "macos-26", symbol: :tahoe }   => 1.0,
           })
       end
     end
@@ -346,9 +343,8 @@ RSpec.describe Homebrew::DevCmd::GenerateCaskCiMatrix do
       it "filters macOS runners by the minimum and maximum macOS requirements" do
         expect(generate_matrix.filter_runners(c_minimum_macos))
           .to eq({
-            { arch: :arm, name: "macos-15", symbol: :sequoia }         => 0.0,
-            { arch: :arm, name: "macos-26", symbol: :tahoe }           => 1.0,
-            { arch: :intel, name: "macos-15-intel", symbol: :sequoia } => 1.0,
+            { arch: :arm, name: "macos-15", symbol: :sequoia } => 0.0,
+            { arch: :arm, name: "macos-26", symbol: :tahoe }   => 1.0,
           })
 
         expect(generate_matrix.filter_runners(c_maximum_macos))
@@ -356,9 +352,8 @@ RSpec.describe Homebrew::DevCmd::GenerateCaskCiMatrix do
 
         expect(generate_matrix.filter_runners(c_minimum_and_maximum_macos))
           .to eq({
-            { arch: :arm, name: "macos-14", symbol: :sonoma }          => 0.0,
-            { arch: :arm, name: "macos-15", symbol: :sequoia }         => 0.0,
-            { arch: :intel, name: "macos-15-intel", symbol: :sequoia } => 1.0,
+            { arch: :arm, name: "macos-14", symbol: :sonoma }  => 0.0,
+            { arch: :arm, name: "macos-15", symbol: :sequoia } => 0.0,
           })
 
         # A requirement excluding all runners must skip macOS, not test them all.
@@ -377,9 +372,8 @@ RSpec.describe Homebrew::DevCmd::GenerateCaskCiMatrix do
     end
 
     context "when cask does not have on_system blocks/calls but has `depends_on arch`" do
-      it "returns an array only including macOS/`depends_on arch` value" do
-        expect(generate_matrix.filter_runners(c_depends_macos_on_intel))
-          .to eq({ { arch: :intel, name: "macos-15-intel", symbol: :sequoia } => 1.0 })
+      it "returns no runners for an Intel-only macOS cask" do
+        expect(generate_matrix.filter_runners(c_depends_macos_on_intel)).to eq({})
       end
     end
 
@@ -387,12 +381,11 @@ RSpec.describe Homebrew::DevCmd::GenerateCaskCiMatrix do
       it "returns an array with combinations of OS and architectures" do
         expect(generate_matrix.filter_runners(c_on_system))
           .to eq({
-            { arch: :arm, name: "macos-14", symbol: :sonoma }          => 0.0,
-            { arch: :arm, name: "macos-15", symbol: :sequoia }         => 0.0,
-            { arch: :arm, name: "macos-26", symbol: :tahoe }           => 1.0,
-            { arch: :arm, name: arm_linux_runner, symbol: :linux }     => 1.0,
-            { arch: :intel, name: "macos-15-intel", symbol: :sequoia } => 1.0,
-            { arch: :intel, name: "ubuntu-latest", symbol: :linux }    => 1.0,
+            { arch: :arm, name: "macos-14", symbol: :sonoma }       => 0.0,
+            { arch: :arm, name: "macos-15", symbol: :sequoia }      => 0.0,
+            { arch: :arm, name: "macos-26", symbol: :tahoe }        => 1.0,
+            { arch: :arm, name: arm_linux_runner, symbol: :linux }  => 1.0,
+            { arch: :intel, name: "ubuntu-latest", symbol: :linux } => 1.0,
           })
       end
     end
@@ -400,25 +393,20 @@ RSpec.describe Homebrew::DevCmd::GenerateCaskCiMatrix do
     context "when cask has on_system blocks/calls and `depends_on arch`" do
       it "returns an array with combinations of OS and `depends_on arch` value" do
         expect(generate_matrix.filter_runners(c_on_system_depends_on_intel))
-          .to eq({
-            { arch: :intel, name: "macos-15-intel", symbol: :sequoia } => 1.0,
-            { arch: :intel, name: "ubuntu-latest", symbol: :linux }    => 1.0,
-          })
+          .to eq({ { arch: :intel, name: "ubuntu-latest", symbol: :linux } => 1.0 })
 
         expect(generate_matrix.filter_runners(c_on_linux_depends_on_intel))
           .to eq({
-            { arch: :arm, name: "macos-14", symbol: :sonoma }          => 0.0,
-            { arch: :arm, name: "macos-15", symbol: :sequoia }         => 0.0,
-            { arch: :arm, name: "macos-26", symbol: :tahoe }           => 1.0,
-            { arch: :intel, name: "macos-15-intel", symbol: :sequoia } => 1.0,
-            { arch: :intel, name: "ubuntu-latest", symbol: :linux }    => 1.0,
+            { arch: :arm, name: "macos-14", symbol: :sonoma }       => 0.0,
+            { arch: :arm, name: "macos-15", symbol: :sequoia }      => 0.0,
+            { arch: :arm, name: "macos-26", symbol: :tahoe }        => 1.0,
+            { arch: :intel, name: "ubuntu-latest", symbol: :linux } => 1.0,
           })
 
         expect(generate_matrix.filter_runners(c_on_macos_depends_on_intel))
           .to eq({
-            { arch: :intel, name: "macos-15-intel", symbol: :sequoia } => 1.0,
-            { arch: :intel, name: "ubuntu-latest", symbol: :linux }    => 1.0,
-            { arch: :arm, name: arm_linux_runner, symbol: :linux }     => 1.0,
+            { arch: :intel, name: "ubuntu-latest", symbol: :linux } => 1.0,
+            { arch: :arm, name: arm_linux_runner, symbol: :linux }  => 1.0,
           })
 
         expect(generate_matrix.filter_runners(c_on_macos_depends_on_arm))
@@ -431,46 +419,24 @@ RSpec.describe Homebrew::DevCmd::GenerateCaskCiMatrix do
           })
 
         expect(generate_matrix.filter_runners(c_on_system_depends_on_mixed))
-          .to eq({
-            { arch: :arm, name: arm_linux_runner, symbol: :linux }     => 1.0,
-            { arch: :intel, name: "macos-15-intel", symbol: :sequoia } => 1.0,
-          })
+          .to eq({ { arch: :arm, name: arm_linux_runner, symbol: :linux } => 1.0 })
       end
     end
   end
 
   describe "::runners" do
-    it "selects macOS and Linux runners independently" do
-      allow(generate_matrix).to receive(:random_runner) do |runners|
-        runners.keys.find { |runner| runner.fetch(:symbol) == :linux } || runners.keys.first
-      end
-
-      runners, multi_os = generate_matrix.runners(cask: c)
-
-      expect(runners.map { |runner| [(runner.fetch(:symbol) == :linux) ? :linux : :macos, runner.fetch(:arch)] })
-        .to contain_exactly([:macos, :arm], [:macos, :intel], [:linux, :arm], [:linux, :intel])
-      expect(multi_os).to be(false)
-    end
-  end
-
-  describe "::runner_arch_pairs" do
     let(:arm_linux_runner) { OS::LINUX_CI_ARM_RUNNER }
 
-    it "emits both Linux runners and no cross-arch macOS jobs when macOS is single-arch" do
-      runners = generate_matrix.filter_runners(c_on_macos_depends_on_arm).keys
-      pairs = generate_matrix.runner_arch_pairs(runners:, multi_os: true)
-      archs_by_runner = pairs.each_with_object({}) do |(runner, arch, _), h|
-        (h[runner.fetch(:name)] ||= []) << arch
-      end
+    it "selects one macOS runner and every Linux runner" do
+      allow(generate_matrix).to receive(:random_runner) { |runners| runners.keys.first }
 
-      # both Linux runners produce jobs for their native arch
-      expect(archs_by_runner[arm_linux_runner]).to eq([:arm])
-      expect(archs_by_runner["ubuntu-latest"]).to eq([:intel])
+      expect(generate_matrix.runners(cask: c).map { |runner| runner.fetch(:name) })
+        .to contain_exactly("macos-14", arm_linux_runner, "ubuntu-latest")
+    end
 
-      # macOS runners only get their native :arm, never simulated :intel
-      expect(archs_by_runner["macos-14"]).to eq([:arm])
-      expect(archs_by_runner["macos-15"]).to eq([:arm])
-      expect(archs_by_runner["macos-26"]).to eq([:arm])
+    it "selects only Linux runners for an Intel-only macOS cask" do
+      expect(generate_matrix.runners(cask: c_on_macos_depends_on_intel).map { |runner| runner.fetch(:name) })
+        .to contain_exactly(arm_linux_runner, "ubuntu-latest")
     end
   end
 end


### PR DESCRIPTION
Remove the `macos-15-intel` runner and the simulated-architecture jobs that ran `audit` and `fetch` with `--arch=intel` on ARM runners, matching the macOS Intel CI removal in Homebrew/brew and Homebrew/homebrew-core. Linux x86_64 is still tested on `ubuntu-latest`.

Caveats;
- Casks with separate Intel and ARM macOS artifacts no longer have their Intel URL or checksum fetched or audited on macOS.
- Intel-only macOS casks get no macOS jobs at all. A `::warning` annotation is emitted when a changed cask has no runner so this is visible on the pull request.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

I used `claude-code` with Fable 5.1 to help generate the extended changes.