### PR TITLE
Fix shim exec loops and reap timed-out commands

### DIFF
--- a/Library/Homebrew/shims/shared/git
+++ b/Library/Homebrew/shims/shared/git
@@ -17,8 +17,9 @@ fi
 
 source "${HOMEBREW_LIBRARY}/Homebrew/shims/utils.sh"
 
+tool="$(lowercase "${SHIM_FILE}")"
 # shellcheck disable=SC2249
-case "$(lowercase "${SHIM_FILE}")" in
+case "${tool}" in
   git)
     if [[ -n "${HOMEBREW_GIT}" && "${HOMEBREW_GIT}" != git ]]
     then
@@ -38,7 +39,8 @@ safe_exec "${brew_prefix_version}" "$@"
 
 try_exec_non_system "${SHIM_FILE}" "$@"
 
-if executable "/usr/bin/xcode-select"
+# Xcode has not shipped svn since 11.4, so only git can be found by xcrun.
+if [[ "${tool}" == "git" ]] && executable "/usr/bin/xcode-select"
 then
   # xcode-select will return empty on no Xcode/CLT configuration.
   #   /usr/bin/<tool> will be a popup stub under such configuration.
@@ -50,7 +52,9 @@ then
   fi
   if [[ -z "${popup_stub}" && "${xcode_path}" != "/" ]]
   then
-    path="$(/usr/bin/xcrun -find "${SHIM_FILE}" 2>/dev/null)"
+    # xcrun falls back to searching PATH (already searched above) and caches
+    # what it finds there, even a Homebrew shim, for every later xcrun -find.
+    path="$(PATH=/usr/bin:/bin /usr/bin/xcrun -find "${SHIM_FILE}" 2>/dev/null)"
     safe_exec "${path}" "$@"
   fi
 fi

