### PR TITLE
Keep invoking user for privileged install steps

### DIFF
--- a/Library/Homebrew/install_steps.rb
+++ b/Library/Homebrew/install_steps.rb
@@ -1219,10 +1219,11 @@ module Homebrew
                        .transform_values { |value| expand_template_tokens(value.to_s) }
         input = step.key?("stdin_path") ? resolve_path(step_path(step, "stdin_path")).read : []
         working_directory = resolve_path(step_path(step, "chdir")) if step.key?("chdir")
-        result = @command.run(command, args:, sudo: step["sudo"] == true, env: environment, input:,
+        sudo = step["sudo"] == true
+        result = @command.run(command, args:, sudo:, env: environment, input:,
                                      must_succeed: step["allow_failure"] != true,
                                      print_stdout: step["print_stdout"] == true,
-                                     print_stderr: step["suppress_stderr"] != true, reset_uid: true,
+                                     print_stderr: step["suppress_stderr"] != true, reset_uid: !sudo,
                                      chdir: working_directory)
 
         return unless step.key?("stdout_path")
@@ -1583,12 +1584,12 @@ module Homebrew
 
       sig { params(command: SystemCommandArg, args: SystemCommandArg, sudo: T::Boolean).void }
       def run_command(command, *args, sudo: false)
-        @command.run!(command, args: args, sudo:, print_stdout: true, print_stderr: true, reset_uid: true)
+        @command.run!(command, args: args, sudo:, print_stdout: true, print_stderr: true, reset_uid: !sudo)
       end
 
       sig { params(command: SystemCommandArg, args: SystemCommandArg, sudo: T::Boolean).returns(String) }
       def run_command_output(command, *args, sudo: false)
-        @command.run!(command, args: args, sudo:, print_stderr: true, reset_uid: true).stdout
+        @command.run!(command, args: args, sudo:, print_stderr: true, reset_uid: !sudo).stdout
       end
     end
   end

--- a/Library/Homebrew/test/install_steps_spec.rb
+++ b/Library/Homebrew/test/install_steps_spec.rb
@@ -672,6 +672,19 @@ RSpec.describe Homebrew::InstallSteps do
     Homebrew::InstallSteps::Runner.new(context:, command:).run(steps)
   end
 
+  specify "keeps the invoking user for privileged commands" do
+    steps = Homebrew::InstallSteps::DSL.build(default_base: :var) do
+      run "helper", sudo: true
+    end
+
+    command = class_double(SystemCommand)
+    expect(command).to receive(:run)
+      .with("helper", args: [], sudo: true, env: {}, input: [], must_succeed: true,
+                      print_stdout: false, print_stderr: true, reset_uid: false, chdir: nil)
+
+    Homebrew::InstallSteps::Runner.new(context:, command:).run(steps)
+  end
+
   specify "serialises command environments as JSON objects" do
     steps = Homebrew::InstallSteps::DSL.build do
       run "helper", env: { "EXAMPLE" => "{{formula_name}}" },
@@ -784,6 +797,19 @@ RSpec.describe Homebrew::InstallSteps do
     expect(command).to receive(:run!)
       .with("/usr/bin/killall", args: ["Example"], sudo: false,
                                 print_stdout: true, print_stderr: true, reset_uid: true)
+
+    Homebrew::InstallSteps::Runner.new(context:, command:).run(steps)
+  end
+
+  specify "keeps the invoking user when terminating a process with sudo" do
+    steps = Homebrew::InstallSteps::DSL.build do
+      terminate_process "Example", sudo: true, must_succeed: true
+    end
+
+    command = class_double(SystemCommand)
+    expect(command).to receive(:run!)
+      .with("/usr/bin/killall", args: ["Example"], sudo: true,
+                                print_stdout: true, print_stderr: true, reset_uid: false)
 
     Homebrew::InstallSteps::Runner.new(context:, command:).run(steps)
   end
@@ -1439,6 +1465,23 @@ RSpec.describe Homebrew::InstallSteps do
       .with("/usr/bin/security", "delete-certificate", "-Z", "DEF456", sudo: true).ordered
 
     runner.run(steps)
+  end
+
+  specify "keeps the invoking user for privileged keychain commands" do
+    steps = Homebrew::InstallSteps::DSL.build do
+      delete_keychain_certificates "Example"
+    end
+
+    command = class_double(SystemCommand)
+    expect(command).to receive(:run!)
+      .with("/usr/bin/security", args: ["find-certificate", "-a", "-c", "Example", "-Z"],
+            sudo: true, print_stderr: true, reset_uid: false)
+      .and_return(instance_double(SystemCommand::Result, stdout: "SHA-256 hash: ABC123\n"))
+    expect(command).to receive(:run!)
+      .with("/usr/bin/security", args: ["delete-certificate", "-Z", "ABC123"],
+            sudo: true, print_stdout: true, print_stderr: true, reset_uid: false)
+
+    Homebrew::InstallSteps::Runner.new(context:, command:).run(steps)
   end
 
   specify "only deletes the keychain certificate matching a local certificate" do


### PR DESCRIPTION
Install steps that ask for `sudo` also pass `reset_uid: true`, which makes `SystemCommand` call `Process::UID.change_privilege(Process.euid)` in the forked child immediately before it execs `sudo`:

```ruby
pid ||= fork do
  if run_as_real_uid? && Process.euid != Process.uid
    Process::UID.change_privilege(Process.uid)
  elsif reset_uid? && Process.euid != Process.uid
    Process::UID.change_privilege(Process.euid)
  end

  exec(exec_env, [executable, executable], *args, **options)
```

Where the real and effective UIDs are the same this is a no-op, so on a normal installation the bug never appears. Where they differ, it sets real, effective and saved UID to the *effective* one, which discards the invoking user and runs `sudo` as an unprivileged account. That account has nothing to authenticate against, so the step can never succeed and the cask is left half-installed.

The two behaviors are visible side by side in one run. These are two `sudo` children of the same `brew` process, uninstalling `proxyman`:

```
16924 16807 petros    /usr/bin/sudo -u root -E -- /bin/launchctl print user/502/com.proxyman.NSProxy.HelperTool
16973 16807 workbrew  /usr/bin/sudo -E -- /usr/bin/security find-certificate -a -c Proxyman -Z
```

The first keeps the invoking user and its password is accepted. The second is switched to the unprivileged user and rejects the same password three times, ending in:

```
cask_artifact.rb:96: The parent process failed to run privileged cask install step 0. (RuntimeError)
Error: Failure while executing; `/usr/bin/sudo -E -- /usr/bin/security find-certificate -a -c Proxyman -Z` exited with 1.
```

The only difference between them is that `create_symlink` and the ownership step call `@command.run!(..., sudo: true)` directly, while the keychain and generic `run` steps route through helpers that add `reset_uid: true`.

This is not a regression from #23641. Before that change the privileged step ran inside the sandbox child, where the UIDs had already been collapsed, so `reset_uid` saw `Process.euid == Process.uid` and did nothing. The step failed earlier and for a different reason, which is what masked this one. Running privileged steps in the parent leaves it holding the differing UIDs that make `reset_uid` take effect here.

### Why

`reset_uid` exists so that arbitrary commands run as the effective user rather than with whatever privileges `brew` happens to hold, which is great. But a step that explicitly asks for `sudo` is asking for the opposite, so applying both to the same command doesn't work.

`cask/artifact/installer.rb` already treats them as incompatible, passing `reset_uid: !args[:sudo]` to its `run!` call. This change applies the same rule to the three call sites in `install_steps.rb` that still combine them, so unprivileged steps are unaffected and privileged ones behave like the neighboring call sites that already work.

No other call site combines the two. The remaining `reset_uid: true` uses are in `unpack_strategy/dmg.rb`, `download_strategy/git_download_strategy.rb` and `services/system/systemctl.rb`, none of which pass `sudo`.

It also removes a duplicate password prompt. A cask could previously prompt once as the invoking user and again as the unprivileged one. Both now run as the same user, so the credentials sudo cached for the first cover the second.

### How to reproduce

Any installation where `brew`'s real and effective UIDs differ. Using `proxyman`, whose `uninstall_postflight_steps` is `delete_keychain_certificates "Proxyman"`:

1. `brew install --cask proxyman`
2. `brew uninstall --cask proxyman`
3. Enter your password at the first prompt. It is accepted.
4. Enter the same password at the second prompt. It is rejected three times and the uninstall fails at `privileged cask install step 0`.

A minimal cask reproduces the generic `run` step without any third-party software:

```ruby
preflight_steps do
  run "/usr/bin/id", args: [], sudo: true, print_stdout: true
end
```

Before the change, that step rejects the password three times. After it, the password is accepted and `id` prints `uid=0(root)`.

### Testing

I verified two of the three changed call sites by hand on an affected machine, before and after. The third, `run_command`, has spec coverage only. The `proxyman` run reached `run_command_output` for `find-certificate`, but that machine had no matching certificate, so the `delete-certificate` call never fired.

Three new specs pin `reset_uid: false` for the privileged shape of each site, and the existing specs still pin `reset_uid: true` for the unprivileged one, so both directions are covered.

After the change, the `proxyman` uninstall completes in full with one prompt instead of two, and no unprivileged `sudo` process appears:

```
==> Removing App '/Applications/Proxyman.app'
==> Unlinking Binary '/opt/homebrew/bin/proxyman-cli'
==> Purging files for version 6.16.0,61600 of Cask proxyman
```

The minimal `run` step cask installs and prints `uid=0(root)`.

This does not reach formulas. `Formula#run_post_install_steps` only runs inside `Sandbox.run_or_fork`, and both of its branches go through `Utils.safe_fork`, whose child collapses the UIDs at `utils/fork.rb:153` before any step runs, so `reset_uid` was already a no-op there.

Nothing is broken today, because no formula in homebrew-core passes `sudo` to a step, so I have left the formula side out of this change. It needs more thought than a flag, since that same process also runs the legacy arbitrary `post_install` block that the privilege drop exists to contain.

The change prevents the failure but does not repair a cask already stranded by it. An existing half-removed cask still needs `--force` to recover.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

I used Claude Code (Claude Opus 5) to help investigate this and draft the change, the tests and this description. I reviewed all of it myself, and verified the behavior by hand on an affected machine before and after, as described above. No commit is attributed to AI/LLM. I will answer maintainer questions and review comments myself without AI/LLM.

-----
