### PR TITLE
Stop fetching unsigned per-package API data

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -22,35 +22,12 @@ module Homebrew
 
     extend Utils::Output::Mixin
 
-    extend T::Generic
-    extend Cachable
-
-    Cache = type_template { { fixed: T::Hash[String, T.untyped] } }
-
     HOMEBREW_CACHE_API = T.let((HOMEBREW_CACHE/"api").freeze, Pathname)
     HOMEBREW_CACHE_API_SOURCE = T.let((HOMEBREW_CACHE/"api-source").freeze, Pathname)
     DEFAULT_API_STALE_SECONDS = T.let(7 * 24 * 60 * 60, Integer) # 7 days
     # Revalidate unsigned per-resource responses hourly to limit how long a
     # poisoned cache can persist without requiring a request for every command.
     UNSIGNED_API_STALE_SECONDS = T.let(60 * 60, Integer)
-
-    sig { params(endpoint: String).returns(T::Hash[String, T.untyped]) }
-    def self.fetch(endpoint)
-      return cache[endpoint] if cache.present? && cache.key?(endpoint)
-
-      api_url = "#{Homebrew::EnvConfig.api_domain}/#{endpoint}"
-      output = Utils::Curl.curl_output("--fail", api_url)
-      if !output.success? && Homebrew::EnvConfig.api_domain != HOMEBREW_API_DEFAULT_DOMAIN
-        # Fall back to the default API domain and try again
-        api_url = "#{HOMEBREW_API_DEFAULT_DOMAIN}/#{endpoint}"
-        output = Utils::Curl.curl_output("--fail", api_url)
-      end
-      raise ArgumentError, "No file found at: #{Tty.underline}#{api_url}#{Tty.reset}" unless output.success?
-
-      cache[endpoint] = JSON.parse(output.stdout, freeze: true)
-    rescue JSON::ParserError
-      raise ArgumentError, "Invalid JSON file: #{Tty.underline}#{api_url}#{Tty.reset}"
-    end
 
     sig { params(target: Pathname, stale_seconds: T.nilable(Integer)).returns(T::Boolean) }
     def self.skip_download?(target:, stale_seconds:)

--- a/Library/Homebrew/api/analytics.rb
+++ b/Library/Homebrew/api/analytics.rb
@@ -1,10 +1,23 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "cachable"
+
 module Homebrew
   module API
     # Helper functions for using the analytics JSON API.
+    #
+    # Analytics files are unsigned, so only analytics data is retained from
+    # them: per-package responses are reduced to their `analytics` key before
+    # anything else can observe or cache them.
     module Analytics
+      extend T::Generic
+      extend Cachable
+
+      Cache = type_template { { fixed: T::Hash[String, T.untyped] } }
+
+      private_class_method :cache
+
       class << self
         sig { returns(String) }
         def analytics_api_path
@@ -13,7 +26,52 @@ module Homebrew
 
         sig { params(category: String, days: T.any(Integer, String)).returns(T::Hash[String, T.untyped]) }
         def fetch(category, days)
-          Homebrew::API.fetch "#{analytics_api_path}/#{category}/#{days}d.json"
+          endpoint = "#{analytics_api_path}/#{category}/#{days}d.json"
+          cache[endpoint] ||= fetch_json(endpoint)
+        end
+
+        sig { params(name: String).returns(T.nilable(T::Hash[String, T.untyped])) }
+        def formula_analytics(name)
+          package_analytics "formula/#{name}.json"
+        end
+
+        sig { params(token: String).returns(T.nilable(T::Hash[String, T.untyped])) }
+        def cask_analytics(token)
+          package_analytics "cask/#{token}.json"
+        end
+
+        private
+
+        # The cached response is revalidated hourly so repeated `brew info`
+        # runs do not download it again.
+        sig { params(endpoint: String).returns(T.nilable(T::Hash[String, T.untyped])) }
+        def package_analytics(endpoint)
+          return cache[endpoint] if cache.key?(endpoint)
+
+          json, = Homebrew::API.fetch_json_api_file(endpoint, stale_seconds: Homebrew::API::UNSIGNED_API_STALE_SECONDS)
+          analytics = json["analytics"] if json.is_a?(Hash)
+          cache[endpoint] = (analytics if analytics.is_a?(Hash))
+        end
+
+        sig { params(endpoint: String).returns(T::Hash[String, T.untyped]) }
+        def fetch_json(endpoint)
+          api_url = "#{Homebrew::EnvConfig.api_domain}/#{endpoint}"
+          output = Utils::Curl.curl_output("--fail", api_url)
+          if !output.success? && Homebrew::EnvConfig.api_domain != HOMEBREW_API_DEFAULT_DOMAIN
+            # Fall back to the default API domain and try again
+            api_url = "#{HOMEBREW_API_DEFAULT_DOMAIN}/#{endpoint}"
+            output = Utils::Curl.curl_output("--fail", api_url)
+          end
+          raise ArgumentError, "No file found at: #{Tty.underline}#{api_url}#{Tty.reset}" unless output.success?
+
+          json = begin
+            JSON.parse(output.stdout, freeze: true)
+          rescue JSON::ParserError
+            nil
+          end
+          raise ArgumentError, "Invalid JSON file: #{Tty.underline}#{api_url}#{Tty.reset}" unless json.is_a?(Hash)
+
+          json
         end
       end
     end

--- a/Library/Homebrew/api/cask.rb
+++ b/Library/Homebrew/api/cask.rb
@@ -18,25 +18,6 @@ module Homebrew
 
       private_class_method :cache
 
-      sig { params(name: String).returns(T::Hash[String, T.untyped]) }
-      def self.cask_json(name)
-        fetch_cask_json! name if !cache.key?("cask_json") || !cache.fetch("cask_json").key?(name)
-
-        cache.fetch("cask_json").fetch(name)
-      end
-
-      sig { params(name: String).void }
-      def self.fetch_cask_json!(name)
-        endpoint = "cask/#{name}.json"
-        json_cask, updated = Homebrew::API.fetch_json_api_file endpoint,
-                                                               stale_seconds: Homebrew::API::UNSIGNED_API_STALE_SECONDS
-
-        json_cask = JSON.parse((HOMEBREW_CACHE_API/endpoint).read) unless updated
-
-        cache["cask_json"] ||= {}
-        cache["cask_json"][name] = json_cask
-      end
-
       sig { returns(Pathname) }
       def self.cached_json_file_path
         HOMEBREW_CACHE_API/DEFAULT_API_FILENAME

