### PR TITLE
Install app_image by moving the AppImage, mirroring the app stanza

### DIFF
--- a/Library/Homebrew/cask/artifact/appimage.rb
+++ b/Library/Homebrew/cask/artifact/appimage.rb
@@ -1,12 +1,12 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "cask/artifact/symlinked"
+require "cask/artifact/moved"
 
 module Cask
   module Artifact
     # Artifact corresponding to the `app_image` stanza.
-    class AppImage < Symlinked
+    class AppImage < Moved
       sig { override.params(target: T.any(String, Pathname), base_dir: T.nilable(Pathname)).returns(Pathname) }
       def resolve_target(target, base_dir: nil)
         Pathname.new("#{config.appimagedir}/#{target}")
@@ -14,21 +14,67 @@ module Cask
 
       sig {
         override.params(
-          force:    T::Boolean,
-          adopt:    T::Boolean,
-          command:  T.class_of(SystemCommand),
-          _options: T.anything,
+          adopt:        T::Boolean,
+          auto_updates: T.nilable(T::Boolean),
+          force:        T::Boolean,
+          verbose:      T::Boolean,
+          predecessor:  T.nilable(Cask),
+          successor:    T.nilable(Cask),
+          reinstall:    T::Boolean,
+          command:      T.class_of(SystemCommand),
         ).void
       }
-      def link(force: false, adopt: false, command: SystemCommand, **_options)
+      def install_phase(adopt: false, auto_updates: false, force: false, verbose: false, predecessor: nil,
+                        successor: nil, reinstall: false, command: SystemCommand)
         super
-        return if source.executable?
 
-        if source.writable?
-          FileUtils.chmod "+x", source
+        return if target.executable?
+
+        if target.writable?
+          FileUtils.chmod "+x", target
         else
-          command.run!("chmod", args: ["+x", source], sudo: true)
+          command.run!("chmod", args: ["+x", target], sudo: true)
         end
+      end
+
+      sig {
+        override.params(
+          skip:      T::Boolean,
+          force:     T::Boolean,
+          adopt:     T::Boolean,
+          verbose:   T::Boolean,
+          successor: T.nilable(Cask),
+          upgrade:   T::Boolean,
+          reinstall: T::Boolean,
+          command:   T.class_of(SystemCommand),
+        ).void
+      }
+      def uninstall_phase(skip: false, force: false, adopt: false, verbose: false, successor: nil, upgrade: false,
+                          reinstall: false, command: SystemCommand)
+        # Migration shim for the `Symlinked` -> `Moved` transition.
+        # Old installs have the real AppImage in the versioned Caskroom `source`
+        # and a symlink at `target` pointing back to it,
+        # which `Moved#move_back` cannot reverse
+        # (a non-forced uninstall errors; a skipping one leaves the target behind).
+        # The old layout is identified by `target` being that back-symlink
+        # (in the new layout, `target` is the real file),
+        # regardless of whether `source` still exists:
+        # the very breakage this stanza fixes
+        # is a self-updater having already deleted the versioned `source`,
+        # leaving `target` dangling. Reverse the old layout directly instead.
+        # This can be removed once pre-transition installs have aged out.
+        if target.symlink? && target.dirname.join(target.readlink) == source
+          Utils.gain_permissions_remove(target, command:)
+          # Preserve `source` during an upgrade
+          # so that it is captured in the staged-directory backup
+          # that `revert_upgrade` restores (and reinstalls from)
+          # if the new install fails;
+          # a successful upgrade purges that backup afterwards.
+          Utils.gain_permissions_remove(source, command:) unless upgrade
+          return
+        end
+
+        super
       end
     end
   end

