### PR TITLE
Move formula Bundler defaults to superenv

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -125,6 +125,10 @@ module Superenv
     self["HIDAPI_SYSTEM_HIDAPI"] = "1"
     self["PYZMQ_NO_BUNDLE"] = "1"
     self["SODIUM_INSTALL"] = "system"
+    # Set defaults for Bundler installs
+    self["BUNDLE_FORCE_RUBY_PLATFORM"] = "true"
+    self["BUNDLE_VERSION"] = "system"
+    self["BUNDLE_WITHOUT"] = "development:test"
 
     set_debug_symbols if debug_symbols
 

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -242,9 +242,6 @@ module Homebrew
           def fetch
             ENV["BUNDLE_PATH"] = ".bundle"
 
-            system "bundle", "config", "set", "force_ruby_platform", "true"
-            system "bundle", "config", "set", "version", "system" # Avoid installing Bundler into the keg
-            system "bundle", "config", "set", "without", "development test"
             system "bundle", "cache", "--no-install"
           end
 


### PR DESCRIPTION
Put all common defaults in our superenv (similar to Python, Cargo, etc. environment variables). This avoids having to add these to every Bundler-installed formula we distribute. And sets our preferred defaults for any nested calls to Bundler.

Switching to `:`-separated `BUNDLE_WITHOUT` for better compatibility with older Bundler (in case any formulae are using old system Bundler).

`BUNDLE_PATH` remains as it differs in fetch vs. install. In Bundler 5, we will likely need to move `BUNDLE_PATH` from fetch to install phase due to changes.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