--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -19,25 +19,6 @@ module Homebrew
 
       private_class_method :cache
 
-      sig { params(name: String).returns(T::Hash[String, T.untyped]) }
-      def self.formula_json(name)
-        fetch_formula_json! name if !cache.key?("formula_json") || !cache.fetch("formula_json").key?(name)
-
-        cache.fetch("formula_json").fetch(name)
-      end
-
-      sig { params(name: String).void }
-      def self.fetch_formula_json!(name)
-        endpoint = "formula/#{name}.json"
-        json_formula, updated = Homebrew::API.fetch_json_api_file endpoint,
-                                                                  stale_seconds: Homebrew::API::UNSIGNED_API_STALE_SECONDS
-
-        json_formula = JSON.parse((HOMEBREW_CACHE_API/endpoint).read) unless updated
-
-        cache["formula_json"] ||= {}
-        cache["formula_json"][name] = json_formula
-      end
-
       sig {
         params(
           formula:        ::Formula,

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -853,49 +853,16 @@ module Cask
       return artifacts if artifacts
       return [] unless api_fallback
 
-      artifacts ||= begin
-        # Only consult the signed payload for a cask that could come from it, and never when the
-        # API is opted out of, so a failure fetching it cannot stop a tap below from being loaded.
-        # `FromAPILoader.try_new` refuses the same way, but only after these lookups would run.
-        api_loader = if !Homebrew::EnvConfig.no_install_from_api? && (tap.nil? || tap.core_cask_tap?)
-          # Use the API loader only once the payload is known to hold this token, since loading
-          # it otherwise raises rather than returning nil. An installed cask can predate a
-          # rename, which the loader itself resolves, so check the current token for it.
-          current_token = Homebrew::API::Internal.cask_renames.fetch(token, token)
-          FromAPILoader.try_new(token) if Homebrew::API::Internal.cask_hash(current_token).present?
+      begin
+        cask = if tap && !tap.core_cask_tap?
+          load("#{tap}/#{token}", warn: false)
+        elsif (loader = FromAPILoader.try_new(token) || FromNameLoader.try_new(token, warn: false))
+          loader.load(config: nil)
         end
-        tap_loader = (FromNameLoader.try_new(token, warn: false) if tap.nil? && api_loader.nil?)
-
-        if tap && !tap.core_cask_tap?
-          load("#{tap}/#{token}", warn: false).artifacts_list(uninstall_only: true)
-        elsif tap_loader
-          tap_loader.load(config: nil).artifacts_list(uninstall_only: true)
-        elsif api_loader
-          # Prefer the JWS-verified internal payload, which carries the same
-          # uninstall directives as the unsigned per-cask endpoint below.
-          api_loader.load(config: nil).artifacts_list(uninstall_only: true)
-        end
+        cask&.artifacts_list(uninstall_only: true) || []
       rescue CaskError, MethodDeprecatedError, JSON::ParserError, KeyError, ErrorDuringExecution, SystemExit
-        nil
+        []
       end
-
-      # API fetch failures must not abort best-effort installed metadata recovery. Reach the
-      # unsigned per-cask endpoint only for a cask that could come from the core tap, and only
-      # once the signed payload has confirmed the token, so neither an absent token nor a failed
-      # membership check can downgrade recovery to it. The endpoint stays available when the API
-      # is opted out of, which `brew update`'s metadata repair relies on.
-      artifacts ||= begin
-        signed_payload_has_token = begin
-          (tap.nil? || tap.core_cask_tap?) && Homebrew::API.cask_token?(token)
-        rescue ErrorDuringExecution, SystemExit
-          false
-        end
-        Homebrew::API::Cask.cask_json(token)["artifacts"] if signed_payload_has_token
-      rescue ErrorDuringExecution, SystemExit
-        nil
-      end
-      artifacts ||= []
-      artifacts
     end
 
     sig {

--- a/Library/Homebrew/test/api/analytics_spec.rb
+++ b/Library/Homebrew/test/api/analytics_spec.rb
@@ -1,0 +1,105 @@
+# typed: true
+# frozen_string_literal: true
+
+require "api"
+
+RSpec.describe Homebrew::API::Analytics do
+  let(:cache_dir) { mktmpdir }
+
+  before do
+    stub_const("Homebrew::API::HOMEBREW_CACHE_API", cache_dir)
+    described_class.clear_cache
+  end
+
+  def mock_curl_output(stdout, success: true)
+    allow(Utils::Curl).to receive(:curl_output)
+      .and_return(instance_double(SystemCommand::Result, success?: success, stdout:))
+  end
+
+  def mock_curl_download(stdout)
+    allow(Utils::Curl).to receive(:curl_download) do |*_args, **kwargs|
+      kwargs[:to].dirname.mkpath
+      kwargs[:to].write stdout
+    end
+  end
+
+  describe "::fetch" do
+    it "fetches an analytics listing" do
+      mock_curl_output '{"items":[]}'
+
+      expect(described_class.fetch("install", 30)).to eq("items" => [])
+    end
+
+    it "raises an error if the file does not exist" do
+      mock_curl_output "", success: false
+
+      expect { described_class.fetch("install", 30) }.to raise_error(ArgumentError, /No file found/)
+    end
+
+    it "raises an error if the JSON file is invalid" do
+      mock_curl_output "foo"
+
+      expect { described_class.fetch("install", 30) }.to raise_error(ArgumentError, /Invalid JSON file/)
+    end
+
+    it "raises an error if the JSON file is not an object" do
+      mock_curl_output "[]"
+
+      expect { described_class.fetch("install", 30) }.to raise_error(ArgumentError, /Invalid JSON file/)
+    end
+  end
+
+  describe "::formula_analytics" do
+    it "keeps only the analytics data from the unsigned per-formula response" do
+      mock_curl_download <<~JSON
+        {
+          "name": "wget",
+          "urls": { "stable": { "url": "https://example.com/wget.tar.gz" } },
+          "post_install_steps": ["rm -rf /"],
+          "analytics": { "install": { "30d": { "wget": 10 } } }
+        }
+      JSON
+
+      expect(described_class.formula_analytics("wget")).to eq("install" => { "30d" => { "wget" => 10 } })
+    end
+
+    it "returns nil when the response has no analytics hash" do
+      mock_curl_download '{"name":"wget","analytics":[]}'
+
+      expect(described_class.formula_analytics("wget")).to be_nil
+    end
+
+    it "revalidates a stale cached response" do
+      target = cache_dir/"formula/wget.json"
+      target.dirname.mkpath
+      target.write('{"analytics":{"install":{"30d":{"wget":1}}}}')
+      FileUtils.touch(target, mtime: Time.now - (2 * 60 * 60))
+      mock_curl_download '{"analytics":{"install":{"30d":{"wget":2}}}}'
+
+      expect(described_class.formula_analytics("wget")).to eq("install" => { "30d" => { "wget" => 2 } })
+    end
+
+    it "reuses a fresh cached response without downloading" do
+      target = cache_dir/"formula/wget.json"
+      target.dirname.mkpath
+      target.write('{"analytics":{"install":{"30d":{"wget":1}}}}')
+      expect(Utils::Curl).not_to receive(:curl_download)
+
+      expect(described_class.formula_analytics("wget")).to eq("install" => { "30d" => { "wget" => 1 } })
+    end
+  end
+
+  describe "::cask_analytics" do
+    it "keeps only the analytics data from the unsigned per-cask response" do
+      mock_curl_download <<~JSON
+        {
+          "token": "firefox",
+          "artifacts": [{ "app": ["Firefox.app"] }],
+          "analytics": { "install": { "30d": { "firefox": 5 } } }
+        }
+      JSON
+
+      expect(described_class.cask_analytics("firefox")).to eq("install" => { "30d" => { "firefox" => 5 } })
+    end
+  end
+end

--- a/Library/Homebrew/test/api/cask_spec.rb
+++ b/Library/Homebrew/test/api/cask_spec.rb
@@ -45,16 +45,4 @@ RSpec.describe Homebrew::API::Cask do
       expect(casks_output).to eq casks_hash
     end
   end
-
-  describe "::cask_json" do
-    it "revalidates a stale per-cask response" do
-      target = cache_dir/"cask/foo.json"
-      target.dirname.mkpath
-      target.write('{"version":"old"}')
-      FileUtils.touch(target, mtime: Time.now - (2 * 60 * 60))
-      mock_curl_download stdout: '{"version":"new"}'
-
-      expect(described_class.cask_json("foo")).to eq("version" => "new")
-    end
-  end
 end

--- a/Library/Homebrew/test/api/formula_spec.rb
+++ b/Library/Homebrew/test/api/formula_spec.rb
@@ -126,18 +126,6 @@ RSpec.describe Homebrew::API::Formula do
     end
   end
 
-  describe "::formula_json" do
-    it "revalidates a stale per-formula response" do
-      target = cache_dir/"formula/foo.json"
-      target.dirname.mkpath
-      target.write('{"versions":{"stable":"old"}}')
-      FileUtils.touch(target, mtime: Time.now - (2 * 60 * 60))
-      mock_curl_download stdout: '{"versions":{"stable":"new"}}'
-
-      expect(described_class.formula_json("foo")).to eq("versions" => { "stable" => "new" })
-    end
-  end
-
   describe "::source_download" do
     let(:f) { Testball.new }
 

--- a/Library/Homebrew/test/api_spec.rb
+++ b/Library/Homebrew/test/api_spec.rb
@@ -5,15 +5,9 @@ require "api"
 require "openssl"
 
 RSpec.describe Homebrew::API do
-  let(:text) { "foo" }
   let(:json) { '{"foo":"bar"}' }
   let(:json_hash) { JSON.parse(json) }
   let(:json_invalid) { '{"foo":"bar"' }
-
-  def mock_curl_output(stdout: "", success: true)
-    curl_output = instance_double(SystemCommand::Result, stdout:, success?: success)
-    allow(Utils::Curl).to receive(:curl_output).and_return curl_output
-  end
 
   def mock_curl_download(stdout:)
     allow(Utils::Curl).to receive(:curl_download) do |*_args, **kwargs|
@@ -33,24 +27,6 @@ RSpec.describe Homebrew::API do
 
       expect(values).to eq(["1", "1"])
       expect(ENV.fetch("HOMEBREW_NO_INSTALL_FROM_API", nil)).to be_nil
-    end
-  end
-
-  describe "::fetch" do
-    it "fetches a JSON file" do
-      mock_curl_output stdout: json
-      fetched_json = described_class.fetch("foo.json")
-      expect(fetched_json).to eq json_hash
-    end
-
-    it "raises an error if the file does not exist" do
-      mock_curl_output success: false
-      expect { described_class.fetch("bar.txt") }.to raise_error(ArgumentError, /No file found/)
-    end
-
-    it "raises an error if the JSON file is invalid" do
-      mock_curl_output stdout: text
-      expect { described_class.fetch("baz.txt") }.to raise_error(ArgumentError, /Invalid JSON file/)
     end
   end
 

--- a/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
@@ -233,8 +233,10 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
       token = "url-less-installed-cask"
       caskroom = mktmpdir
       allow(Cask::Caskroom).to receive(:path).and_return(caskroom)
-      allow(Homebrew::API).to receive(:cask_token?).with(token).and_return(true)
-      allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_return({ "artifacts" => [] })
+      allow(described_class).to receive(:try_new).and_call_original
+      allow(described_class).to receive(:try_new).with(token).and_return(
+        Cask::CaskLoader::FromInstanceLoader.new(Cask::Cask.new(token)),
+      )
       path = caskroom/token/".metadata/latest/20260713000000.000/Casks/#{token}.json"
       cask = described_class.new(token, from_json: {}, path:, from_installed_caskfile: true).load(config: nil)
       allow(cask).to receive(:installed_version).and_return("latest")
@@ -248,14 +250,14 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
       token = "receipt-less-installed-cask"
       caskroom = mktmpdir
       allow(Cask::Caskroom).to receive(:path).and_return(caskroom)
-      allow(Homebrew::API).to receive(:cask_token?).with(token).and_return(true)
-      allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_return({
-        "artifacts" => [
-          { "app" => ["Receipt-less.app"] },
-          { "uninstall" => [{ "quit" => "com.example.receipt-less" }] },
-          { "zap" => [{ "trash" => "~/Library/Preferences/com.example.receipt-less.plist" }] },
-        ],
-      })
+      api_cask = Cask::Cask.new(token) do
+        app "Receipt-less.app"
+        uninstall quit: "com.example.receipt-less"
+        zap trash: "~/Library/Preferences/com.example.receipt-less.plist"
+      end
+      allow(described_class).to receive(:try_new).and_call_original
+      allow(described_class).to receive(:try_new).with(token)
+                                                 .and_return(Cask::CaskLoader::FromInstanceLoader.new(api_cask))
       path = caskroom/token/".metadata/1.0/20260713000000.000/Casks/#{token}.json"
 
       cask = described_class.new(token, from_json: {}, path:, from_installed_caskfile: true).load(config: nil)

--- a/Library/Homebrew/test/cask/cask_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader_spec.rb
@@ -225,9 +225,9 @@ RSpec.describe Cask::CaskLoader, :cask do
     before { caskfile.write("{}") }
 
     it "falls back to the API for missing artifacts by default" do
-      allow(Homebrew::API).to receive(:cask_token?).with("stubbed").and_return(true)
-      expect(Homebrew::API::Cask).to receive(:cask_json).with("stubbed").and_return(
-        "artifacts" => [{ "app" => ["Stubbed.app"] }],
+      allow(Cask::CaskLoader::FromAPILoader).to receive(:try_new).and_call_original
+      allow(Cask::CaskLoader::FromAPILoader).to receive(:try_new).with("stubbed").and_return(
+        Cask::CaskLoader::FromInstanceLoader.new(Cask::Cask.new("stubbed") { app "Stubbed.app" }),
       )
 
       expect(described_class.load_from_installed_caskfile(caskfile).artifacts_list(uninstall_only: true))
@@ -235,7 +235,7 @@ RSpec.describe Cask::CaskLoader, :cask do
     end
 
     it "does not consult the API when api_fallback is disabled" do
-      expect(Homebrew::API::Cask).not_to receive(:cask_json)
+      expect(Homebrew::API).not_to receive(:cask_token?)
 
       expect(described_class.load_from_installed_caskfile(caskfile, api_fallback: false).artifacts_list)
         .to be_empty
@@ -567,170 +567,104 @@ RSpec.describe Cask::CaskLoader, :cask do
   end
 
   describe "::resolve_installed_artifacts" do
-    before do
-      allow(Homebrew::API).to receive(:cask_token?).and_return(true)
-      allow(Homebrew::API::Internal).to receive(:cask_renames).and_return({})
-    end
-
-    it "does not request API metadata for a removed cask" do
-      token = "removed-cask"
-      allow(Homebrew::API).to receive(:cask_token?).with(token).and_return(false)
-      expect(Homebrew::API::Cask).not_to receive(:cask_json)
-
-      expect(described_class.resolve_installed_artifacts(token, nil)).to eq([])
-    end
-
-    context "when the signed API payload carries the token" do
-      let(:token) { "signed-cask" }
-      let(:verified_artifacts) { [{ "uninstall" => [{ "quit" => "com.example.app" }] }] }
-
-      before do
-        cask = instance_double(Cask::Cask)
-        allow(cask).to receive(:artifacts_list).with(uninstall_only: true).and_return(verified_artifacts)
-        loader = instance_double(Cask::CaskLoader::FromAPILoader)
-        allow(loader).to receive(:load).with(config: nil).and_return(cask)
-        allow(Cask::CaskLoader::FromAPILoader).to receive(:try_new).with(token).and_return(loader)
-        allow(Homebrew::API::Internal).to receive(:cask_hash).with(token).and_return({ "token" => token })
-      end
-
-      it "prefers it over the unsigned per-cask endpoint for an untapped cask" do
-        expect(Homebrew::API::Cask).not_to receive(:cask_json)
-
-        expect(described_class.resolve_installed_artifacts(token, nil)).to eq(verified_artifacts)
-      end
-
-      it "prefers it over the unsigned per-cask endpoint for a core tap cask" do
-        expect(Homebrew::API::Cask).not_to receive(:cask_json)
-
-        expect(described_class.resolve_installed_artifacts(token, nil, tap: CoreCaskTap.instance))
-          .to eq(verified_artifacts)
+    let(:api_cask) do
+      Cask::Cask.new("api-cask") do
+        app "API.app"
+        uninstall quit: "com.example.api"
       end
     end
+    let(:api_artifacts) { [{ uninstall: [{ quit: "com.example.api" }] }, { app: ["API.app"] }] }
 
-    it "recovers a cask installed under a token the signed payload has since renamed" do
-      old_token = "renamed-cask"
-      current_token = "current-cask"
-      verified_artifacts = [{ "uninstall" => [{ "quit" => "com.example.app" }] }]
-      cask = instance_double(Cask::Cask)
-      allow(cask).to receive(:artifacts_list).with(uninstall_only: true).and_return(verified_artifacts)
-      loader = instance_double(Cask::CaskLoader::FromAPILoader)
-      allow(loader).to receive(:load).with(config: nil).and_return(cask)
-      allow(Cask::CaskLoader::FromAPILoader).to receive(:try_new).with(old_token).and_return(loader)
-      allow(Homebrew::API).to receive(:cask_token?).with(old_token).and_return(false)
-      allow(Homebrew::API::Internal).to receive(:cask_renames).and_return(old_token => current_token)
-      allow(Homebrew::API::Internal).to receive(:cask_hash).with(old_token).and_return(nil)
-      allow(Homebrew::API::Internal).to receive(:cask_hash)
-        .with(current_token).and_return({ "token" => current_token })
-      expect(Homebrew::API::Cask).not_to receive(:cask_json)
-
-      expect(described_class.resolve_installed_artifacts(old_token, nil)).to eq(verified_artifacts)
+    def stub_api_loader(token, loader = Cask::CaskLoader::FromInstanceLoader.new(api_cask))
+      allow(Cask::CaskLoader::FromAPILoader).to receive(:try_new).with(token).and_return(loader)
     end
 
-    it "recovers from a recorded tap when the signed API is unavailable" do
+    it "uses uninstall artifacts from the signed API for an untapped cask" do
+      stub_api_loader("api-cask")
+
+      expect(described_class.resolve_installed_artifacts("api-cask", nil)).to eq(api_artifacts)
+    end
+
+    it "uses uninstall artifacts from the signed API for a core tap cask" do
+      stub_api_loader("api-cask")
+
+      expect(described_class.resolve_installed_artifacts("api-cask", nil, tap: CoreCaskTap.instance))
+        .to eq(api_artifacts)
+    end
+
+    it "recovers from a recorded tap without consulting the API" do
       token = "thirdparty-cask"
       tap = Tap.fetch("thirdparty", "present")
-      tap_artifacts = [{ "app" => ["Thirdparty.app"] }]
-      cask = instance_double(Cask::Cask)
-      allow(cask).to receive(:artifacts_list).with(uninstall_only: true).and_return(tap_artifacts)
-      allow(described_class).to receive(:load).with("#{tap}/#{token}", warn: false).and_return(cask)
-      unavailable = ErrorDuringExecution.new(["curl"], status: 22)
-      allow(Homebrew::API).to receive(:cask_token?).and_raise(unavailable)
-      allow(Homebrew::API::Internal).to receive(:cask_renames).and_raise(unavailable)
-      allow(Homebrew::API::Internal).to receive(:cask_hash).and_raise(unavailable)
-      expect(Homebrew::API::Cask).not_to receive(:cask_json)
+      allow(described_class).to receive(:load).with("#{tap}/#{token}", warn: false).and_return(api_cask)
+      allow(Homebrew::API).to receive(:cask_token?).and_raise(ErrorDuringExecution.new(["curl"], status: 22))
 
-      expect(described_class.resolve_installed_artifacts(token, nil, tap:)).to eq(tap_artifacts)
+      expect(described_class.resolve_installed_artifacts(token, nil, tap:)).to eq(api_artifacts)
     end
 
     it "recovers from the local core tap when the API is opted out of", :no_api do
       token = "opted-out-cask"
-      tap_artifacts = [{ "app" => ["OptedOut.app"] }]
-      cask = instance_double(Cask::Cask)
-      allow(cask).to receive(:artifacts_list).with(uninstall_only: true).and_return(tap_artifacts)
-      loader = instance_double(Cask::CaskLoader::FromNameLoader)
-      allow(loader).to receive(:load).with(config: nil).and_return(cask)
-      allow(Cask::CaskLoader::FromNameLoader).to receive(:try_new).with(token, warn: false).and_return(loader)
-      unavailable = ErrorDuringExecution.new(["curl"], status: 22)
-      allow(Homebrew::API).to receive(:cask_token?).and_raise(unavailable)
-      allow(Homebrew::API::Internal).to receive(:cask_renames).and_raise(unavailable)
-      allow(Homebrew::API::Internal).to receive(:cask_hash).and_raise(unavailable)
-      expect(Homebrew::API::Cask).not_to receive(:cask_json)
-
-      expect(described_class.resolve_installed_artifacts(token, nil)).to eq(tap_artifacts)
-    end
-
-    it "does not request unsigned API metadata for a cask recorded in a non-core tap" do
-      token = "thirdparty-absent"
-      tap = Tap.fetch("thirdparty", "absent")
-      allow(described_class).to receive(:load)
-        .with("#{tap}/#{token}", warn: false)
-        .and_raise(Cask::TapCaskUnavailableError.new(tap, token))
-      expect(Homebrew::API::Cask).not_to receive(:cask_json)
-
-      expect(described_class.resolve_installed_artifacts(token, nil, tap:)).to eq([])
-    end
-
-    # `cask_hash` and `cask_token?` read the same signed index, so the reachable way to fall
-    # through to the endpoint for a core tap cask is a signed loader that fails, not a missing hash.
-    it "requests unsigned API metadata when the signed loader fails for a core tap cask" do
-      token = "core-tap-unsigned"
-      api_artifacts = [{ "app" => ["Unsigned.app"] }]
-      loader = instance_double(Cask::CaskLoader::FromAPILoader)
-      allow(loader).to receive(:load).with(config: nil).and_raise(Cask::CaskError.new("unreadable"))
-      allow(Cask::CaskLoader::FromAPILoader).to receive(:try_new).with(token).and_return(loader)
-      allow(Homebrew::API::Internal).to receive(:cask_hash).with(token).and_return({ "token" => token })
-      allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_return({ "artifacts" => api_artifacts })
+      allow(Cask::CaskLoader::FromNameLoader).to receive(:try_new).with(token, warn: false)
+                                                                  .and_return(Cask::CaskLoader::FromInstanceLoader.new(api_cask))
+      allow(Homebrew::API).to receive(:cask_token?).and_raise(ErrorDuringExecution.new(["curl"], status: 22))
 
       expect(described_class.resolve_installed_artifacts(token, nil, tap: CoreCaskTap.instance)).to eq(api_artifacts)
     end
 
-    it "does not request unsigned API metadata when the membership check fails" do
-      token = "unavailable-membership"
-      allow(Homebrew::API).to receive(:cask_token?).with(token).and_raise(
-        ErrorDuringExecution.new(["curl"], status: 22),
-      )
-      expect(Homebrew::API::Cask).not_to receive(:cask_json)
+    it "returns empty artifacts for a removed cask" do
+      allow(Homebrew::API).to receive_messages(cask_token?: false, cask_renames: {})
+
+      expect(described_class.resolve_installed_artifacts("removed-cask", nil)).to eq([])
+    end
+
+    it "returns empty artifacts when the membership check fails" do
+      allow(Homebrew::API).to receive(:cask_token?).and_raise(ErrorDuringExecution.new(["curl"], status: 22))
+
+      expect(described_class.resolve_installed_artifacts("unavailable-membership", nil)).to eq([])
+    end
+
+    it "returns empty artifacts when the signed loader fails" do
+      token = "unreadable"
+      loader = Cask::CaskLoader::FromAPILoader.new(token)
+      allow(loader).to receive(:load).and_raise(Cask::CaskError.new("unreadable"))
+      stub_api_loader(token, loader)
 
       expect(described_class.resolve_installed_artifacts(token, nil)).to eq([])
     end
 
-    it "returns empty artifacts when the API download fails" do
-      token = "unavailable"
-      allow(Homebrew::API).to receive(:cask_token?).with(token).and_return(true)
-      allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_raise(
-        ErrorDuringExecution.new(["curl"], status: 22),
-      )
+    it "returns empty artifacts when the signed index has no cask payload" do
+      token = "missing-payload"
+      loader = Cask::CaskLoader::FromAPILoader.new(token)
+      allow(loader).to receive(:load).and_raise(KeyError.new("key not found: #{token.inspect}"))
+      stub_api_loader(token, loader)
 
       expect(described_class.resolve_installed_artifacts(token, nil)).to eq([])
     end
 
     it "returns empty artifacts when the API cannot be loaded" do
-      allow(Homebrew::API).to receive(:cask_token?).with("unavailable").and_return(true)
-      allow(Homebrew::API::Cask).to receive(:cask_json).with("unavailable").and_raise(SystemExit.new(1))
+      token = "unavailable"
+      loader = Cask::CaskLoader::FromAPILoader.new(token)
+      allow(loader).to receive(:load).and_raise(SystemExit.new(1))
+      stub_api_loader(token, loader)
 
-      expect(described_class.resolve_installed_artifacts("unavailable", nil)).to eq([])
+      expect(described_class.resolve_installed_artifacts(token, nil)).to eq([])
     end
 
-    it "falls back to API artifacts when tap lookup is ambiguous" do
+    it "returns empty artifacts when tap lookup is ambiguous" do
       token = "ambiguous"
-      api_artifacts = [{ "app" => ["API.app"] }]
-      allow(Homebrew::API).to receive(:cask_token?).with(token).and_return(true)
-      allow(Cask::CaskLoader::FromAPILoader).to receive(:try_new).with(token).and_return(nil)
+      allow(Homebrew::API).to receive_messages(cask_token?: false, cask_renames: {})
       allow(Cask::CaskLoader::FromNameLoader).to receive(:try_new)
         .with(token, warn: false)
         .and_raise(Cask::TapCaskAmbiguityError.new(token, []))
-      allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_return({ "artifacts" => api_artifacts })
 
-      expect(described_class.resolve_installed_artifacts(token, nil)).to eq(api_artifacts)
+      expect(described_class.resolve_installed_artifacts(token, nil)).to eq([])
     end
 
-    it "returns empty artifacts when the installed tap and API are unavailable" do
+    it "returns empty artifacts when the recorded tap is unavailable" do
       token = "unavailable-tap"
       tap = Tap.fetch("thirdparty", "missing")
       allow(described_class).to receive(:load)
         .with("#{tap}/#{token}", warn: false)
         .and_raise(Cask::TapCaskUnavailableError.new(tap, token))
-      allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_raise(SystemExit.new(1))
 
       expect(described_class.resolve_installed_artifacts(token, nil, tap:)).to eq([])
     end
@@ -751,7 +685,7 @@ RSpec.describe Cask::CaskLoader, :cask do
         "uninstall_flight_blocks" => false,
         "uninstall_artifacts"     => [{ "app" => ["Recoverable.app"] }],
       })
-      expect(Homebrew::API::Cask).not_to receive(:cask_json)
+      expect(Homebrew::API).not_to receive(:cask_token?)
 
       recovered_cask = described_class.recover_from_installed_caskfile(caskfile)
 
@@ -774,7 +708,7 @@ RSpec.describe Cask::CaskLoader, :cask do
         "uninstall_flight_blocks" => true,
         "uninstall_artifacts"     => [{ "uninstall_preflight" => nil }],
       })
