### PR TITLE
cask/cask_loader: recover uninstall artifacts from the signed payload

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -854,27 +854,43 @@ module Cask
       return [] unless api_fallback
 
       artifacts ||= begin
-        tap_loader = (FromNameLoader.try_new(token, warn: false) if tap.nil? && FromAPILoader.try_new(token).nil?)
+        # Only consult the signed payload for a cask that could come from it, and never when the
+        # API is opted out of, so a failure fetching it cannot stop a tap below from being loaded.
+        # `FromAPILoader.try_new` refuses the same way, but only after these lookups would run.
+        api_loader = if !Homebrew::EnvConfig.no_install_from_api? && (tap.nil? || tap.core_cask_tap?)
+          # Use the API loader only once the payload is known to hold this token, since loading
+          # it otherwise raises rather than returning nil. An installed cask can predate a
+          # rename, which the loader itself resolves, so check the current token for it.
+          current_token = Homebrew::API::Internal.cask_renames.fetch(token, token)
+          FromAPILoader.try_new(token) if Homebrew::API::Internal.cask_hash(current_token).present?
+        end
+        tap_loader = (FromNameLoader.try_new(token, warn: false) if tap.nil? && api_loader.nil?)
 
         if tap && !tap.core_cask_tap?
           load("#{tap}/#{token}", warn: false).artifacts_list(uninstall_only: true)
         elsif tap_loader
           tap_loader.load(config: nil).artifacts_list(uninstall_only: true)
+        elsif api_loader
+          # Prefer the JWS-verified internal payload, which carries the same
+          # uninstall directives as the unsigned per-cask endpoint below.
+          api_loader.load(config: nil).artifacts_list(uninstall_only: true)
         end
-      rescue CaskError, MethodDeprecatedError, JSON::ParserError, ErrorDuringExecution, SystemExit
+      rescue CaskError, MethodDeprecatedError, JSON::ParserError, KeyError, ErrorDuringExecution, SystemExit
         nil
       end
 
-      # API fetch failures must not abort best-effort installed metadata recovery. Skip the
-      # per-cask endpoint only when the token is definitively absent from the current API;
-      # a membership-check failure is treated as unknown so recovery still tries the endpoint.
+      # API fetch failures must not abort best-effort installed metadata recovery. Reach the
+      # unsigned per-cask endpoint only for a cask that could come from the core tap, and only
+      # once the signed payload has confirmed the token, so neither an absent token nor a failed
+      # membership check can downgrade recovery to it. The endpoint stays available when the API
+      # is opted out of, which `brew update`'s metadata repair relies on.
       artifacts ||= begin
-        definitely_absent = begin
-          !Homebrew::API.cask_token?(token)
+        signed_payload_has_token = begin
+          (tap.nil? || tap.core_cask_tap?) && Homebrew::API.cask_token?(token)
         rescue ErrorDuringExecution, SystemExit
           false
         end
-        Homebrew::API::Cask.cask_json(token)["artifacts"] unless definitely_absent
+        Homebrew::API::Cask.cask_json(token)["artifacts"] if signed_payload_has_token
       rescue ErrorDuringExecution, SystemExit
         nil
       end

--- a/Library/Homebrew/test/cask/cask_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader_spec.rb
@@ -567,7 +567,10 @@ RSpec.describe Cask::CaskLoader, :cask do
   end
 
   describe "::resolve_installed_artifacts" do
-    before { allow(Homebrew::API).to receive(:cask_token?).and_return(true) }
+    before do
+      allow(Homebrew::API).to receive(:cask_token?).and_return(true)
+      allow(Homebrew::API::Internal).to receive(:cask_renames).and_return({})
+    end
 
     it "does not request API metadata for a removed cask" do
       token = "removed-cask"
@@ -577,15 +580,118 @@ RSpec.describe Cask::CaskLoader, :cask do
       expect(described_class.resolve_installed_artifacts(token, nil)).to eq([])
     end
 
