### PR TITLE
Make macOS installer package Apple Silicon only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,21 +231,11 @@ jobs:
           path: Homebrew-${{ steps.homebrew-version.outputs.version }}.pkg
   test:
     needs: build
-    name: "test (${{matrix.name}})"
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        include:
-          # Intel
-          # Keep building and testing the installer on Tier 3 Intel macOS for now.
-          - runner: macos-15-intel
-            name: macos-15-x86_64
-          # Apple Silicon
-          - runner: macos-15
-            name: macos-15-arm64
-          - runner: macos-26
-            name: macos-26-arm64
+        runner: [macos-15, macos-26]
     steps:
       - name: Download installer from GitHub Actions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -257,9 +247,9 @@ jobs:
 
       - name: Remove existing Homebrew installations
         run: |
-          sudo rm -rf brew /{usr/local,opt/homebrew}/{Cellar,Caskroom,Homebrew/Library/Taps}
+          sudo rm -rf brew /opt/homebrew/{Cellar,Caskroom,Homebrew/Library/Taps}
           brew cleanup --prune-prefix
-          sudo rm -rf /usr/local/{bin/brew,Homebrew} /opt/homebrew /home/linuxbrew
+          sudo rm -rf /opt/homebrew /home/linuxbrew
 
       - name: Zero existing installer logs
         run: echo | sudo tee /var/log/install.log
@@ -285,8 +275,7 @@ jobs:
 
       - run: brew config
 
-      - if: matrix.name != 'macos-15-x86_64'
-        run: brew doctor
+      - run: brew doctor
 
       - name: Zero existing installer logs (again)
         run: echo | sudo tee /var/log/install.log
@@ -302,8 +291,7 @@ jobs:
 
       - run: brew config
 
