### PR TITLE
unpack_strategy/zip: move volume labels by basename

### DIFF
--- a/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rb
+++ b/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rb
@@ -54,7 +54,17 @@ module UnpackStrategy
                             verbose:)
 
             volumes.each do |volume|
-              FileUtils.mv tmp_unpack_dir/volume, unpack_dir/volume, verbose:
+              # Move by basename so a same-named symlink cannot redirect the destination.
+              # `Pathname#/` cleans `.` and `..` away, so skip a name that is not a leaf.
+              volume_path = tmp_unpack_dir/File.basename(volume)
+              next if volume_path.parent != tmp_unpack_dir
+
+              # Across filesystems `FileUtils.mv` copies instead of renaming, and that copy
+              # opens the destination, so clear a symlink `unzip` left on the same name.
+              destination = unpack_dir/volume_path.basename
+              destination.unlink if destination.symlink?
+
+              FileUtils.mv volume_path, unpack_dir, verbose:
             end
           end
         end

--- a/Library/Homebrew/test/unpack_strategy/zip_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/zip_spec.rb
@@ -1,6 +1,8 @@
 # typed: true
 # frozen_string_literal: true
 
+require "zlib"
+
 require_relative "shared_examples"
 
 RSpec.describe UnpackStrategy::Zip do
@@ -20,5 +22,72 @@ RSpec.describe UnpackStrategy::Zip do
     end
 
     include_examples "UnpackStrategy::detect"
+  end
+
+  context "when the archive contains a volume label", :needs_macos, :needs_unzip do
+    let(:root) { mktmpdir }
+    let(:unpack_dir) { (root/"unpack").tap(&:mkpath) }
+    let(:zip_path) { root/"volume-label.zip" }
+
+    # A member reads as a volume label when its host is FAT (0) and its MS-DOS attributes
+    # set the label bit (0x08), and as a symlink when its host is Unix (3) and its mode
+    # says so. `unzip` skips the former and names it on stderr, which is what gets scraped.
+    def write_zip(path, members)
+      local = +""
+      central = +""
+      members.each do |name, data, host, external_attrs|
+        crc = Zlib.crc32(data)
+        offset = local.bytesize
+        local << ["PK\x03\x04", 10, 0, 0, 0, 0, crc, data.bytesize, data.bytesize,
+                  name.bytesize, 0].pack("a4v5V3v2") << name << data
+        central << ["PK\x01\x02", (host << 8) | 20, 10, 0, 0, 0, 0, crc, data.bytesize, data.bytesize,
+                    name.bytesize, 0, 0, 0, 0, external_attrs, offset].pack("a4v6V3v5V2") << name
+      end
+      path.binwrite(local + central +
+                    ["PK\x05\x06", 0, 0, members.size, members.size,
+                     central.bytesize, local.bytesize, 0].pack("a4v4V2v"))
+    end
+
+    it "does not move the label member through a planted symlink of the same name" do
+      outside = (root/"outside").tap(&:mkpath)
+      name = "A" * 24
+      write_zip(zip_path, [[name, "label\n", 0, 0x08], [name, outside.to_s, 3, 0120777 << 16]])
+
+      described_class.new(zip_path).extract(to: unpack_dir)
+
+      expect(outside.children).to be_empty
+    end
+
+    # `unpack_dir` can be on another filesystem, as `brew unpack --destdir` allows, and
+    # `FileUtils.mv` then copies rather than renames, opening the destination path.
+    it "does not write through a planted symlink when moving across filesystems" do
+      victim = root/"victim"
+      victim.write "original\n"
+      name = "A" * 24
+      write_zip(zip_path, [[name, "label\n", 0, 0x08], [name, victim.to_s, 3, 0120777 << 16]])
+      allow(File).to receive(:rename).and_raise(Errno::EXDEV)
+
+      described_class.new(zip_path).extract(to: unpack_dir)
+
+      expect(victim.read).to eq("original\n")
+    end
+
+    it "confines a label member whose name traverses upwards" do
+      name = "../../../victimfileAAAAAAAAAAAAAA"
+      write_zip(zip_path, [[name, "label\n", 0, 0x08]])
+
+      described_class.new(zip_path).extract(to: unpack_dir)
+
+      expect(unpack_dir.children.map { |child| child.basename.to_s }).to contain_exactly(File.basename(name))
+    end
+
+    it "still extracts a label member that no symlink shadows" do
+      name = "SomeDiskImageVolumeLabel.dmg"
+      write_zip(zip_path, [["readme.txt", "hi\n", 3, 0100644 << 16], [name, "disk image\n", 0, 0x08]])
+
+      described_class.new(zip_path).extract(to: unpack_dir)
+
+      expect(unpack_dir.children.map { |child| child.basename.to_s }).to contain_exactly("readme.txt", name)
+    end
   end
 end


### PR DESCRIPTION
The macOS ZIP strategy re-extracts volume label members with `ditto`, because `unzip` skips them, and it learns their names by scraping `unzip`'s stderr. That scraped name was then used on both sides of `FileUtils.mv`. Passing a full destination path makes `FileUtils` call `File.directory?` on it, which follows a symlink, so a member `unzip` had already extracted under the same name could redirect the move. An archive carrying a volume label and a symlink with identical names therefore moves the label's content to wherever the symlink points, outside the unpack directory.

Handing `FileUtils.mv` the directory instead lets it derive the leaf from `File.basename`, so the only path followed is `unpack_dir` itself, and the final component is created by `File.rename`, which replaces a symlink rather than writing through it. The `basename` also confines a label name containing `../`, which `unzip` does report verbatim, and the leaf check drops the names `basename` alone cannot confine, since `Pathname#/` resolves `.`, `..` and a bare `/` straight back out of the staging directory. Across filesystems `FileUtils.mv` copies rather than renames, and that copy opens the destination path, so a symlink `unzip` left on the same name is cleared before the move. For an ordinary archive the resulting destination is unchanged.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug? Reproducing needs a hand-built archive rather than `brew` commands, so the added spec builds one instead.
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Claude Code with Opus 5, with local review and testing.

-----


