### PR TITLE
utils/bottles: only trust a padded build prefix from the bottle manifest

### DIFF
--- a/Library/Homebrew/test/utils/bottles/bottles_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/bottles_spec.rb
@@ -56,5 +56,63 @@ RSpec.describe Utils::Bottles do
         expect(runtime_dependencies).to contain_exactly(a_hash_including("full_name" => "testball1"))
       end
     end
+
+    # The `sh.brew.tab` manifest annotation is fetched without a checksum, so the build prefix
+    # must be derived from trusted sources rather than taken from the annotation.
+    context "when the manifest annotation supplies a built_prefix" do
+      before do
+        path = CoreTap.instance.new_formula_path("testball1")
+        path.write <<~RUBY
+          class #{Formulary.class_s("testball1")} < Formula
+            url "testball1"
+            version "0.1"
+          end
+        RUBY
+        Formula["testball1"].prefix.mkpath
+        # An arm64 macOS tag has a padded prefix on every host, unlike the running tag.
+        allow(described_class).to receive(:tag)
+          .and_return(Utils::Bottles::Tag.new(system: :tahoe, arch: :arm64))
+      end
+
+      it "derives a pinned-cellar prefix from the formula rather than the annotation" do
+        formula = Formula["testball1"]
+        allow(formula.bottle_specification).to receive(:tag_to_cellar).and_return("/custom/prefix/Cellar")
+        allow(formula).to receive(:bottle_tab_attributes).and_return(
+          "built_on" => { "os" => HOMEBREW_SYSTEM }, "built_prefix" => "/usr", "padded_prefix" => false,
+        )
+
+        expect(described_class.load_tab(formula).built_prefix).to eq("/custom/prefix")
+      end
+
+      it "clears the prefix for a relocatable bottle" do
+        formula = Formula["testball1"]
+        allow(formula.bottle_specification).to receive(:tag_to_cellar).and_return(:any_skip_relocation)
+        allow(formula).to receive(:bottle_tab_attributes).and_return(
+          "built_on" => { "os" => HOMEBREW_SYSTEM }, "built_prefix" => "/usr", "padded_prefix" => false,
+        )
+
+        expect(described_class.load_tab(formula).built_prefix).to be_nil
+      end
+
+      it "substitutes this tag's padded prefix for a padded bottle" do
+        formula = Formula["testball1"]
+        padded = Utils::Bottles::Tag.new(system: :tahoe, arch: :arm64).padded_prefix
+        allow(formula).to receive(:bottle_tab_attributes).and_return(
+          "built_on" => { "os" => HOMEBREW_SYSTEM }, "built_prefix" => padded, "padded_prefix" => true,
+        )
+
+        expect(described_class.load_tab(formula).built_prefix).to eq(padded)
+      end
+
+      it "substitutes the local prefix even when a padded bottle supplies a forged one" do
+        formula = Formula["testball1"]
+        padded = Utils::Bottles::Tag.new(system: :tahoe, arch: :arm64).padded_prefix
+        allow(formula).to receive(:bottle_tab_attributes).and_return(
+          "built_on" => { "os" => HOMEBREW_SYSTEM }, "built_prefix" => "/usr", "padded_prefix" => true,
+        )
+
+        expect(described_class.load_tab(formula).built_prefix).to eq(padded)
+      end
+    end
   end
 end

--- a/Library/Homebrew/utils/bottles.rb
+++ b/Library/Homebrew/utils/bottles.rb
@@ -124,6 +124,14 @@ module Utils
 
         if bottle_json_path.nil? && (tab_attributes = formula.bottle_tab_attributes.presence)
           tab = Tab.from_file_content(tab_attributes.to_json, tabfile)
+          # Annotations are not covered by the bottle checksum, so derive the build prefix from
+          # trusted sources: this tag's padded prefix, or the prefix the formula's cellar implies.
+          tab.built_prefix = if tab.padded_prefix
+            Utils::Bottles.tag.padded_prefix
+          else
+            cellar = formula.bottle_specification.tag_to_cellar
+            Pathname(cellar.to_s).parent.to_s if cellar.is_a?(String)
+          end
           return tab if tab.built_on&.[]("os") == HOMEBREW_SYSTEM
         elsif !tabfile.exist? && bottle_json_path&.exist?
           _, tag, = Utils::Bottles.extname_tag_rebuild(formula.local_bottle_path.to_s)


### PR DESCRIPTION
`load_tab` builds a `Tab` from the `sh.brew.tab` GHCR manifest annotation, and that annotation is fetched with no integrity check at all: `Resource::BottleManifest#verify_download_integrity` only parses it, as its own comment says. The `built_prefix` it carries then reaches the in-place binary patcher in `keg_relocate.rb` as a search string, the absolute-symlink relativiser in `formula_installer.rb`, and the receipt written next to the keg.

A padded build is the only case where the annotation holds a prefix the formula does not already imply, because bottling keeps `bottle_tag.default_cellar` in the formula for those, and the padded prefix is a per-platform constant compiled into `brew`. So the supplied string is not needed: for a padded bottle the local constant is the right value, and for anything else the prefix implied by the formula's cellar already is. Deriving it locally means no annotation-supplied bytes reach relocation at all, which is a smaller trust surface than comparing the supplied string against the constant.

This continues the threat model already adopted in cbbaa10b07, where `keg_files` gained its containment check and the comment "Metadata may come from a mirror". Forging the annotation means tampering with `ghcr.io` responses in a stock configuration, or operating a mirror or registry proxy under `HOMEBREW_BOTTLE_DOMAIN` or `HOMEBREW_ARTIFACT_DOMAIN`. That is hardening rather than a practically exploitable bug, and the reach is narrow in both directions: the binary patcher only runs for non-relocatable bottles, 1186 of 8586 formulae on `arm64_tahoe`, and while the relativiser runs for all bottles, current ones carry no absolute symlinks for it to rewrite.

The other three readers of the field are unaffected. `built_cellar` interpolates it into an `opoo` string, `compatible_locations_from_tab?` reduces it to a boolean, and `BottleSpecification#skip_relocation?` ignores its `tab:` argument entirely.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug? Reproducing needs a bottle published with a crafted manifest annotation rather than `brew` commands, so the added specs stub the annotation instead.
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Claude Code with Opus 5, with local review and testing.

-----
