### PR TITLE
api/formula/formula_struct_generator: defer placeholder replacement

### DIFF
--- a/Library/Homebrew/api/formula/formula_struct_generator.rb
+++ b/Library/Homebrew/api/formula/formula_struct_generator.rb
@@ -43,10 +43,6 @@ module Homebrew
         def generate_formula_struct_hash(hash, bottle_tag: Homebrew::SimulateSystem.current_tag)
           hash = Homebrew::API.merge_variations(hash, bottle_tag:).dup.deep_stringify_keys
 
-          if (caveats = hash["caveats"])
-            hash["caveats"] = Formulary.replace_placeholders(caveats)
-          end
-
           hash["bottle_checksums"] = begin
             files = hash.dig("bottle", "stable", "files") || {}
             files.map do |tag, bottle_spec|

--- a/Library/Homebrew/test/api/formula/formula_struct_generator_spec.rb
+++ b/Library/Homebrew/test/api/formula/formula_struct_generator_spec.rb
@@ -135,45 +135,69 @@ RSpec.describe Homebrew::API::Formula::FormulaStructGenerator do
     ).to eq [[], []]
   end
 
-  specify "::generate_formula_struct_hash falls back to stable deps when head_dependencies is absent" do
-    hash = {
-      "desc"                     => "Test formula",
-      "homepage"                 => "https://example.com",
-      "license"                  => "MIT",
-      "ruby_source_checksum"     => { "sha256" => "abc123" },
-      "versions"                 => { "stable" => "1.0.0" },
-      "urls"                     => { "stable" => { "url" => "https://example.com/foo-1.0.tar.gz" } },
-      "dependencies"             => ["foo"],
-      "recommended_dependencies" => [],
-      "optional_dependencies"    => [],
-      "uses_from_macos"          => [],
-      "uses_from_macos_bounds"   => [],
-    }
+  describe "::generate_formula_struct_hash" do
+    subject(:struct) { described_class.generate_formula_struct_hash(hash) }
 
-    struct = described_class.generate_formula_struct_hash(hash)
+    let(:hash) do
+      {
+        "desc"                 => "Test formula",
+        "homepage"             => "https://example.com",
+        "license"              => "MIT",
+        "ruby_source_checksum" => { "sha256" => "abc123" },
+        "versions"             => { "stable" => "1.0.0" },
+        "urls"                 => { "stable" => { "url" => "https://example.com/foo-1.0.tar.gz" } },
+      }
+    end
 
-    expect(struct.head_dependencies).not_to be_empty
-    expect(struct.head_dependencies).to eq struct.stable_dependencies
-  end
+    it "falls back to stable deps when head_dependencies is absent" do
+      hash.update({
+        "dependencies"             => ["foo"],
+        "recommended_dependencies" => [],
+        "optional_dependencies"    => [],
+        "uses_from_macos"          => [],
+        "uses_from_macos_bounds"   => [],
+      })
+      expect(struct.head_dependencies).not_to be_empty
+      expect(struct.head_dependencies).to eq struct.stable_dependencies
+    end
 
-  specify "::generate_formula_struct_hash preserves stable patches" do
-    hash = {
-      "desc"                 => "Test formula",
-      "homepage"             => "https://example.com",
-      "license"              => "MIT",
-      "ruby_source_checksum" => { "sha256" => "abc123" },
-      "versions"             => { "stable" => "1.0.0" },
-      "urls"                 => { "stable" => { "url" => "https://example.com/foo-1.0.tar.gz" } },
-      "patches"              => [
-        {
-          "strip"  => "p1",
-          "url"    => "https://example.com/foo.patch",
-          "sha256" => "def456",
-        },
-      ],
-    }
+    it "preserves stable patches" do
+      hash.update({
+        "patches" => [
+          {
+            "strip"  => "p1",
+            "url"    => "https://example.com/foo.patch",
+            "sha256" => "def456",
+          },
+        ],
+      })
+      expect(struct.stable_patches).to eq hash["patches"]
+    end
 
-    expect(described_class.generate_formula_struct_hash(hash).stable_patches).to eq hash["patches"]
+    context "when input contains placeholders" do
+      let(:caveats_with_placeholder) { "Message about $HOMEBREW_CELLAR/foo/1.0.0/bin/foo" }
+      let(:log_path_with_placeholder) { "$HOMEBREW_PREFIX/var/log/foo.log" }
+
+      before do
+        stub_const("HOMEBREW_PREFIX", "/tmp/homebrew")
+        stub_const("HOMEBREW_CELLAR", "/tmp/homebrew/Cellar")
+        hash.update({
+          "caveats"      => caveats_with_placeholder,
+          "service_args" => [[:log_path, log_path_with_placeholder]],
+        })
+      end
+
+      it "replaces them when not generating JSON" do
+        expect(struct.caveats).to eq "Message about /tmp/homebrew/Cellar/foo/1.0.0/bin/foo"
+        expect(struct.service_args).to eq [[:log_path, "/tmp/homebrew/var/log/foo.log"]]
+      end
+
+      it "preserves them when generating JSON" do
+        allow(Formula).to receive(:generating_hash?).and_return(true)
+        expect(struct.caveats).to eq caveats_with_placeholder
+        expect(struct.service_args).to eq [[:log_path, log_path_with_placeholder]]
+      end
+    end
   end
 
   specify "::symbolize_dependency_hash" do


### PR DESCRIPTION
This method runs `FormulaStruct.from_hash` at the end which will call `::Formula.deep_remove_placeholders`. The latter detects if generating JSON so that placeholders are preserved until loaded by user.

https://github.com/Homebrew/brew/blob/8d49bd078bff5afee5820cf801d62856a42b8f5c/Library/Homebrew/api/formula_struct.rb#L12-L13

https://github.com/Homebrew/brew/blob/8d49bd078bff5afee5820cf801d62856a42b8f5c/Library/Homebrew/api_hashable.rb#L29-L30

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