-      expect(Homebrew::API::Cask).not_to receive(:cask_json)
+      expect(Homebrew::API).not_to receive(:cask_token?)
 
       expect(described_class.recover_from_installed_caskfile(caskfile)).to be_nil
     end

--- a/Library/Homebrew/test/cask/caskroom_spec.rb
+++ b/Library/Homebrew/test/cask/caskroom_spec.rb
@@ -341,10 +341,10 @@ RSpec.describe Cask::Caskroom do
           app "Old.app"
         end
       RUBY
-      allow(Homebrew::API).to receive(:cask_token?).with(token).and_return(true)
-      allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_return({
-        "artifacts" => [{ "app" => ["Current.app"] }],
-      })
+      allow(Cask::CaskLoader::FromAPILoader).to receive(:try_new).and_call_original
+      allow(Cask::CaskLoader::FromAPILoader).to receive(:try_new).with(token).and_return(
+        Cask::CaskLoader::FromInstanceLoader.new(Cask::Cask.new(token) { app "Current.app" }),
+      )
 
       described_class.migrate_caskfile_to_json(caskfile)
 
@@ -364,10 +364,10 @@ RSpec.describe Cask::Caskroom do
       allow(Cask::CaskLoader).to receive(:load)
         .with(caskfile, warn: false)
         .and_raise(MethodDeprecatedError.new)