-      - if: matrix.name != 'macos-15-x86_64'
-        run: brew doctor
+      - run: brew doctor
 
   upload:
     needs: [build, test]

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -8,7 +8,7 @@ Instructions for a supported install of Homebrew are on the [homepage](https://b
 
 The script installs Homebrew to its default prefix (`/opt/homebrew` for Apple Silicon, `/usr/local` for macOS Intel and `/home/linuxbrew/.linuxbrew` for Linux) so that [you don’t need *sudo* after Homebrew's initial installation](FAQ.md#why-does-homebrew-say-sudo-is-bad) when you `brew install`. This prefix is required for most bottles (binary packages) to be used. It is a careful script; it can be run even if you have stuff installed in the preferred prefix already. It tells you exactly what it will do before it does it too. You have to confirm everything it will do before it starts.
 
-The macOS `.pkg` installer also installs Homebrew to its default prefix (`/opt/homebrew` for Apple Silicon and `/usr/local` for macOS Intel) for the same reasons as above.
+The macOS `.pkg` installer supports only Apple Silicon and also installs Homebrew to its default prefix (`/opt/homebrew`) for the same reasons as above.
 It is available on [Homebrew/brew's latest GitHub release](https://github.com/Homebrew/brew/releases/latest).
 To specify an alternate install user, such as when the package is installed at the login window before a user has logged in, create `/var/tmp/.homebrew_pkg_user.plist` with a `HOMEBREW_PKG_USER` value before installation:
 

--- a/package/Distribution.xml
+++ b/package/Distribution.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <installer-gui-script minSpecVersion="2">
   <pkg-ref id="sh.brew.homebrew"/>
-  <options customize="never" hostArchitectures="x86_64,arm64" rootVolumeOnly="true"/>
+  <options customize="never" hostArchitectures="arm64" rootVolumeOnly="true"/>
   <volume-check>
     <allowed-os-versions>
         <os-version min="14.0.0"/>
@@ -32,33 +32,15 @@
 
   <script>
     // See https://developer.apple.com/documentation/installer_js
-    function is_intel() {
-      try {
-        // `hw.machine` exists on both architectures. An unavailable lookup can
-        // return a falsey value instead of throwing, so compare positively.
-        return system.sysctl("hw.machine") == "x86_64";
-      } catch (error) {
-        // Never warn a Tier 1 Mac just because the probe failed.
-        return false;
-      }
-    }
-
     function installation_check() {
-      if (!system.files.fileExistsAtPath("/Library/Developer/CommandLineTools/usr/bin/git")) {
+      if (system.files.fileExistsAtPath("/Library/Developer/CommandLineTools/usr/bin/git")) {
+        return true;
+      } else {
         my.result.title = "Command Line Tools (CLT) are missing";
         my.result.message = "You must install the Command Line Tools (CLT) before installing Homebrew by running `xcode-select --install` from a Terminal.";
         my.result.type = "Fatal";
         return false;
       }
-
-      if (is_intel()) {
-        my.result.title = "Intel Macs are a Tier 3 configuration";
-        my.result.message = "Homebrew no longer routinely builds bottles for Intel Macs, so packages will increasingly be built from source, and issues affecting only Intel may be closed without investigation. See https://docs.brew.sh/Support-Tiers#tier-3";
-        my.result.type = "Warning";
-        return false;
-      }
-
-      return true;
     }
   </script>
   <installation-check script="installation_check()" />

--- a/package/resources/CONCLUSION.rtf
+++ b/package/resources/CONCLUSION.rtf
@@ -36,10 +36,7 @@ Homebrew is run entirely by unpaid volunteers. Please consider donating:\
 \pard\tx940\tx1440\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li1440\fi-1440\pardirnatural\partightenfactor0
 \ls3\ilvl1\cf0 {\listtext	\uc0\u8259 	}
 \f2 eval "$(/opt/homebrew/bin/brew shellenv)"
-\f1  on Apple Silicon\
-\ls3\ilvl1{\listtext	\uc0\u8259 	}
-\f2 eval "$(/usr/local/bin/brew shellenv)"
-\f1  on Intel\
+\f1 \
 \pard\tx220\tx720\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li720\fi-720\pardirnatural\partightenfactor0
 \ls3\ilvl0\cf0 {\listtext	\uc0\u8259 	}Run 
 \f2 brew help

--- a/package/resources/WELCOME.rtf
+++ b/package/resources/WELCOME.rtf
@@ -10,11 +10,5 @@
 \f0\fs24 \cf0 This package will install to:\
 \pard\tx220\tx720\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li720\fi-720\pardirnatural\partightenfactor0
 \ls1\ilvl0\cf0 {\listtext	\uc0\u8259 	}
-\f1 /opt/homebrew
-\f0  on Apple Silicon\
-{\listtext	\uc0\u8259 	}
-\f1 /usr/local/bin/brew
-\f0  and 
-\f1 /usr/local/Homebrew
-\f0  on Intel\
+\f1 /opt/homebrew\
 }

--- a/package/scripts/postinstall
+++ b/package/scripts/postinstall
@@ -52,34 +52,6 @@ git_no_hooks -C "${homebrew_directory}" reset --hard "${latest_tag}"
 git_no_hooks -C "${homebrew_directory}" clean -f -d
 rm -f "${homebrew_directory}/.gitconfig"
 
-# move to /usr/local if on x86_64
-if [[ $(uname -m) == "x86_64" ]]
-then
-  if [[ -f "/usr/local/bin/brew" && -d "/usr/local/Homebrew" ]]
-  then
-    cp -pRL "${homebrew_directory}/.git" "/usr/local/Homebrew/"
-    mv "${homebrew_directory}/cache_api" "/usr/local/Homebrew/"
-
-    export HOME="/usr/local/Homebrew"
-    rm -rf "/usr/local/Homebrew/.git/hooks" "/usr/local/Homebrew/.gitconfig" "/usr/local/Homebrew/.config/git"
-    git config --global --add safe.directory "/usr/local/Homebrew"
-    git_no_hooks -C "/usr/local/Homebrew" checkout --force -B stable
-    git_no_hooks -C "/usr/local/Homebrew" reset --hard
-    git_no_hooks -C "/usr/local/Homebrew" clean -f -d
-    rm -f "/usr/local/Homebrew/.gitconfig"
-  else
-    mkdir -vp /usr/local/bin
-    mv "${homebrew_directory}" "/usr/local/Homebrew/"
-
-    # create symlink to /usr/local/bin/brew
-    ln -svf "../Homebrew/bin/brew" "/usr/local/bin/brew"
-  fi
-
-  rm -rf "${homebrew_directory}"
-  homebrew_directory="/usr/local/Homebrew"
-  cd /usr/local
-fi
-
 refuse_symlinked_directories() {
   for dir in Caskroom Cellar Frameworks bin etc include lib opt sbin share var var/homebrew var/homebrew/linked
   do
@@ -140,14 +112,7 @@ chmod -h ug=rwx Caskroom Cellar Frameworks bin etc include lib opt sbin share va
   enter_managed_directory linked "${prefix_directory}/var/homebrew/linked" var/homebrew/linked
   chmod ug=rwx .
 )
-if [[ "${homebrew_directory}" == "/usr/local/Homebrew" ]]
-then
-  chown -h "${homebrew_pkg_user}:admin" bin bin/brew etc include lib opt sbin share var
-  chown -h -R "${homebrew_pkg_user}:admin" Caskroom Cellar Frameworks Homebrew var/homebrew
-  chown -h -R "${homebrew_pkg_user}" etc include share var
-else
-  chown -R "${homebrew_pkg_user}:admin" .
-fi
+chown -R "${homebrew_pkg_user}:admin" .
 
 # move API cache to ~/Library/Caches/Homebrew
 user_home_dir="$(homebrew-user-home "${homebrew_pkg_user}")" ||
@@ -162,11 +127,9 @@ cp -vpR "${homebrew_directory}/cache_api/." "${user_api_cache_dir}"
 chown -R "${homebrew_pkg_user}:staff" "${user_cache_dir}"
 rm -vrf "${homebrew_directory}/cache_api"
 
-# create paths.d file for /opt/homebrew installs
-# (/usr/local/bin is already in the PATH)
-if [[ -d "/etc/paths.d" && "${homebrew_directory}" == "/opt/homebrew" ]]
+# add Homebrew to the default PATH
+if [[ -d "/etc/paths.d" ]]
 then
-  mkdir -vp /etc/paths.d
-  echo "/opt/homebrew/bin" >/etc/paths.d/homebrew
+  echo "${homebrew_directory}/bin" >/etc/paths.d/homebrew
   chown root:wheel /etc/paths.d/homebrew
 fi


### PR DESCRIPTION
- Intel macOS is a Tier 3 configuration without new bottles, so stop shipping and testing the `.pkg` installer there.
- `hostArchitectures="arm64"` makes Installer refuse to run on Intel Macs rather than warn, leaving the `/usr/local` relocation in `postinstall`, the Intel welcome and conclusion text and the `macos-15-intel` test runner as dead code.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude with Fable at Extra High effort, with local review and testing.

-----