--- a/Library/Homebrew/shims/utils.sh
+++ b/Library/Homebrew/shims/utils.sh
@@ -56,8 +56,12 @@ safe_exec() {
   then
     return
   fi
-  # prevent fork-bombs
-  if [[ "$(lowercase "${arg0}")" == "${SHIM_FILE}" || "$(realpath "${arg0}")" == "${SHIM_REAL}" ]]
+  # prevent fork-bombs and exec loops between this shim and the same shared
+  # shim in another Homebrew checkout (found on PATH or by a stale xcrun cache)
+  local arg0_real
+  arg0_real="$(realpath "${arg0}")"
+  if [[ "$(lowercase "${arg0}")" == "${SHIM_FILE}" || "${arg0_real}" == "${SHIM_REAL}" ||
+        "${arg0_real}" == */shims/shared/"${SHIM_REAL##*/}" ]]
   then
     return
   fi

--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -382,9 +382,31 @@ module Homebrew
 
       files.each_slice((files.length.to_f / chunk_count).ceil).map do |chunk|
         Thread.new do
-          system_command shellcheck_path, args: [*args, "--", *chunk], print_stderr: false
+          run_linter(shellcheck_path, [*args, "--"], chunk, timeout: SHELLCHECK_TIMEOUT)
         end
       end.map(&:value)
+    end
+
+    # In CI `brew style` takes ~70s on Homebrew/brew and ~140s on the official
+    # taps, nearly all of it RuboCop; each of these linters needs a few seconds.
+    SHELLCHECK_TIMEOUT = 60
+    SHFMT_TIMEOUT = 60
+    ACTIONLINT_TIMEOUT = 30
+
+    sig {
+      params(
+        executable: T.any(String, Pathname),
+        args:       T::Array[T.any(String, Pathname)],
+        files:      T::Array[Pathname],
+        timeout:    Integer,
+        env:        T::Hash[String, String],
+      ).returns(SystemCommand::Result)
+    }
+    private_class_method def self.run_linter(executable, args, files, timeout:, env: {})
+      system_command executable, args: [*args, *files], env:, print_stderr: false, timeout:
+    rescue Timeout::Error
+      raise Timeout::Error, "#{Pathname(executable).basename} did not finish within #{timeout}s on " \
+                            "#{files.length} file(s)."
     end
 
     sig {
@@ -403,13 +425,10 @@ module Homebrew
       files.delete(HOMEBREW_REPOSITORY/"completions/bash/brew")
       files.delete(HOMEBREW_REPOSITORY/"Dockerfile")
 
-      args = ["--language-dialect", "bash", "--indent", "2", "--case-indent", "--", *files]
+      args = ["--language-dialect", "bash", "--indent", "2", "--case-indent", "--"]
       args.unshift("--write") if fix # need to add before "--"
 
-      result = system_command shfmt,
-                              args:,
-                              env:          { "HOMEBREW_SHFMT" => shfmt_path.to_s },
-                              print_stderr: false
+      result = run_linter(shfmt, args, files, timeout: SHFMT_TIMEOUT, env: { "HOMEBREW_SHFMT" => shfmt_path.to_s })
       out.print result.stdout
       err.print result.stderr
       result.success?
@@ -449,7 +468,7 @@ module Homebrew
               "-ignore", "image: string; options: string",
               "-ignore", "label .* is unknown"]
       args << "-color" if Tty.color?
-      result = system_command actionlint_path, args: [*args, *files], print_stderr: false
+      result = run_linter(actionlint_path, args, files, timeout: ACTIONLINT_TIMEOUT)
       out.print result.stdout
       err.print result.stderr
       result.success?

--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -421,7 +421,24 @@ class SystemCommand
     end
 
     end_time = Time.now + @timeout if @timeout
-    raise Timeout::Error if raw_wait_thr.join(Utils::Timer.remaining(end_time)).nil?
+    if raw_wait_thr.join(Utils::Timer.remaining(end_time)).nil?
+      # Signal the whole process group so a timed-out command and its descendants
+      # cannot outlive brew. `sudo` children share our group, so signal them directly.
+      target = sudo? ? raw_wait_thr.pid : -raw_wait_thr.pid
+      begin
+        Process.kill("TERM", target)
+        # `kill(0)` raises `ESRCH` once every process in the group has exited
+        # (`EPERM` on macOS while only unreaped zombies remain).
+        50.times do
+          Process.kill(0, target)
+          sleep 0.1
+        end
+        Process.kill("KILL", target)
+      rescue Errno::ESRCH, Errno::EPERM
+        nil
+      end
+      raise Timeout::Error
+    end
 
     @status = T.let(raw_wait_thr.value, T.nilable(Process::Status))
   rescue Interrupt

--- a/Library/Homebrew/test/shims/shared/git_spec.rb
+++ b/Library/Homebrew/test/shims/shared/git_spec.rb
@@ -1,0 +1,32 @@
+# typed: true
+# frozen_string_literal: true
+
+require "fileutils"
+require "system_command"
+
+RSpec.describe "shims/shared/git", type: :system do
+  let(:tool) { "homebrew-shim-test" }
+
+  it "does not exec itself from outside shims/shared" do
+    shims_dir = mktmpdir/"Library/Homebrew/shims/super"
+    shims_dir.mkpath
+    FileUtils.cp HOMEBREW_SHIMS_PATH/"shared/git", shims_dir/tool
+    ENV["PATH"] = PATH.new(ENV.fetch("PATH")).prepend(shims_dir).to_s
+
+    expect(SystemCommand.run(shims_dir/tool, timeout: 10).stderr).to eq("You must: brew install #{tool}\n")
+  end
+
+  it "does not exec the same shim from another Homebrew checkout" do
+    shims_dirs = %w[a b].map do |checkout|
+      shims_dir = mktmpdir/checkout/"Library/Homebrew/shims/shared"
+      shims_dir.mkpath
+      FileUtils.cp HOMEBREW_SHIMS_PATH/"shared/git", shims_dir
+      FileUtils.ln_s "git", shims_dir/tool
+      shims_dir
+    end
+    ENV["PATH"] = PATH.new(ENV.fetch("PATH")).prepend(*shims_dirs).to_s
+
+    expect(SystemCommand.run(shims_dirs.fetch(0)/tool, timeout: 10).stderr)
+      .to eq("You must: brew install #{tool}\n")
+  end
+end

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -254,11 +254,6 @@ RSpec.configure do |config|
 
     svn_paths = PATH.new(ENV.fetch("PATH"))
 
-    if OS.mac?
-      xcrun_svn = Utils.popen_read("xcrun", "-f", "svn")
-      svn_paths.append(File.dirname(xcrun_svn)) if $CHILD_STATUS.success? && xcrun_svn.present?
-    end
-
     svn_shim = HOMEBREW_SHIMS_PATH/"shared/svn"
     unless quiet_system svn_shim, "--version"
       svn_client_skip_reason = "Subversion is not installed."

--- a/Library/Homebrew/test/style_spec.rb
+++ b/Library/Homebrew/test/style_spec.rb
@@ -79,7 +79,9 @@ RSpec.describe Homebrew::Style do
                        "-ignore", "image: string; options: string",
                        "-ignore", "label .* is unknown",
                        workflow],