-      allow(Homebrew::API).to receive(:cask_token?).with(token).and_return(true)
-      allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_return({
-        "artifacts" => [{ "app" => ["Current.app"] }],
-      })
+      allow(Cask::CaskLoader::FromAPILoader).to receive(:try_new).and_call_original
+      allow(Cask::CaskLoader::FromAPILoader).to receive(:try_new).with(token).and_return(
+        Cask::CaskLoader::FromInstanceLoader.new(Cask::Cask.new(token) { app "Current.app" }),
+      )
 
       described_class.migrate_caskfile_to_json(caskfile)
 
@@ -391,7 +391,6 @@ RSpec.describe Cask::Caskroom do
       Homebrew::Trust.trust!(:tap, tap.name)
       allow(Homebrew::EnvConfig).to receive(:no_install_from_api?).and_return(false)
       allow(Homebrew::API).to receive_messages(cask_token?: false, cask_renames: {})
-      allow(Homebrew::API::Cask).to receive(:cask_json).and_raise("unexpected official API lookup")
 
       described_class.migrate_caskfile_to_json(caskfile)
 
@@ -422,10 +421,10 @@ RSpec.describe Cask::Caskroom do
     it "replaces malformed installed JSON using API metadata" do
       token = "malformed-json"
       caskfile = write_installed_caskfile(token, "{", extension: "json")
