### PR TITLE
test: cover Utils.safe_filename and .safe_filename?

### DIFF
--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -211,6 +211,43 @@ RSpec.describe Utils do
     end
   end
 
+  describe ".safe_filename?" do
+    specify(:aggregate_failures) do
+      expect(described_class.safe_filename?("formula-1.2.3.tar.gz")).to be(true)
+      expect(described_class.safe_filename?("")).to be(true)
+
+      expect(described_class.safe_filename?("etc/passwd")).to be(false)
+      expect(described_class.safe_filename?("with\nnewline")).to be(false)
+      expect(described_class.safe_filename?("with\0null")).to be(false)
+      expect(described_class.safe_filename?("with\ttab")).to be(false)
+    end
+
+    # A basename is only unsafe here if it can escape its directory or smuggle a
+    # control character; a relative traversal has to survive as a separate
+    # component to matter, and the separator is what this rejects.
+    specify "relative components are not separators", :aggregate_failures do
+      expect(described_class.safe_filename?("..")).to be(true)
+      expect(described_class.safe_filename?("../etc")).to be(false)
+    end
+  end
+
+  describe ".safe_filename" do
+    specify(:aggregate_failures) do
+      expect(described_class.safe_filename("formula-1.2.3.tar.gz")).to eq("formula-1.2.3.tar.gz")
+
+      expect(described_class.safe_filename("etc/passwd")).to eq("etcpasswd")
+      expect(described_class.safe_filename("../../etc/passwd")).to eq("....etcpasswd")
+      expect(described_class.safe_filename("with\nnewline")).to eq("withnewline")
+      expect(described_class.safe_filename("with\0null")).to eq("withnull")
+    end
+
+    specify "the result is always safe", :aggregate_failures do
+      ["a/b", "a\nb", "..", "", "\0"].each do |basename|
+        expect(described_class.safe_filename?(described_class.safe_filename(basename))).to be(true)
+      end
+    end
+  end
+
   describe ".convert_to_string_or_symbol" do
     specify(:aggregate_failures) do
       expect(described_class.convert_to_string_or_symbol(":example")).to eq(:example)


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Tests only, no behaviour change.

`Utils.safe_filename` and `Utils.safe_filename?` had no coverage at all, and both sit on paths where the input is not fully ours: `Cleanup#cleanup_cask` passes `File.basename` of a cask URL through `safe_filename`, and `VCSDownloadStrategy` / `CurlGitHubPackagesDownloadStrategy` build cache paths out of the result. A sanitiser with no tests is one refactor away from quietly widening.

Why I bothered: reading it, `SAFE_FILENAME_REGEX` looked like it might be missing relative-path handling, since `File.basename("http://example.com/../")` really does return `".."`. It is not a hole - every caller that builds a path prefixes the value (`"#{name}--"`, `"#{Digest::SHA256.hexdigest(url)}--"`), and the one caller that does not only uses it for a `start_with?` comparison, so a bare `".."` can never be a whole path component. That reasoning is exactly what was not written down anywhere, so the specs now pin it: `safe_filename?("..")` is `true`, `safe_filename?("../etc")` is `false`.

The rest is the current contract: control characters and path separators are stripped, everything else survives, and the output of `safe_filename` always satisfies `safe_filename?`.

The unticked box is the bug-fix one - there is no bug here to reproduce, and I did not change `utils.rb`.

Verification: `brew lgtm` passes locally (style, typechecking, `brew tests --changed`), and `brew tests --only=utils` is green. To check the specs actually bite, I replaced `basename.gsub(SAFE_FILENAME_REGEX, "")` with `basename` and both new `safe_filename` examples failed, then restored it.

AI/LLM disclosure: I used Claude Code (Claude Opus 5) to audit the helper and draft these specs, and reviewed the result; no commit is attributed to AI. I will answer review questions myself.
