### PR TITLE
Add cask audit for versioned app_image targets

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -388,6 +388,36 @@ module Cask
     end
 
     sig { void }
+    def audit_appimage_versioned_target
+      # `app_image` artifacts live inside `on_linux` blocks,
+      # so an audit running on another OS would not materialize them.
+      # Evaluate every tag (restoring the default afterwards)
+      # so the check runs regardless of the audit host.
+      basenames = if cask.on_system_blocks_exist?
+        begin
+          OnSystem::VALID_OS_ARCH_TAGS.flat_map do |tag|
+            cask.refresh_for_tag(tag) { appimage_target_basenames } || []
+          end
+        ensure
+          cask.refresh
+        end
+      else
+        appimage_target_basenames
+      end
+
+      basenames.uniq.each do |basename|
+        # electron-updater renames the AppImage on self-update
+        # if its basename contains an `X.Y.Z` version,
+        # which leaves the Caskroom back-symlink dangling.
+        # A version-less target is overwritten in place instead.
+        next unless basename.match?(/\d+\.\d+\.\d+/)
+
+        add_error "app_image target '#{basename}' should not embed a version; " \
+                  "use a version-less `target:` so self-updaters overwrite it in place"
+      end
+    end
+
+    sig { void }
     def audit_no_string_version_latest
       return unless cask.version
 
@@ -1219,6 +1249,15 @@ module Cask
     end
 
     private
+
+    sig { returns(T::Array[String]) }
+    def appimage_target_basenames
+      cask.artifacts.filter_map do |artifact|
+        next unless artifact.is_a?(Artifact::AppImage)
+
+        artifact.target.basename.to_s
+      end
+    end
 
     # Rewrites the cask's source file when `--fix` was passed, restoring it if
     # the rewrite doesn't load. Returns whether the problem was corrected.

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -211,6 +211,95 @@ RSpec.describe Cask::Audit, :cask do
       end
     end
 
+    describe "app_image versioned target" do
+      let(:only) { ["appimage_versioned_target"] }
+      let(:error) { /app_image target .* should not embed a version/ }
+
+      context "when the target embeds an X.Y.Z version via the source basename" do
+        let(:cask) do
+          Cask::Cask.new("appimage-versioned-source") do
+            version "1.2.3"
+            sha256 :no_check
+            url "https://brew.sh/foo"
+            name "AppImage Versioned Source"
+            homepage "https://brew.sh/"
+            app_image "foo_#{version}_linux.AppImage"
+          end
+        end
+
+        it { is_expected.to error_with(error) }
+      end
+
+      context "when an explicit target embeds an X.Y.Z version" do
+        let(:cask) do
+          Cask::Cask.new("appimage-versioned-target") do
+            version "1.2.3"
+            sha256 :no_check
+            url "https://brew.sh/foo"
+            name "AppImage Versioned Target"
+            homepage "https://brew.sh/"
+            app_image "foo.AppImage", target: "Foo-#{version}.AppImage"
+          end
+        end
+
+        it { is_expected.to error_with(error) }
+      end
+
+      context "when the target is version-less" do
+        let(:cask) do
+          Cask::Cask.new("appimage-versionless-target") do
+            version "1.2.3"
+            sha256 :no_check
+            url "https://brew.sh/foo"
+            name "AppImage Version-less Target"
+            homepage "https://brew.sh/"
+            app_image "foo_#{version}.AppImage", target: "Foo.AppImage"
+          end
+        end
+
+        it { is_expected.not_to error_with(error) }
+      end
+
+      context "when the target embeds only the major version" do
+        let(:cask) do
+          Cask::Cask.new("appimage-major-version-target") do
+            version "2.1.0"
+            sha256 :no_check
+            url "https://brew.sh/foo"
+            name "AppImage Major Version Target"
+            homepage "https://brew.sh/"
+            app_image "foo.AppImage", target: "Foo#{version.major}.AppImage"
+          end
+        end
+
+        it { is_expected.not_to error_with(error) }
+      end
+
+      context "when a versioned AppImage is scoped to on_linux and audited on macOS" do
+        let(:cask) do
+          Homebrew::SimulateSystem.with(os: :sequoia, arch: :arm) do
+            Cask::Cask.new("appimage-on-linux") do
+              version "1.2.3"
+              sha256 :no_check
+              url "https://brew.sh/foo"
+              name "AppImage On Linux"
+              homepage "https://brew.sh/"
+
+              on_macos do
+                app "Foo.app"
+              end
+
+              on_linux do
+                app_image "foo_#{version}_linux.AppImage"
+              end
+            end
+          end
+        end
+
+        it { is_expected.to error_with(error) }
+      end
+    end
+
     describe "checking homepage availability" do
       let(:online) { true }
       let(:only) { ["homepage_https_availability"] }


### PR DESCRIPTION
_Note: this is a follow up to #23771._

The `app_image` stanza installs an AppImage whose effective target (the explicit `target:` if it exists, or the source basename otherwise) becomes the user-facing filename. If that filename embeds an `X.Y.Z` version, a self-update performed via electron-updater renames it on disk and leaves the previous Caskroom symlink dangling.

This audit guards against reintroducing that situation. For each `Artifact::AppImage`, it checks the resolved target basename against electron-updater's own version heuristic (`/\d+\.\d+\.\d+/`) and errors if it matches, nudging the cask toward a version-less `target:` that self-updaters overwrite in place.

The check lives in the runtime auditor rather than a RuboCop cop so that it can capture both hardcoded version strings and interpolations like `target: "foo_#{version}.AppImage"`. Only once the cask is loaded is `version` resolved, so a source-level cop cannot tell whether it yields an `X.Y.Z` string. `Relocated#target` already computes the effective target with the source-basename fallback and interpolation applied, so the audit just reads `artifact.target.basename`.

Because `app_image` is Linux-only, it lives inside an `on_linux` block, so a cask audited on another OS would not materialize it. The audit therefore evaluates the cask under every OS/arch tag (via `refresh_for_tag`, restoring the default afterwards) and deduplicates the resulting targets, so it runs regardless of the audit host.

Note: the audit intentionally does not require an explicit `target:`. Since it defaults to the source basename, and the audit checks the _resolved_ target, it catches both a versioned target and a missing target + versioned source basename. Requiring an explicit `target:` would also diverge from the `app` stanza, which has no such requirement.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?
  _Note_: `brew lgtm` passes `brew typecheck` and `brew style --changed --fix`, but on my Linux machine `brew tests --changed` cannot run due to missing the Fiddle library.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

I used Kiro CLI to help draft this change and its tests, and validated the correctness by running the tests locally.

-----