--- a/Library/Homebrew/test/cask/artifact/appimage_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/appimage_spec.rb
@@ -1,0 +1,175 @@
+# typed: true
+# frozen_string_literal: true
+
+RSpec.describe Cask::Artifact::AppImage, :cask do
+  let(:cask) { Cask::CaskLoader.load(cask_path("with-appimage")) }
+  let(:command) { NeverSudoSystemCommand }
+  let(:adopt) { false }
+  let(:force) { false }
+  let(:auto_updates) { false }
+  let(:artifact) { cask.artifacts.find { |a| a.is_a?(described_class) } }
+
+  let(:source_path) { cask.staged_path.join("naked.AppImage") }
+  let(:target_path) { Pathname(cask.config.appimagedir).join("naked.AppImage") }
+
+  let(:install_phase) { artifact.install_phase(command:, adopt:, force:, auto_updates:) }
+  let(:uninstall_phase) { artifact.uninstall_phase(command:, force:) }
+
+  let(:setup_cask) { InstallHelper.install_without_artifacts(cask) }
+
+  before do
+    setup_cask
+  end
+
+  describe "install_phase" do
+    it "moves the real AppImage to appimagedir and back-links from the Caskroom" do
+      install_phase
+
+      expect(target_path).to be_a_file
+      expect(target_path).not_to be_a_symlink
+      expect(source_path).to be_a_symlink
+      expect(source_path.readlink).to eq(target_path)
+    end
+
+    it "makes a non-executable AppImage executable at the target" do
+      FileUtils.chmod "-x", source_path
+      expect(source_path).not_to be_executable
+
+      install_phase
+
+      expect(target_path).to be_executable
+    end
+
+    describe "when a self-updater replaces the target in place" do
+      it "keeps the Caskroom back-link valid and pointing at the new contents" do
+        install_phase
+
+        replacement = "#!/bin/sh\necho \"AppImage v2\"\n"
+        File.write(target_path, replacement)
+
+        expect(source_path).to be_a_symlink
+        expect(source_path.readlink).to exist
+        expect(File.read(source_path)).to eq(replacement)
+      end
+    end
+
+    describe "given the adopt option" do
+      let(:adopt) { true }
+
+      before do
+        target_path.dirname.mkpath
+        FileUtils.cp source_path, target_path
+      end
+
+      it "adopts an identical existing AppImage without auto_updates" do
+        install_phase
+
+        expect(target_path).to be_a_file
+        expect(source_path).to be_a_symlink
+      end
+
+      describe "when the cask auto_updates" do
+        let(:auto_updates) { true }
+
+        before do
+          File.write(target_path, "#!/bin/sh\necho \"AppImage v2\"\n")
+        end
+
+        it "adopts the existing AppImage without comparing contents" do
+          install_phase
+
+          expect(target_path).to be_a_file
+          expect(source_path).to be_a_symlink
+        end
+      end
+    end
+  end
+
+  describe "uninstall_phase" do
+    it "removes the target AppImage" do
+      install_phase
+
+      expect(target_path).to exist
+
+      uninstall_phase
+
+      expect(target_path).not_to exist
+    end
+
+    describe "migrating from the old Symlinked layout" do
+      before do
+        # Recreate the pre-inversion on-disk state: a real file in the
+        # versioned Caskroom source and a symlink at the target pointing back.
+        target_path.dirname.mkpath
+        FileUtils.ln_sf source_path, target_path
+      end
+
+      it "removes both the target symlink and the Caskroom file without raising" do
+        expect(source_path).to be_a_file
+        expect(target_path).to be_a_symlink
+
+        expect { uninstall_phase }.not_to raise_error
+
+        expect(target_path).not_to exist
+        expect(source_path).not_to exist
+      end
+
+      describe "when a self-updater already deleted the versioned source" do
+        before do
+          # The exact breakage this stanza fixes: `source` is gone and the
+          # `target` symlink is left dangling.
+          source_path.delete
+        end
+
+        it "removes the dangling target without raising" do
+          expect(target_path).to be_a_symlink
+          expect(target_path).not_to exist
+          expect(source_path).not_to exist
+
+          expect { uninstall_phase }.not_to raise_error
+
+          expect(target_path).not_to be_a_symlink
+          expect(target_path).not_to exist
+        end
+      end
+
+      describe "during an upgrade" do
+        let(:uninstall_phase) { artifact.uninstall_phase(command:, force:, upgrade: true) }
+
+        it "removes the target symlink but preserves the source for the backup" do
+          expect(source_path).to be_a_file
+          expect(target_path).to be_a_symlink
+
+          expect { uninstall_phase }.not_to raise_error
+
+          expect(target_path).not_to exist
+          expect(source_path).to be_a_file
+        end
+      end
+    end
+  end
+
+  describe "summary" do
+    let(:contents) { artifact.summarize_installed }
+
+    it "returns the correct english_description" do
+      expect(artifact.class.english_description).to eq("App Images")
+    end
+
+    describe "AppImage is missing" do
+      let(:setup_cask) { nil }
+
+      it "returns a warning and the supposed path to the AppImage" do
+        expect(contents).to match(/.*Missing App Image.*: #{target_path}/)
+      end
+    end
+
+    describe "AppImage is correctly installed" do
+      it "returns the path to the AppImage" do
+        install_phase
+
+        expect(contents).to eq("#{target_path} (#{target_path.abv})")
+      end
+    end
+  end
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-appimage.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-appimage.rb
@@ -1,0 +1,13 @@
+# typed: false
+
+cask "with-appimage" do
+  version "1.2.3"
+  sha256 "73e5daee562b151389dc3e0751579c9f69f8be05b6b057f9c058c7a6e00a10f7"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/naked.AppImage"
+  name "With AppImage"
+  desc "Cask with an app_image stanza"
+  homepage "https://brew.sh/with-appimage"
+
+  app_image "naked.AppImage"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/naked.AppImage
+++ b/Library/Homebrew/test/support/fixtures/cask/naked.AppImage
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "AppImage v1"
+exit 0


### PR DESCRIPTION
Today `app_image` installs the real AppImage into a versioned Caskroom directory and puts the user-facing entry at `config.appimagedir` (default `~/Applications`) as a *symlink* back to it (via `Artifact::Symlinked`). For example: `~/Applications/OpenWhispr.AppImage` -> `/home/linuxbrew/.linuxbrew/Caskroom/openwhispr/1.8.3/OpenWhispr-1.8.3-linux-x86_64.AppImage`.

That symlink exposes the *versioned* Caskroom path as `$APPIMAGE` to the running app. For casks that self-update with electron-updater, [`doInstall()`](https://github.com/electron-userland/electron-builder/blob/93061602d9ee89d824834cef0b06c75353fa6a4a/packages/electron-updater/src/AppImageUpdater.ts#L83) branches on the `$APPIMAGE` filename: if the basename contains an `X.Y.Z` version, it writes a *new* versioned filename and `unlinkSync`s the old one; conversely, version-less basenames are updated in place. Because the exposed path (the Caskroom one) _is_ versioned, `doInstall()`'s rename branch is followed: a new `<App>-<newver>.AppImage` lands inside the *older* version's Caskroom dir (e.g. */home/linuxbrew/.linuxbrew/Caskroom/openwhispr/**1.8.3**/OpenWhispr-**1.9.2**-linux-x86_64.AppImage*), the old file is deleted, and the `appimagedir` symlink (at `~/Applications`) is left dangling until the user manually runs `brew reinstall`.

This patch inverts the relationship to match `Cask::Artifact::App` (i.e. the macOS flow): `AppImage` now subclasses `Moved` instead of `Symlinked`, so the real AppImage lives at the stable, unversioned `appimagedir` target, and the Caskroom holds the versioned back-symlink. Most `app_image` casks already declare a version-less `target:` (e.g. `Obsidian.AppImage`, `Heroic.AppImage`), so `$APPIMAGE` becomes version-less and electron-updater overwrites in place — the file stays put across self-updates and nothing user-facing breaks. (If some other AppImage updater renames anyway, only the disposable Caskroom-side pointer is affected, not the user's file.)

Note: This change introduces *no new home-directory destination*: `app_image` already writes to `config.appimagedir`, whose documented default `~/Applications` was explicitly proposed and accepted when the stanza landed (#20334). This only changes that entry from a symlink to the real file, plus a Caskroom backlink — the same model `App` and other `Moved` artifacts (`Font`, `Dictionary`, `ScreenSaver`, ...) already use. Linux already extends `Moved`, so no new cross-platform machinery is needed.

The change applies to all `app_image` casks, not only self-updaters: gating on `auto_updates` would mean two opposing placement/uninstall models for the same artifact class.

On backward compatibility: `app_image` has shipped since 5.1.12, so users already have AppImages installed with the current symlink setup (`appimagedir` → `$APPIMAGE`). To account for this, a small, clearly-marked migration shim in `uninstall_phase` reverses the old `Symlinked` on-disk layout directly (a plain `Moved#move_back` would otherwise error on a non-forced uninstall of a pre-inversion install).

#### Validation

- Added `test/cask/artifact/appimage_spec.rb` covering placement + backlink, the executable bit, in-place self-update, adopt (with and without `auto_updates`), uninstall, migration from the old `Symlinked` layout, and installed-summary output. It runs with the rest of the cask suite on macOS CI.
- Manually verified end-to-end on Linux with a real cask: install → in-place self-update (simulating electron-updater rewriting the target under the same name) → uninstall. Confirmed the target stays a real executable file, the Caskroom backlink stays valid and resolves to the updated contents across the self-update, and uninstall removes the target and the Caskroom entry.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?
  _Note_: `brew lgtm` passes `brew typecheck` and `brew style --changed --fix`, but on my Linux machine `brew tests --changed` cannot run due to missing the Fiddle library.
  That's probably a bug to be fixed separately; either way, CI will validate the changes.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. -->

I used GPT 5.6 Sol to perform the initial investigation and draft an implementation plan, and then Claude Opus 4.8 to implement and run the tests. I reviewed every change and validated the tests locally as described above.
