### PR TITLE
formula_creator: add deny network for ruby

### DIFF
--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -223,7 +223,7 @@ module Homebrew
           # depends_on "cmake" => :build
         <% end %>
 
-        <% if [:crystal, :node, :python, :ruby].exclude? @mode %>
+        <% if [:crystal, :node, :python].exclude? @mode %>
           deny_network_access!
 
         <% end %>
@@ -236,6 +236,16 @@ module Homebrew
         <% elsif @mode == :go %>
           def fetch
             system "go", "mod", "download"
+          end
+
+        <% elsif @mode == :ruby %>
+          def fetch
+            ENV["BUNDLE_PATH"] = ".bundle"
+
+            system "bundle", "config", "set", "force_ruby_platform", "true"
+            system "bundle", "config", "set", "version", "system" # Avoid installing Bundler into the keg
+            system "bundle", "config", "set", "without", "development test"
+            system "bundle", "cache", "--no-install"
           end
 
         <% elsif @mode == :rust %>
@@ -296,12 +306,9 @@ module Homebrew
         <% elsif @mode == :python %>
             virtualenv_install_with_resources
         <% elsif @mode == :ruby %>
-            ENV["BUNDLE_FORCE_RUBY_PLATFORM"] = "1"
-            ENV["BUNDLE_VERSION"] = "system" # Avoid installing Bundler into the keg
-            ENV["BUNDLE_WITHOUT"] = "development test"
             ENV["GEM_HOME"] = libexec
 
-            system "bundle", "install"
+            system "bundle", "install", "--local"
             system "gem", "build", "\#{name}.gemspec"
             system "gem", "install", "--ignore-dependencies", "\#{name}-\#{version}.gem"
 

--- a/Library/Homebrew/test/formula_creator_spec.rb
+++ b/Library/Homebrew/test/formula_creator_spec.rb
@@ -118,6 +118,10 @@ RSpec.describe Homebrew::FormulaCreator do
                     includes: ["deny_network_access!", "PERL5LIB", 'resource "'],
                     excludes: ["unrecognized options"]
 
+    it_behaves_like "expected", :ruby,
+                    includes: ["deny_network_access!", /"cache".*"--no-install"/, /"install".*"--local"/],
+                    excludes: ["unrecognized options", 'resource "']
+
     it_behaves_like "expected", :rust,
                     includes: ["deny_network_access!", "std_cargo_args", /"cargo".*"fetch"/],
                     excludes: ["unrecognized options", 'resource "']


### PR DESCRIPTION
Examples for handling network access of Ruby formulae at:
- https://github.com/Homebrew/homebrew-core/pull/302225

Based on https://guides.rubygems.org/caching-and-vendoring/

Some extra notes:
* Using `bundle config` to preserve config across both fetch & build phase. Could consider making this part of superenv / build environment, but would need to check on usage (and will need a way to avoid for stuff like `sorbet-static` which currently uses prebuilt binaries)
* `BUNDLE_PATH=.bundle` is Bundler 5 default so can be removed in the future. Currently needed as RubyGems still creates some bin files for main package even when `--no-install` is used.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