+        env:          {},
         print_stderr: false,
+        timeout:      30,
       ).and_return(actionlint_result)
 
       described_class.run_actionlint!([workflow])
@@ -99,7 +101,9 @@ RSpec.describe Homebrew::Style do
                        "-ignore", "image: string; options: string",
                        "-ignore", "label .* is unknown",
                        workflow],
+        env:          {},
         print_stderr: false,
+        timeout:      30,
       ).and_return(actionlint_result)
 
       described_class.run_actionlint!([workflow])
@@ -125,7 +129,9 @@ RSpec.describe Homebrew::Style do
                        "-ignore", "image: string; options: string",
                        "-ignore", "label .* is unknown",
                        workflow1, workflow2],
+        env:          {},
         print_stderr: false,
+        timeout:      30,
       ).and_return(actionlint_result)
 
       described_class.run_actionlint!([workflow1, workflow2])
@@ -178,6 +184,7 @@ RSpec.describe Homebrew::Style do
         args:         ["--language-dialect", "bash", "--indent", "2", "--case-indent", "--", shell_file],
         env:          { "HOMEBREW_SHFMT" => "/usr/bin/shfmt" },
         print_stderr: false,
+        timeout:      60,
       ).and_return(shfmt_result)
 
       expect(described_class.run_shfmt!([shell_file])).to be true
@@ -212,6 +219,19 @@ RSpec.describe Homebrew::Style do
       first_chunk = chunks.find { |chunk| chunk.include?("script1.sh") }
       expect(first_chunk).to include("script2.sh")
       expect(first_chunk).not_to include("script3.sh")
+    end
+
+    it "raises a descriptive error when shellcheck exceeds its timeout" do
+      stub_const("Homebrew::Style::SHELLCHECK_TIMEOUT", 1)
+      dir = mktmpdir
+      slow_shellcheck = dir/"shellcheck"
+      slow_shellcheck.write "#!/bin/bash\nsleep 30\n"
+      slow_shellcheck.chmod 0755
+      file = dir/"script.sh"
+      file.write "#!/bin/bash\n"
+
+      expect { described_class.run_shellcheck([file], :json, shellcheck_path: slow_shellcheck) }
+        .to raise_error(Timeout::Error, "shellcheck did not finish within 1s on 1 file(s).")
     end
   end
 

--- a/Library/Homebrew/test/system_command_spec.rb
+++ b/Library/Homebrew/test/system_command_spec.rb
@@ -285,6 +285,23 @@ RSpec.describe SystemCommand do
     end
   end
 
+  context "when the timeout expires" do
+    it "kills the whole process group, including descendants ignoring TERM" do
+      pid_file = mktmpdir/"pid"
+      script = "(trap '' TERM; exec sleep 30) & echo $! > #{pid_file}; wait"
+      expect { described_class.run("/bin/sh", args: ["-c", script], timeout: 0.5) }.to raise_error(Timeout::Error)
+
+      grandchild_pid = pid_file.read.to_i
+      # The orphaned grandchild is reaped by `init`/`launchd` asynchronously.
+      expect do
+        10.times do
+          Process.kill(0, grandchild_pid)
+          sleep(0.1)
+        end
+      end.to raise_error(Errno::ESRCH)
+    end
+  end
+
   context "when given an invalid variable name" do
     it "raises an ArgumentError" do
       expect { described_class.run("true", env: { "1ABC" => true }) }


### PR DESCRIPTION
- `xcrun -find` falls back to a PATH search and caches the result regardless of PATH, so one `brew` run with `shims/shared` on PATH left every later `xcrun -find svn` returning that checkout's shim.
- `safe_exec` only refused to exec its own file, so shims from two checkouts exec'd each other forever, forking subshells on every hop and outliving the `brew` that started them.
- Refuse to exec the same shim from any checkout, run `xcrun` with a system-only PATH and skip `xcrun` for `svn`, which Xcode has not shipped since 11.4. Drop the matching dead `xcrun -f svn` test setup.
- `SystemCommand` raised `Timeout::Error` but left the child running; signal its process group so timed-out commands cannot become orphans.
- Bound `shellcheck`, `shfmt` and `actionlint` so a stuck linter names the tool and file count instead of hanging `brew style` indefinitely. In CI the whole `brew style` step takes ~70s on Homebrew/brew and ~140s on the official taps, almost all RuboCop, while these linters finish in seconds, so 60s/60s/30s leave ample headroom.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude with Fable at Extra High effort, with local review and testing.

-----