-      allow(Homebrew::API).to receive(:cask_token?).with(token).and_return(true)
-      allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_return({
-        "artifacts" => [{ "app" => ["Current.app"] }],
-      })
+      allow(Cask::CaskLoader::FromAPILoader).to receive(:try_new).and_call_original
+      allow(Cask::CaskLoader::FromAPILoader).to receive(:try_new).with(token).and_return(
+        Cask::CaskLoader::FromInstanceLoader.new(Cask::Cask.new(token) { app "Current.app" }),
+      )
 
       described_class.migrate_caskfile_to_json(caskfile)
 
@@ -437,10 +436,10 @@ RSpec.describe Cask::Caskroom do
     it "replaces invalid artifact data in installed JSON using API metadata" do
       token = "invalid-artifacts"
       caskfile = write_installed_caskfile(token, JSON.generate({ "artifacts" => ["invalid"] }), extension: "json")
-      allow(Homebrew::API).to receive(:cask_token?).with(token).and_return(true)
-      allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_return({
-        "artifacts" => [{ "app" => ["Current.app"] }],
-      })
+      allow(Cask::CaskLoader::FromAPILoader).to receive(:try_new).and_call_original
+      allow(Cask::CaskLoader::FromAPILoader).to receive(:try_new).with(token).and_return(
+        Cask::CaskLoader::FromInstanceLoader.new(Cask::Cask.new(token) { app "Current.app" }),
+      )
 
       described_class.migrate_caskfile_to_json(caskfile)
 
