### PR TITLE
cask: do not follow a symlinked `rmdir` path

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -649,6 +649,7 @@ module Cask
       def recursive_rmdir(*directories, command:, **_kwargs)
         directories.all? do |resolved_path|
           puts resolved_path.sub(Dir.home, "~")
+          next false if resolved_path.symlink?
 
           if resolved_path.readable?
             children = resolved_path.children

--- a/Library/Homebrew/cask/utils.rb
+++ b/Library/Homebrew/cask/utils.rb
@@ -43,7 +43,9 @@ module Cask
 
     sig { params(path: Pathname, command: T.class_of(SystemCommand)).void }
     def self.gain_permissions_rmdir(path, command: SystemCommand)
-      gain_permissions(path, [], command) do |p|
+      # `-h` unconditionally: it is a no-op on a real directory and avoids
+      # deciding from a path that could be replaced before the recovery runs.
+      gain_permissions(path, ["-h"], command) do |p|
         if p.parent.writable?
           FileUtils.rmdir p
         else

--- a/Library/Homebrew/test/cask/artifact/zap_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/zap_spec.rb
@@ -34,6 +34,25 @@ RSpec.describe Cask::Artifact::Zap, :cask do
         expect(ds_store).not_to exist
         expect(empty_directory).not_to exist
       end
+
+      context "when the directory is a symlink" do
+        let(:target) { Pathname.new("#{TEST_TMPDIR}/rmdir_symlink_target") }
+
+        before do
+          FileUtils.rm_rf empty_directory
+          target.join("nested").mkpath
+          FileUtils.ln_s target, empty_directory
+        end
+
+        after { FileUtils.rm_rf target }
+
+        it "leaves the link and its target alone" do
+          expect { artifact.zap_phase(command: fake_system_command) }.not_to raise_error
+
+          expect(empty_directory).to be_a_symlink
+          expect(target.join("nested")).to be_a_directory
+        end
+      end
     end
   end
 end

--- a/Library/Homebrew/test/cask/utils_spec.rb
+++ b/Library/Homebrew/test/cask/utils_spec.rb
@@ -77,4 +77,20 @@ RSpec.describe Cask::Utils do
       expect(path).not_to exist
     end
   end
+
+  describe "::gain_permissions_rmdir" do
+    it "changes the permissions of the symlink, not the directory it points to" do
+      path.mkpath
+      (path/"sub").mkpath
+      path.chmod(0500)
+      FileUtils.ln_s path, link
+
+      expect { described_class.gain_permissions_rmdir(link, command:) }.to raise_error(Errno::ENOTDIR)
+
+      expect(path.stat.mode & 0777).to eq 0500
+      expect(path/"sub").to be_a_directory
+
+      path.chmod(0700)
+    end
+  end
 end


### PR DESCRIPTION
`uninstall rmdir:` and `zap rmdir:` paths come from the cask, so one can name a location that a local user is able to replace with a symlink. `recursive_rmdir` recursed through such a link and removed empty directories inside its target, and `gain_permissions_rmdir` then ran its `chflags`, `chmod` and `sudo chown` recovery round against the target too, because it passed no `-h`. The uninstall aborted afterwards with an uncaught `Errno::ENOTDIR`, so that path never removed anything successfully anyway.

Skipping symlinks in `recursive_rmdir` and always passing `-h` in `gain_permissions_rmdir` means a symlinked `rmdir` path can no longer redirect the privileged permission changes onto whatever it points at, and the abort becomes a clean "not empty" skip. `-h` needs no condition because it is a no-op on a real directory, so nothing is decided from a path that could change before the recovery runs. Real directories are unaffected.

This narrows the traversal rather than closing it: `children` and the per-directory `rmdir` can still be redirected if the path is swapped between the check and the use. Doing better needs descriptor-relative traversal with `O_NOFOLLOW`, which Ruby cannot express without FFI and which would replace `recursive_rmdir` rather than guard it. Before this change the link was followed on every run, so the window goes from certain to raced.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug? Reproducing needs a cask naming a path a second account can replace, covered by the added specs instead.
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Claude Code with Opus 5, with local review and testing.

-----
