### PR TITLE
rubocops/formula_cop: match array dependency type values

### DIFF
--- a/Library/Homebrew/rubocops/extend/formula_cop.rb
+++ b/Library/Homebrew/rubocops/extend/formula_cop.rb
@@ -85,7 +85,6 @@ module RuboCop
       end
 
       # Returns true if given dependency name and dependency type exist in given dependency method call node.
-      # TODO: Add case where key of hash is an array
       sig {
         params(
           node: RuboCop::AST::Node, name: T.nilable(T.any(String, Symbol)), type: Symbol,
@@ -124,7 +123,7 @@ module RuboCop
       EOS
 
       def_node_search :dependency_type_hash_match?, <<~EOS
-        (hash (pair ({str sym} _) ({str sym} %1)))
+        (hash (pair ({str sym} _) {({str sym} %1) (array <({str sym} %1) ...>)}))
       EOS
 
       def_node_search :dependency_name_hash_match?, <<~EOS

--- a/Library/Homebrew/test/rubocops/options_spec.rb
+++ b/Library/Homebrew/test/rubocops/options_spec.rb
@@ -27,6 +27,16 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Options do
       RUBY
     end
 
+    it "does not report an offense when `check` is an optional dependency given as an array value" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          url 'https://brew.sh/foo-1.0.tgz'
+          depends_on "check" => [:optional, :test]
+          option "with-check"
+        end
+      RUBY
+    end
+
     it "reports an offense when using `deprecated_option` in homebrew/core" do
       expect_offense(<<~RUBY, "/homebrew-core/")
         class Foo < Formula


### PR DESCRIPTION


value like `"x" => [:optional, :test]` was silently missed. This made `Options` warn to use `--with-test` even when the formula already had `check` as an optional dependency written as an array. Widened the node pattern to also match the type inside an array value, and dropped the old TODO


-----


<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