-    it "falls back to API artifacts when the membership check fails" do
+    context "when the signed API payload carries the token" do
+      let(:token) { "signed-cask" }
+      let(:verified_artifacts) { [{ "uninstall" => [{ "quit" => "com.example.app" }] }] }
+
+      before do
+        cask = instance_double(Cask::Cask)
+        allow(cask).to receive(:artifacts_list).with(uninstall_only: true).and_return(verified_artifacts)
+        loader = instance_double(Cask::CaskLoader::FromAPILoader)
+        allow(loader).to receive(:load).with(config: nil).and_return(cask)
+        allow(Cask::CaskLoader::FromAPILoader).to receive(:try_new).with(token).and_return(loader)
+        allow(Homebrew::API::Internal).to receive(:cask_hash).with(token).and_return({ "token" => token })
+      end
+
+      it "prefers it over the unsigned per-cask endpoint for an untapped cask" do
+        expect(Homebrew::API::Cask).not_to receive(:cask_json)
+
+        expect(described_class.resolve_installed_artifacts(token, nil)).to eq(verified_artifacts)
+      end
+
+      it "prefers it over the unsigned per-cask endpoint for a core tap cask" do
+        expect(Homebrew::API::Cask).not_to receive(:cask_json)
+
+        expect(described_class.resolve_installed_artifacts(token, nil, tap: CoreCaskTap.instance))
+          .to eq(verified_artifacts)
+      end
+    end
+
+    it "recovers a cask installed under a token the signed payload has since renamed" do
+      old_token = "renamed-cask"
+      current_token = "current-cask"
+      verified_artifacts = [{ "uninstall" => [{ "quit" => "com.example.app" }] }]
+      cask = instance_double(Cask::Cask)
+      allow(cask).to receive(:artifacts_list).with(uninstall_only: true).and_return(verified_artifacts)
+      loader = instance_double(Cask::CaskLoader::FromAPILoader)
+      allow(loader).to receive(:load).with(config: nil).and_return(cask)
+      allow(Cask::CaskLoader::FromAPILoader).to receive(:try_new).with(old_token).and_return(loader)
+      allow(Homebrew::API).to receive(:cask_token?).with(old_token).and_return(false)
+      allow(Homebrew::API::Internal).to receive(:cask_renames).and_return(old_token => current_token)
+      allow(Homebrew::API::Internal).to receive(:cask_hash).with(old_token).and_return(nil)
+      allow(Homebrew::API::Internal).to receive(:cask_hash)
+        .with(current_token).and_return({ "token" => current_token })
+      expect(Homebrew::API::Cask).not_to receive(:cask_json)
+
+      expect(described_class.resolve_installed_artifacts(old_token, nil)).to eq(verified_artifacts)
+    end
+
+    it "recovers from a recorded tap when the signed API is unavailable" do
+      token = "thirdparty-cask"
+      tap = Tap.fetch("thirdparty", "present")
+      tap_artifacts = [{ "app" => ["Thirdparty.app"] }]
+      cask = instance_double(Cask::Cask)
+      allow(cask).to receive(:artifacts_list).with(uninstall_only: true).and_return(tap_artifacts)
+      allow(described_class).to receive(:load).with("#{tap}/#{token}", warn: false).and_return(cask)
+      unavailable = ErrorDuringExecution.new(["curl"], status: 22)
+      allow(Homebrew::API).to receive(:cask_token?).and_raise(unavailable)
+      allow(Homebrew::API::Internal).to receive(:cask_renames).and_raise(unavailable)
+      allow(Homebrew::API::Internal).to receive(:cask_hash).and_raise(unavailable)
+      expect(Homebrew::API::Cask).not_to receive(:cask_json)
+
+      expect(described_class.resolve_installed_artifacts(token, nil, tap:)).to eq(tap_artifacts)
+    end
+
+    it "recovers from the local core tap when the API is opted out of", :no_api do
+      token = "opted-out-cask"
+      tap_artifacts = [{ "app" => ["OptedOut.app"] }]
+      cask = instance_double(Cask::Cask)
+      allow(cask).to receive(:artifacts_list).with(uninstall_only: true).and_return(tap_artifacts)
+      loader = instance_double(Cask::CaskLoader::FromNameLoader)
+      allow(loader).to receive(:load).with(config: nil).and_return(cask)
+      allow(Cask::CaskLoader::FromNameLoader).to receive(:try_new).with(token, warn: false).and_return(loader)
+      unavailable = ErrorDuringExecution.new(["curl"], status: 22)
+      allow(Homebrew::API).to receive(:cask_token?).and_raise(unavailable)
+      allow(Homebrew::API::Internal).to receive(:cask_renames).and_raise(unavailable)
+      allow(Homebrew::API::Internal).to receive(:cask_hash).and_raise(unavailable)
+      expect(Homebrew::API::Cask).not_to receive(:cask_json)
+
+      expect(described_class.resolve_installed_artifacts(token, nil)).to eq(tap_artifacts)
+    end
+
+    it "does not request unsigned API metadata for a cask recorded in a non-core tap" do
+      token = "thirdparty-absent"
+      tap = Tap.fetch("thirdparty", "absent")
+      allow(described_class).to receive(:load)
+        .with("#{tap}/#{token}", warn: false)
+        .and_raise(Cask::TapCaskUnavailableError.new(tap, token))
+      expect(Homebrew::API::Cask).not_to receive(:cask_json)
+
+      expect(described_class.resolve_installed_artifacts(token, nil, tap:)).to eq([])
+    end
+
+    # `cask_hash` and `cask_token?` read the same signed index, so the reachable way to fall
+    # through to the endpoint for a core tap cask is a signed loader that fails, not a missing hash.
+    it "requests unsigned API metadata when the signed loader fails for a core tap cask" do
+      token = "core-tap-unsigned"
+      api_artifacts = [{ "app" => ["Unsigned.app"] }]
+      loader = instance_double(Cask::CaskLoader::FromAPILoader)
+      allow(loader).to receive(:load).with(config: nil).and_raise(Cask::CaskError.new("unreadable"))
+      allow(Cask::CaskLoader::FromAPILoader).to receive(:try_new).with(token).and_return(loader)
+      allow(Homebrew::API::Internal).to receive(:cask_hash).with(token).and_return({ "token" => token })
+      allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_return({ "artifacts" => api_artifacts })
+
+      expect(described_class.resolve_installed_artifacts(token, nil, tap: CoreCaskTap.instance)).to eq(api_artifacts)
+    end
+
+    it "does not request unsigned API metadata when the membership check fails" do
       token = "unavailable-membership"