@@ -451,7 +450,7 @@ RSpec.describe Cask::Caskroom do
 
     it "keeps intentional empty artifacts in installed JSON" do
       caskfile = write_installed_caskfile("stage-only", JSON.generate({ "artifacts" => [] }), extension: "json")
-      expect(Homebrew::API::Cask).not_to receive(:cask_json)
+      expect(Cask::CaskLoader::FromAPILoader).not_to receive(:try_new)
 
       described_class.migrate_caskfile_to_json(caskfile)
 
@@ -461,10 +460,7 @@ RSpec.describe Cask::Caskroom do
     it "does not mark unavailable artifacts as intentionally empty" do
       token = "removed-cask"
       caskfile = write_installed_caskfile(token, "{}", extension: "json")
-      allow(Homebrew::API).to receive(:cask_token?).with(token).and_return(false)
-      allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_raise(
-        ErrorDuringExecution.new(["curl"], status: 22),
-      )
+      allow(Homebrew::API).to receive_messages(cask_token?: false, cask_renames: {})
 
       described_class.migrate_caskfile_to_json(caskfile)
 

--- a/Library/Homebrew/test/cask/uninstall_spec.rb
+++ b/Library/Homebrew/test/cask/uninstall_spec.rb
@@ -199,10 +199,7 @@ RSpec.describe Cask::Uninstall, :cask do
       before do
         saved_caskfile.dirname.mkpath
         saved_caskfile.write("{}")
