### PR TITLE
livecheck: really use referenced livecheck options

### DIFF
--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -207,11 +207,16 @@ class Livecheck
     referer: nil,
     user_agent: nil
   )
-    # Don't use `T.nilable(FalseClass)` and `T.nilable(TrueClass)` for `compressed` and `homebrew_curl`
-    # as we won't be able to check types without Sorbet runtime
+    # This manually enforces stricter values for `compressed` and
+    # `homebrew_curl`, as we can't rely on the Sorbet runtime being enabled in
+    # all circumstances.
     raise ArgumentError, "`compressed` option should only be `false` or omitted" if compressed == true
     raise ArgumentError, "`homebrew_curl` option should only be `true` or omitted" if homebrew_curl == false
-    raise ArgumentError, "Only use `post_form` or `post_json`, not both" if post_form && post_json
+    if (post_form && post_json) ||
+       (@options.post_form && post_json) ||
+       (@options.post_json && post_form)
+      raise ArgumentError, "Only use `post_form` or `post_json`, not both"
+    end
 
     @options.compressed = compressed unless compressed.nil?
     @options.cookies = cookies unless cookies.nil?

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -639,7 +639,7 @@ module Homebrew
       livecheck = formula_or_cask.livecheck
       referenced_livecheck = referenced_formula_or_cask&.livecheck
 
-      livecheck_options = livecheck.options || referenced_livecheck&.options
+      livecheck_options = referenced_livecheck&.options&.merge(livecheck.options) || livecheck.options
       livecheck_url_options = livecheck_options.url_options.compact
       livecheck_url = livecheck.url || referenced_livecheck&.url
       livecheck_regex = livecheck.regex || referenced_livecheck&.regex
@@ -680,6 +680,8 @@ module Homebrew
             puts "Formula Ref:      #{formula_name(ref_formula_or_cask, full_name:)}"
           when Cask::Cask
             puts "Cask Ref:         #{cask_name(ref_formula_or_cask, full_name:)}"
+          else
+            T.absurd(ref_formula_or_cask) # simplecov:disable
           end
         end
       end
@@ -854,6 +856,8 @@ module Homebrew
                 { formula: formula_name(ref_formula_or_cask, full_name:) }
               when Cask::Cask
                 { cask: cask_name(ref_formula_or_cask, full_name:) }
+              else
+                T.absurd(ref_formula_or_cask) # simplecov:disable
               end
             end
           end

--- a/Library/Homebrew/livecheck/options.rb
+++ b/Library/Homebrew/livecheck/options.rb
@@ -66,16 +66,7 @@ module Homebrew
       # `Options` object, as these are unitiailized values. This ensures that
       # existing values in `self` aren't unexpectedly overwritten with defaults.
       sig { params(other: T.any(Options, T::Hash[Symbol, T.untyped])).returns(Options) }
-      def merge(other)
-        return dup if other.empty?
-
-        this_hash = to_h
-        other_hash = other.is_a?(Options) ? other.to_h : other
-        return dup if this_hash == other_hash
-
-        new_options = this_hash.merge(other_hash)
-        Options.new(**new_options)
-      end
+      def merge(other) = dup.merge!(other)
 
       # Merges values from `other` into `self` and returns `self`.
       #
@@ -85,6 +76,14 @@ module Homebrew
       sig { params(other: T.any(Options, T::Hash[Symbol, T.untyped])).returns(Options) }
       def merge!(other)
         return self if other.empty?
+
+        # These options are mutually exclusive, so we can't know which should be
+        # used when `other` has both
+        other_post_form = T.let(other.is_a?(Options) ? other.post_form : other[:post_form], Object)
+        other_post_json = T.let(other.is_a?(Options) ? other.post_json : other[:post_json], Object)
+        if other_post_form && other_post_json
+          raise ArgumentError, "Cannot merge provided options using both `post_form` and `post_json`"
+        end
 
         if other.is_a?(Options)
           return self if self == other
@@ -99,6 +98,13 @@ module Homebrew
             cmd = :"#{k}="
             send(cmd, v) if respond_to?(cmd)
           end
+        end
+
+        # Merging one of these options should unset the opposite value in `self`
+        if !other_post_form.nil?
+          @post_json = nil
+        elsif !other_post_json.nil?
+          @post_form = nil
         end
 
         self

--- a/Library/Homebrew/test/livecheck/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_spec.rb
@@ -345,6 +345,17 @@ RSpec.describe Homebrew::Livecheck do
   end
 
   describe "::latest_version" do