-      api_artifacts = [{ "app" => ["API.app"] }]
       allow(Homebrew::API).to receive(:cask_token?).with(token).and_raise(
         ErrorDuringExecution.new(["curl"], status: 22),
       )
-      allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_return({ "artifacts" => api_artifacts })
+      expect(Homebrew::API::Cask).not_to receive(:cask_json)
 
-      expect(described_class.resolve_installed_artifacts(token, nil)).to eq(api_artifacts)
+      expect(described_class.resolve_installed_artifacts(token, nil)).to eq([])
     end
 
     it "returns empty artifacts when the API download fails" do


### PR DESCRIPTION
`resolve_installed_artifacts` recovers an installed cask's `uninstall` and `zap` directives when the receipt has lost its own copy, and it falls back to the `cask/<token>.json` endpoint to do so. `Homebrew::API.fetch_json_api_file` verifies a JWS signature only for endpoints ending in `.jws.json`, so that response is not verified, while the directives it carries become real `Uninstall` artifacts whose `script:` and `delete:` entries run under `sudo`. One branch earlier the method already builds a `FromAPILoader`, whose `load_from_internal_api` reads the same directives out of the JWS-verified internal payload, and then discards it after using it only as a `nil` test.

Using that loader when the signed payload holds the token means the directives Homebrew acts on are the signed ones, so an unverified response can no longer decide what gets executed or deleted. Gating on `Internal.cask_hash` is needed because `cask_struct` raises rather than returning `nil` for an absent token, and `KeyError` joins the rescue list for the same reason. The gate resolves `cask_renames` first, so a cask installed under a token the payload has since renamed still recovers, matching the tokens `FromAPILoader.try_new` itself accepts. It also matches that loader's `HOMEBREW_NO_INSTALL_FROM_API` opt-out, which the payload lookups would otherwise run ahead of, leaving source-mode users unable to recover from a local tap. The unsigned endpoint deliberately stays reachable when the API is opted out of, since `brew update`'s metadata repair depends on it.

This also covers a core-tap cask, not only one with no recorded tap. Both fell through to the unsigned endpoint before, so fixing just the no-tap case would have left the same path reachable.

The per-cask endpoint is now reached only once the signed payload has confirmed the token. Its guard used to rescue a failed membership check into "not definitely absent", so a signed payload that was unavailable or failed verification still let the unsigned response through, which is the same downgrade by a second route. Reading that check positively closes it, at the cost of recovering no artifacts when the signed payload cannot be consulted at all. For a method that already returns `[]` on error, leaving files behind on uninstall is the better failure than running `sudo` directives from an unverified source. This reverses a deliberate trade-off, so the example that spec'd the old behaviour is replaced rather than removed.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug? Reaching this needs a crafted API response, covered by the added spec instead.
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Claude Code with Opus 5, with local review and testing.

-----



