### PR TITLE
Stop fetching bottle manifests when creating tabs

### DIFF
--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -158,7 +158,7 @@ class AbstractTab
       "full_name"             => formula.full_name,
       "version"               => formula.version.to_s,
       "revision"              => formula.revision,
-      "bottle_rebuild"        => formula.bottle&.rebuild,
+      "bottle_rebuild"        => formula.bottle_for_tag(Utils::Bottles.tag)&.rebuild,
       "pkg_version"           => formula.pkg_version.to_s,
       "declared_directly"     => declared_deps.include?(formula.full_name),
       "compatibility_version" => formula.compatibility_version,

--- a/Library/Homebrew/test/tab_spec.rb
+++ b/Library/Homebrew/test/tab_spec.rb
@@ -444,6 +444,35 @@ RSpec.describe Tab do
       expect(tab.source["scm_revision"]).to be_nil
     end
 
+    it "records a dependency's bottle rebuild without checking its bottle locations" do
+      # don't try to load gcc/glibc
+      allow(DevelopmentTools).to receive_messages(needs_libc_formula?: false, needs_compiler_formula?: false)
+
+      tag = Utils::Bottles.tag
+      bar = formula("bar") do
+        T.bind(self, T.class_of(Formula))
+        url "bar-2.0"
+
+        bottle do
+          rebuild 1
+          sha256 tag.to_sym => "deadbeef" * 8
+        end
+      end
+      stub_formula_loader bar
+      bottle = bar.bottle_for_tag(tag)
+      allow(bar).to receive(:bottle_for_tag).with(tag).and_return(bottle)
+      expect(bottle).not_to receive(:compatible_locations?)
+
+      f = formula do
+        T.bind(self, T.class_of(Formula))
+        url "file:///foo-1.0"
+        depends_on "bar"
+      end
+
+      expect(described_class.create(f, DevelopmentTools.default_compiler, :libcxx).runtime_dependencies)
+        .to include(hash_including("full_name" => "bar", "bottle_rebuild" => 1))
+    end
+
     it "records a non-default bottle build prefix" do
       f.build = BuildOptions.new(Options.create(["--build-bottle"]), f.options)
       allow(Homebrew).to receive(:default_prefix?).and_return(false)


### PR DESCRIPTION
- `Formula#bottle` now checks `compatible_locations?`, which fetches the bottle manifest when the tab metadata is not yet cached.
- `Tab.create` runs inside the build sandbox and called this for every runtime dependency, so formulae with a `fetch` phase failed to install once the sandbox denied the cache write.
- The dependency's rebuild number only depends on the bottle spec for the current tag, so read it without the location check.

Fixes #23759

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude with Fable at High effort, with local review and testing.

-----