### PR TITLE
services: resolve owner from the registered service file

### DIFF
--- a/Library/Homebrew/services/formula_wrapper.rb
+++ b/Library/Homebrew/services/formula_wrapper.rb
@@ -279,6 +279,8 @@ module Homebrew
           plist_username = plist["UserName"] if plist
 
           return plist_username if plist_username.present?
+          return "root" if registered_destination.dirname == System.boot_path
+          return System.user if registered_destination.dirname == System.user_path
         end
         return "root" if boot_path_service_file_present?
         return System.user if user_path_service_file_present?

--- a/Library/Homebrew/test/services/formula_wrapper_spec.rb
+++ b/Library/Homebrew/test/services/formula_wrapper_spec.rb
@@ -337,6 +337,46 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
       expect(service.owner).to eq("_serviced")
     end
 
+    it "prefers the active user service when a compatible root service also exists" do
+      plist = mktmpdir/"sh.brew.mysql.plist"
+      plist.write <<~XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+          <dict>
+            <key>Label</key>
+            <string>sh.brew.mysql</string>
+          </dict>
+        </plist>
+      XML
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: true, user: "user", user_path: plist.dirname)
+      allow(service).to receive_messages(registered_destination:          plist,
+                                         boot_path_service_file_present?: true,
+                                         user_path_service_file_present?: true)
+
+      expect(service.owner).to eq("user")
+    end
+
+    it "prefers the active root service when a compatible user service also exists" do
+      plist = mktmpdir/"sh.brew.mysql.plist"
+      plist.write <<~XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+          <dict>
+            <key>Label</key>
+            <string>sh.brew.mysql</string>
+          </dict>
+        </plist>
+      XML
+      allow(Homebrew::Services::System).to receive_messages(boot_path: plist.dirname, launchctl?: true)
+      allow(service).to receive_messages(registered_destination:          plist,
+                                         boot_path_service_file_present?: true,
+                                         user_path_service_file_present?: true)
+
+      expect(service.owner).to eq("root")
+    end
+
     it "root if file present" do
       allow(service).to receive(:boot_path_service_file_present?).and_return(true)
       expect(service.owner).to eq("root")


### PR DESCRIPTION
Follow-up to #23750. `FormulaWrapper#owner` fell through to the boot-path presence check whenever the registered plist had no `UserName`, so a user whose own `sh.brew.<formula>` agent is registered under `~/Library/LaunchAgents` was reported as `root` as soon as a legacy `homebrew.mxcl.<formula>` daemon also existed under `/Library/LaunchDaemons`. That wrong owner shows up in `brew services list` and `info` and in the root-skipping filter behind `stop --all` and `restart --all`.

The owner now follows the registered service file: in the boot path it is `root`, in the user path it is the current user, and only then does the presence-based fallback run. This also fixes a nil owner for package-provided plists whose label is not one of the formula's generated names, since the presence checks only look at those names. Linux and systemd behavior is unchanged.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Fable 5.1) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the change and pass with it, and ran `brew lgtm`.

-----
