### PR TITLE
formula: handle `--offline` in std_cargo_args

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1628,7 +1628,7 @@ class Formula
   # end
   #
   # def install
-  #   system "cargo", "install", "--offline", *std_cargo_args
+  #   system "cargo", "install", *std_cargo_args
   # end
   # ```
   #
@@ -2171,6 +2171,7 @@ class Formula
   def std_cargo_args(root: prefix, path: ".", features: nil)
     args = ["--jobs", ENV.make_jobs.to_s, "--locked", "--root=#{root}", "--path=#{path}"]
     args += ["--features=#{Array(features).join(",")}"] if features
+    args << "--offline" if fetch_defined?
     args
   end
 

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -308,7 +308,7 @@ module Homebrew
             bin.install libexec/"bin/\#{name}"
             bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV["GEM_HOME"])
         <% elsif @mode == :rust %>
-            system "cargo", "install", "--offline", *std_cargo_args
+            system "cargo", "install", *std_cargo_args
         <% elsif @mode == :zig %>
             system "zig", "build", *std_zig_args
         <% else %>

--- a/Library/Homebrew/test/formula_creator_spec.rb
+++ b/Library/Homebrew/test/formula_creator_spec.rb
@@ -119,7 +119,9 @@ RSpec.describe Homebrew::FormulaCreator do
                     excludes: ["unrecognized options"]
 
     it_behaves_like "expected", :rust,
-                    includes: ["deny_network_access!", "std_cargo_args", /"cargo".*"fetch"/],
+                    includes: ["deny_network_access!",
+                               '"cargo", "install", *std_cargo_args',
+                               '"cargo", "fetch"'],
                     excludes: ["unrecognized options", 'resource "']
 
     it_behaves_like "expected", :zig,

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -3452,6 +3452,27 @@ RSpec.describe Formula do
     end
   end
 
+  describe "#std_cargo_args" do
+    before { allow(ENV).to receive(:make_jobs).and_return(10) }
+
+    it "excludes `--offline` by default" do
+      f = formula do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      expect(f.std_cargo_args).not_to include("--offline")
+    end
+
+    it "includes `--offline` when formula has fetch phase" do
+      f = formula do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+        def fetch; end
+      end
+      expect(f.std_cargo_args).to include("--offline")
+    end
+  end
+
   describe "#std_go_args" do
     let(:f) do
       formula do

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1233,7 +1233,7 @@ class Foo < Formula
   end
 
   def install
-    system "cargo", "install", "--offline", *std_cargo_args
+    system "cargo", "install", *std_cargo_args
   end
 end
 ```


### PR DESCRIPTION
Something we were discussing on Slack.

Since `fetch` disables network access, Cargo needs `--offline` to work so may as well let brew handle it.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

n/a

-----