-        allow(Homebrew::API).to receive(:cask_token?).with(token).and_return(false)
-        allow(Homebrew::API::Cask).to receive(:cask_json).with(token).and_raise(
-          ErrorDuringExecution.new(["curl"], status: 22),
-        )
+        allow(Homebrew::API).to receive_messages(cask_token?: false, cask_renames: {})
       end
 
       it "removes Homebrew's records and warns that installed files may remain" do

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -789,10 +789,10 @@ RSpec.describe Cask::Upgrade, :cask do
     it "uses the forced upgrade metadata for the next upgrade" do
       receipt_path = local_caffeine.metadata_main_container_path/AbstractTab::FILENAME
       receipt_path.unlink
-      allow(Homebrew::API).to receive(:cask_token?).with("local-caffeine").and_return(true)
-      allow(Homebrew::API::Cask).to receive(:cask_json).with("local-caffeine").and_return({
-        "artifacts" => [{ "app" => ["Caffeine.app"] }],
-      })
+      allow(Cask::CaskLoader::FromAPILoader).to receive(:try_new).and_call_original
+      allow(Cask::CaskLoader::FromAPILoader).to receive(:try_new).with("local-caffeine").and_return(
+        Cask::CaskLoader::FromInstanceLoader.new(Cask::Cask.new("local-caffeine") { app "Caffeine.app" }),
+      )
 
       expect(receipt_path).not_to exist
       expect(Cask::CaskLoader.load_from_installed_caskfile(local_caffeine.installed_caskfile).artifacts)

--- a/Library/Homebrew/test/cmd/update-report_spec.rb
+++ b/Library/Homebrew/test/cmd/update-report_spec.rb
@@ -329,10 +329,10 @@ RSpec.describe Homebrew::Cmd::UpdateReport do
     allow(Cask::Caskroom).to receive(:path).and_return(caskroom)
     allow(Homebrew::EnvConfig).to receive_messages(developer?: false, disable_load_formula?: true,
                                                    no_install_from_api?: true)