+    let(:github_url) { head_url.delete_suffix(".git") }
+
+    let(:f_no_livecheck) do
+      formula("test_no_livecheck") do
+        T.bind(self, T.class_of(Formula))
+        desc "Test formula with no `livecheck` block"
+        homepage "https://github.com/Homebrew/brew"
+        url "https://brew.sh/test-0.0.1.tgz"
+      end
+    end
+
     let(:f_throttle_rate) do
       formula("test_throttle_rate") do
         T.bind(self, T.class_of(Formula))
@@ -453,6 +464,11 @@ RSpec.describe Homebrew::Livecheck do
         <a href="test-0.0.2.tgz">0.0.2</a>
       HTML
     end
+    let(:git_content) do
+      <<~EOS
+        ed9942fbd1ec4243f0a92ab8f9b2411c8b1fb091\trefs/tags/1.2.3
+      EOS
+    end
 
     context "with terminal control characters" do
       let(:terminal_control_version) { "0.0.2\e]0;changed-title\a" }
@@ -495,6 +511,252 @@ RSpec.describe Homebrew::Livecheck do
 
         expect { livecheck.run_checks([f_terminal_control_version], json: true) }
           .to output("#{expected}\n").to_stdout
+      end
+    end
+
+    it "can use a default check when there is no livecheck block" do
+      # Only check the Git URL, so we can ensure the strategy doesn't make
+      # network requests
+      allow(livecheck).to receive(:checkable_urls).with(f_no_livecheck).and_return([github_url])
+      allow(Homebrew::Livecheck::Strategy::Git).to receive(:ls_remote_tags)
+        .and_return({ content: git_content })
+
+      f_jv_version_info = livecheck.latest_version(f_no_livecheck, json: true, verbose: true)
+      expect(f_jv_version_info&.dig(:meta)).not_to include(:references)
+      expect(f_jv_version_info&.dig(:meta, :url, :original)).to eq(github_url)
+      expect(f_jv_version_info&.dig(:meta, :url, :processed)).to eq(head_url)
+      expect(f_jv_version_info&.dig(:latest)).to eq(Version.new("1.2.3"))
+    end
+
+    context "with a referenced formula/cask" do
+      let(:f_options) do
+        formula("test_options") do
+          T.bind(self, T.class_of(Formula))
+          desc "Test formula with `livecheck` block options"
+          homepage "https://brew.sh"
+          url "https://brew.sh/test-0.0.1.tgz"
+
+          livecheck do
+            url :homepage,
+                homebrew_curl: true,
+                post_json:     { key: "value" },
+                user_agent:    :browser
+            regex(/href=.*?test[._-]v?(\d+(?:\.\d+)+)\.(?:t|dmg)/i)
+          end
+        end
+      end
+      let(:f_reference) do
+        formula("test_reference") do
+          T.bind(self, T.class_of(Formula))
+          desc "Test formula referencing another formula"
+          homepage "https://brew.sh"
+          url "https://brew.sh/test-0.0.1.tgz"
+
+          livecheck do
+            formula "test_options"
+          end
+        end
+      end
+      let(:f_reference_with_overrides) do
+        formula("test_reference") do
+          T.bind(self, T.class_of(Formula))
+          desc "Test formula referencing another formula"
+          homepage "https://brew.sh"
+          url "https://brew.sh/test-0.0.1.tgz"
+
+          livecheck do
+            formula "test_options"
+            url "https://brew.sh/test-override-referenced-url/",
+                post_json:  { key: "overridden value" },
+                user_agent: :curl
+          end
+        end
+      end
+      let(:f_reference_no_livecheck) do
+        formula("test_reference") do
+          T.bind(self, T.class_of(Formula))
+          desc "Test formula referencing another formula"
+          homepage "https://brew.sh"
+          url "https://brew.sh/test-0.0.1.tgz"
+
+          livecheck do
+            formula "test_no_livecheck"
+          end
+        end
+      end
+
+      let(:c_options) do
+        Cask::CaskLoader.load(+<<-RUBY)
+          cask "test_options" do
+            version "0.0.1"
+
+            url "https://brew.sh/test-0.0.1.dmg"
+            name "Test"
+            desc "Test cask with `livecheck` block options"
+            homepage "https://brew.sh"
+
+            livecheck do
+              url :homepage,
+                  homebrew_curl: true,
+                  post_json:     { key: "value" },
+                  user_agent:    :browser
+              regex(/href=.*?test[._-]v?(\\d+(?:\\.\\d+)+)\\.(?:t|dmg)/i)
+            end
+          end
+        RUBY
+      end
+      let(:c_reference) do
+        Cask::CaskLoader.load(+<<-RUBY)
+          cask "test_reference" do
+            version "0.0.1"
+
+            url "https://brew.sh/test-0.0.1.dmg"
+            name "Test"
+            desc "Test cask referencing another cask"
+            homepage "https://brew.sh"
+
+            livecheck do
+              cask "test_options"
+            end
+          end
+        RUBY
+      end
+
+      it "uses options from the referenced `livecheck` block" do
+        options_hash = {
+          homebrew_curl: true,
+          post_json:     { key: "value" },
+          user_agent:    :browser,
+        }
+
+        expect(Homebrew::Livecheck::Strategy).to receive(:page_content)
+          .at_least(:once)
+          .with(
+            homepage_url,
+            options: Homebrew::Livecheck::Options.new(**options_hash),
+          ).and_return({ content: base_content })
+
+        expect do
+          livecheck.latest_version(
+            f_reference,
+            referenced_formula_or_cask: f_options,
+            livecheck_references:       [f_options],
+            debug:                      true,
+          )
+        end.to output(
+          a_string_matching(/Formula Ref:\s+test_options/)
+            .and(matching(/URL \(homepage\):\s+#{homepage_url}/))
+            .and(matching(/URL Options:\s+#{options_hash}/)),
+        ).to_stdout
+
+        f_jv_version_info = livecheck.latest_version(
+          f_reference,
+          referenced_formula_or_cask: f_options,
+          livecheck_references:       [f_options],
+          json:                       true,
+          verbose:                    true,
+        )
+        expect(f_jv_version_info&.dig(:meta, :references)).to eq([{ formula: "test_options" }])
+        expect(f_jv_version_info&.dig(:meta, :url, :symbol)).to eq(:homepage)
+        expect(f_jv_version_info&.dig(:meta, :url, :original)).to eq(homepage_url)
+        expect(f_jv_version_info&.dig(:meta, :url, :options)).to eq(options_hash)
+
+        expect do
+          livecheck.latest_version(
+            c_reference,
+            referenced_formula_or_cask: c_options,
+            livecheck_references:       [c_options],
+            debug:                      true,
+          )
+        end.to output(
+          a_string_matching(/Cask Ref:\s+test_options/)
+            .and(matching(/URL \(homepage\):\s+#{homepage_url}/))
+            .and(matching(/URL Options:\s+#{options_hash}/)),
+        ).to_stdout
+
+        c_jv_version_info = livecheck.latest_version(
+          c_reference,
+          referenced_formula_or_cask: c_options,
+          livecheck_references:       [c_options],
+          json:                       true,
+          verbose:                    true,
+        )
+        expect(c_jv_version_info&.dig(:meta, :references)).to eq([{ cask: "test_options" }])
+        expect(c_jv_version_info&.dig(:meta, :url, :symbol)).to eq(:homepage)
+        expect(c_jv_version_info&.dig(:meta, :url, :original)).to eq(homepage_url)
+        expect(c_jv_version_info&.dig(:meta, :url, :options)).to eq(options_hash)
+      end
+
+      it "merges options from the initial `livecheck` block into referenced options" do
+        overridden_url = "https://brew.sh/test-override-referenced-url/"
+        options_hash = {
+          homebrew_curl: true,
+          post_json:     { key: "overridden value" },
+          user_agent:    :curl,
+        }
+
+        expect(Homebrew::Livecheck::Strategy).to receive(:page_content)
+          .at_least(:once)
+          .with(
+            overridden_url,
+            options: Homebrew::Livecheck::Options.new(**options_hash),
+          ).and_return({ content: base_content })
+
+        expect do
+          livecheck.latest_version(
+            f_reference_with_overrides,
+            referenced_formula_or_cask: f_options,
+            livecheck_references:       [f_options],
+            debug:                      true,
+          )
+        end.to output(
+          a_string_matching(/Formula Ref:\s+test_options/)
+            .and(matching(/URL:\s+#{overridden_url}/))
+            .and(matching(/URL Options:\s+#{options_hash}/)),
+        ).to_stdout
+
+        f_jv_version_info = livecheck.latest_version(
+          f_reference_with_overrides,
+          referenced_formula_or_cask: f_options,
+          livecheck_references:       [f_options],
+          json:                       true,
+          verbose:                    true,
+        )
+        expect(f_jv_version_info&.dig(:meta, :references)).to eq([{ formula: "test_options" }])
+        expect(f_jv_version_info&.dig(:meta, :url, :original)).to eq(overridden_url)
+        expect(f_jv_version_info&.dig(:meta, :url, :options)).to eq(options_hash)
+      end
+
+      it "uses values from a referenced package without a `livecheck` block" do
+        # Only check the Git URL, so we can ensure the strategy doesn't make
+        # network requests
+        allow(livecheck).to receive(:checkable_urls).with(f_no_livecheck).and_return([github_url])
+        allow(Homebrew::Livecheck::Strategy::Git).to receive(:ls_remote_tags)
+          .and_return({ content: git_content })
+
+        expect do
+          livecheck.latest_version(
+            f_reference_no_livecheck,
+            referenced_formula_or_cask: f_no_livecheck,
+            livecheck_references:       [f_no_livecheck],
+            debug:                      true,
+          )
+        end.to output(
+          a_string_matching(/Formula Ref:\s+test_no_livecheck/)
+            .and(matching(/URL:\s+#{github_url}/))
+            .and(matching(/URL \(processed\):\s+#{head_url}/)),
+        ).to_stdout
+
+        f_jv_version_info = livecheck.latest_version(
+          f_reference_no_livecheck,
+          referenced_formula_or_cask: f_no_livecheck,
+          livecheck_references:       [f_no_livecheck],
+          json:                       true,
+          verbose:                    true,
+        )
+        expect(f_jv_version_info&.dig(:meta, :references)).to eq([{ formula: "test_no_livecheck" }])
+        expect(f_jv_version_info&.dig(:meta, :url, :original)).to eq(github_url)
+        expect(f_jv_version_info&.dig(:meta, :url, :processed)).to eq(head_url)
       end
     end
 

--- a/Library/Homebrew/test/livecheck/options_spec.rb
+++ b/Library/Homebrew/test/livecheck/options_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe Homebrew::Livecheck::Options do
       header:        header_string,
       homebrew_curl: true,
       post_form:     post_hash,
-      post_json:     post_hash,
       referer:       referer_url,
       user_agent:    :browser,
     }
@@ -34,7 +33,15 @@ RSpec.describe Homebrew::Livecheck::Options do
       post_form: { something: "else" },
     }
   end
+  # `post_form` and `post_json` are mutually exclusive
+  let(:post_json_args) { args.except(:post_form).merge(post_json: post_hash) }
+  let(:other_post_json_args) do
+    {
+      post_json: { something: "else" },
+    }
+  end
   let(:merged_hash) { args.merge(other_args) }
+  let(:post_json_merged_hash) { post_json_args.merge(other_post_json_args) }
   let(:base_options) { options.new(**args) }
   let(:other_options) { options.new(**other_args) }
   let(:merged_options) { options.new(**merged_hash) }
@@ -83,6 +90,12 @@ RSpec.describe Homebrew::Livecheck::Options do
       expect(options.new(**args).merge({}))
         .to eq(options.new(**args))
     end
+
+    it "doesn't modify `self`" do
+      o1 = options.new(**args)
+      expect(o1.merge(other_post_json_args)).to eq(options.new(**post_json_merged_hash))
+      expect(o1).to eq(base_options)
+    end
   end
 
   describe "#merge!" do
@@ -116,6 +129,33 @@ RSpec.describe Homebrew::Livecheck::Options do
       o1 = options.new(**args)
       expect(o1.merge!({ nonexistent: true })).to eq(base_options)
       expect(o1).to eq(base_options)
+    end
+
+    it "unsets the opposite value when `other` sets `post_form` or `post_json`" do
+      o1 = options.new(**args)
+      expect(o1.merge!(options.new(**other_post_json_args))).to eq(options.new(**post_json_merged_hash))
+
+      o2 = options.new(**args)
+      expect(o2.merge!(other_post_json_args)).to eq(options.new(**post_json_merged_hash))
+
+      o3 = options.new(**post_json_args)
+      expect(o3.merge!(other_args)).to eq(merged_options)
+    end
+
+    it "raises an error if `other` sets both `post_form` and `post_json`" do
+      o1 = options.new(**args)
+      expect { o1.merge!({ post_form: post_hash, post_json: post_hash }) }
+        .to raise_error(ArgumentError, /both `post_form` and `post_json`/)
+      expect(o1).to eq(base_options)
+
+      o2 = options.new(**args)
+      expect { o2.merge!(options.new(post_form: post_hash, post_json: post_hash)) }
+        .to raise_error(ArgumentError, /both `post_form` and `post_json`/)
+      expect(o2).to eq(base_options)
+
+      # o3 = options.new(post_form: post_hash, post_json: post_hash)
+      # expect { o3.merge!(options.new(post_form: post_hash, post_json: post_hash)) }
+      #   .to raise_error(ArgumentError, /both `post_form` and `post_json`/)
     end
   end
 

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -179,15 +179,18 @@ RSpec.describe Livecheck do
         referer:       referer_url,
         user_agent:    :browser,
       )
-      livecheck_f.url(url_string, post_json: post_hash)
       expect(livecheck_f.options.compressed).to be(false)
       expect(livecheck_f.options.cookies).to eq(cookies)
       expect(livecheck_f.options.header).to eq(header_str)
       expect(livecheck_f.options.homebrew_curl).to be(true)
       expect(livecheck_f.options.post_form).to eq(post_hash)
-      expect(livecheck_f.options.post_json).to eq(post_hash)
       expect(livecheck_f.options.referer).to eq(referer_url)
       expect(livecheck_f.options.user_agent).to eq(:browser)
+
+      # `post_form` and `post_json` can't be set at the same time
+      livecheck_f.options.post_form = nil
+      livecheck_f.url(url_string, post_json: post_hash)
+      expect(livecheck_f.options.post_json).to eq(post_hash)
 
       header_array = ["Accept: */*", "X-Requested-With: XMLHttpRequest"]
       livecheck_f.url(url_string, header: header_array)
@@ -218,6 +221,20 @@ RSpec.describe Livecheck do
     it "raises an ArgumentError if both `post_form` and `post_json` arguments are provided" do
       expect do
         livecheck_f.url(:stable, post_form: post_hash, post_json: post_hash)
+      end.to raise_error ArgumentError
+    end
+
+    it "raises an ArgumentError if `@options.post_form` is set and `post_json` is provided" do
+      livecheck_f.url(url_string, post_form: post_hash)
+      expect do
+        livecheck_f.url(url_string, post_json: post_hash)
+      end.to raise_error ArgumentError
+    end
+
+    it "raises an ArgumentError if `@options.post_json` is set and `post_form` is provided" do
+      livecheck_f.url(url_string, post_json: post_hash)
+      expect do
+        livecheck_f.url(url_string, post_form: post_hash)
       end.to raise_error ArgumentError
     end
   end


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

I implemented this fix by hand and confirmed it through manual testing. Afterward, I used Claude Code (Opus 5 high) to review the change and implement tests to cover the modified line.

The produced tests covered the primary scenarios involved in the fix but not everything. The tests exercised the code in a basic way (to produce coverage) but didn't check debug or [verbose] JSON output to confirm that the related code works as expected end-to-end. I reworked those tests until I was satisfied with them and added more tests to better test the fix.

I then expanded the tests to provide 100% coverage for all the logic in `latest_version` that relates to referenced `livecheck` blocks and used Claude Code to review the final changes. Overall, AI was helpful for reviewing but I could have implemented the tests entirely by hand from the start (though having AI produce a starting point saved me some typing).

-----

When I introduced `Livecheck::Options` I added some logic in `Livecheck::latest_version` that was intended to fall back to a referenced package's options but that will never happen, as `livecheck.options` is never `nil`. Even if we used `livecheck.options.presence`, it wouldn't work as expected because we want to combine options from the initial `livecheck` block with the referenced check (including overriding an option that they both set). Basically, we should start with the referenced `livecheck` block options (if any) and then merge options from the initial `livecheck` block (so we can override, if necessary).

This was my original idea of how this should work (and part of the reason why I added `Options#merge`) but I didn't catch this oversight until I was testing a referenced `livecheck` block recently. This will become a little trickier if we add support for multi-level references (i.e., A references B which references C and options can be set in each) but this is fairly straightforward for now.

This addresses the issue by reworking how we handle referenced options to ensure we merge when a reference is used in a `livecheck` block. This also adds tests that fail without this fix as well as other tests that provide 100% coverage for reference-related code in `latest_version`.

[If there's any question, the `T.absurd(ref_formula_or_cask) # simplecov:disable` else branches only serve the purpose of getting those case statements to 100% coverage (which isn't possible without an `else` branch). This is something you'll see again in an upcoming PR where I'm expanding livecheck test coverage further.]

------

You can reproduce this issue by running `brew livecheck --debug tableau` (which outputs "URL Options: {user_agent: :browser}") and then compare the output to `brew livecheck --debug tableau-prep` (which omits the user agent option). With the changes in this PR, the user agent option from the referenced check is also present for `tableau-prep`, as intended. [The `tableau-prep` check intermittently works without the `:browser` user agent but this will become a more notable issue when we deprecate the user agent fallback logic in the near future, as the check would fail in that scenario.]