-    allow(Homebrew::API).to receive(:cask_token?).with("stubbed").and_return(true)
-    expect(Homebrew::API::Cask).to receive(:cask_json).once.with("stubbed").and_return({
-      "artifacts" => [{ "app" => ["Stubbed.app"] }],
-    })
+    allow(Cask::CaskLoader::FromNameLoader).to receive(:try_new).and_call_original
+    expect(Cask::CaskLoader::FromNameLoader).to receive(:try_new).once.with("stubbed", warn: false).and_return(
+      Cask::CaskLoader::FromInstanceLoader.new(Cask::Cask.new("stubbed") { app "Stubbed.app" }),
+    )
 
     2.times { run_quiet_update_report }
     expect(JSON.parse(caskfile.read)).to eq({
@@ -355,10 +355,10 @@ RSpec.describe Homebrew::Cmd::UpdateReport do
     migrated_internal_caskfile = internal_json_caskfile.dirname/"internal-json.json"
     uninstall_flight_caskfile =
       caskroom/"uninstall-flight-block/.metadata/1.0/20250101000000.000/Casks/uninstall-flight-block.rb"
-    allow(Homebrew::API).to receive(:cask_token?).with("pre-receipt-stubbed").and_return(true)
-    expect(Homebrew::API::Cask).to receive(:cask_json).once.with("pre-receipt-stubbed").and_return({
-      "artifacts" => [{ "app" => ["Pre Receipt Stubbed.app"] }],
-    })
+    pre_receipt_stubbed_cask = Cask::Cask.new("pre-receipt-stubbed") { app "Pre Receipt Stubbed.app" }
+    allow(Cask::CaskLoader::FromAPILoader).to receive(:try_new).and_call_original
+    expect(Cask::CaskLoader::FromAPILoader).to receive(:try_new).once.with("pre-receipt-stubbed")
+                                                                .and_return(Cask::CaskLoader::FromInstanceLoader.new(pre_receipt_stubbed_cask))
 
     described_class.new(["--quiet"]).migrate_caskroom_caskfiles_to_json
 

--- a/Library/Homebrew/test/utils/analytics_spec.rb
+++ b/Library/Homebrew/test/utils/analytics_spec.rb
@@ -318,7 +318,7 @@ RSpec.describe Utils::Analytics do
   end
 
   describe "::output_github_packages_downloads" do
-    let(:json) { { "analytics" => { "install" => { "30d" => { "wget" => 750_000, "wget --HEAD" => 500 } } } } }
+    let(:analytics) { { "install" => { "30d" => { "wget" => 750_000, "wget --HEAD" => 500 } } } }
     let(:args) { Homebrew::Cmd::Info.new(["--github-packages-downloads", "wget"]).args }
     let(:wget) { instance_double(Formula, name: "wget", core_formula?: true) }
 
@@ -346,7 +346,7 @@ RSpec.describe Utils::Analytics do
     it "outputs downloads per tag, a total and the difference from analytics install events" do
       stub_github_packages_pages("1.25.0-2" => "1,000", "1.25.0-1" => "1.5M")
 
-      expect { described_class.output_github_packages_downloads(wget, json, args:) }
+      expect { described_class.output_github_packages_downloads(wget, analytics, args:) }
         .to output(
           match(/^1 +\| 1\.25\.0-1 +\| 1,500,000 \| +99\.93%$/)
             .and(match(/^2 +\| 1\.25\.0-2 +\| +1,000 \| +0\.07%$/))
@@ -358,7 +358,7 @@ RSpec.describe Utils::Analytics do
     it "warns instead of outputting a partial total when a tag's downloads cannot be fetched" do
       stub_github_packages_pages("1.25.0-2" => "1,000")
 
-      expect { described_class.output_github_packages_downloads(wget, json, args:) }
+      expect { described_class.output_github_packages_downloads(wget, analytics, args:) }
         .to output(/Failed to fetch GitHub Packages downloads for: 1\.25\.0-1$/).to_stderr
         .and not_to_output.to_stdout
     end

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -264,14 +264,14 @@ module Utils
         table_output(category, days, results, os_version:, cask_install:)
       end
 
-      sig { params(json: T::Hash[String, T.untyped], args: Homebrew::Cmd::Info::Args).void }
-      def output_analytics(json, args:)
+      sig { params(analytics: T::Hash[String, T.untyped], args: Homebrew::Cmd::Info::Args).void }
+      def output_analytics(analytics, args:)
         full_analytics = args.analytics? || verbose?
 
         ohai "Analytics"
-        json["analytics"].each do |category, value|
+        analytics.each do |category, value|
           category = category.tr("_", "-")
-          analytics = []
+          summaries = []
 
           value.each do |days, results|
             days = days.to_i
@@ -282,11 +282,11 @@ module Utils
               table_output(category, days.to_s, results)
             else
               total_count = results.values.sum
-              analytics << "#{Formatter.number_readable(total_count)} (#{days} days)"
+              summaries << "#{Formatter.number_readable(total_count)} (#{days} days)"
             end
           end
 
-          puts "#{category}: #{analytics.join(", ")}" unless full_analytics
+          puts "#{category}: #{summaries.join(", ")}" unless full_analytics
         end
       end
 
@@ -294,8 +294,8 @@ module Utils
       # It relies on screen scraping some GitHub HTML that's not available as an API.
       # This seems very likely to break in the future.
       # That said, it's the only way to get the data we want right now.
-      sig { params(formula: Formula, json: T::Hash[String, T.untyped], args: Homebrew::Cmd::Info::Args).void }
-      def output_github_packages_downloads(formula, json, args:)
+      sig { params(formula: Formula, analytics: T::Hash[String, T.untyped], args: Homebrew::Cmd::Info::Args).void }
+      def output_github_packages_downloads(formula, analytics, args:)
         return unless args.github_packages_downloads?
         return unless formula.core_formula?
 
@@ -342,7 +342,7 @@ module Utils
         table_output("github-packages-downloads", "30", downloads_by_tag.sort_by { |_, count| -count }.to_h,
                      name_header: "Tag")
 
-        install_count = json.dig("analytics", "install", "30d")&.values&.sum
+        install_count = analytics.dig("install", "30d")&.values&.sum
         return unless install_count&.positive?
 
         difference = ((downloads_by_tag.sum { |_, count| count } - install_count) * 100.0) / install_count
@@ -358,11 +358,11 @@ module Utils
 
         return unless Homebrew::API.formula_name? formula.name
 
-        json = Homebrew::API::Formula.formula_json formula.name
-        return if json.blank? || json["analytics"].blank?
+        analytics = Homebrew::API::Analytics.formula_analytics formula.name
+        return if analytics.blank?
 
-        output_analytics(json, args:)
-        output_github_packages_downloads(formula, json, args:)
+        output_analytics(analytics, args:)
+        output_github_packages_downloads(formula, analytics, args:)
       rescue ArgumentError
         # Ignore failed API requests
         nil
@@ -376,10 +376,10 @@ module Utils
 
         return unless Homebrew::API.cask_token?(cask.token)
 
-        json = Homebrew::API::Cask.cask_json cask.token
-        return if json.blank? || json["analytics"].blank?
+        analytics = Homebrew::API::Analytics.cask_analytics cask.token
+        return if analytics.blank?
 
-        output_analytics(json, args:)
+        output_analytics(analytics, args:)
       rescue ArgumentError
         # Ignore failed API requests
         nil


### PR DESCRIPTION
Remove the fetching, caching and public accessors for the unsigned `formula/<name>.json` and `cask/<token>.json` API files. Everything they contain, other than analytics, is already available from the JWS-signed `formula.jws.json`, `cask.jws.json` and internal `packages.*.jws.json` files, so an endpoint that could be used insecurely was being kept around for data Homebrew did not need.

An audit found only two consumers. `brew info` read the `analytics` key, which the signed files do not carry. Cask uninstall recovery read the unsigned `artifacts` to decide which files to delete when installed metadata lacked them, and the public `formula_json`/`cask_json` accessors plus the on-disk cache under `api/formula` and `api/cask` made the whole unsigned response available to any other code path.

Uninstall recovery in `cask/cask_loader.rb` now loads the cask through the signed internal API loader or the installed tap and otherwise returns no artifacts, relying on the existing "files may remain" warning. `brew info` keeps its analytics summary and `--analytics` tables through new `formula_analytics` and `cask_analytics` methods in `api/analytics.rb`. These curl the endpoint straight into memory, keep the `analytics` hash only if it is one and cache just that slice; the HTTP helper and reducer are private so nothing else can observe the rest of the response. `Homebrew::API.fetch` had no other callers and becomes that private helper. `cleanup.rb` no longer prunes per-resource cache directories and `cmd/update.sh` deletes the leftover ones.

Specs stub the signed API loader instead of the removed accessors and a new `api/analytics_spec` checks that only analytics data survives.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude with Fable at High effort, with local review and testing.

-----