### PR TITLE
Add std_shards_args and update creator for crystal

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2307,6 +2307,15 @@ class Formula
     args
   end
 
+  # Standard parameters for Shards builds.
+  #
+  # @api public
+  sig { returns(T::Array[String]) }
+  def std_shards_args
+    debug_or_no_debug = ENV.debug_symbols? ? "--debug" : "--no-debug"
+    ["--production", "--release", debug_or_no_debug]
+  end
+
   # Standard parameters for Swift builds.
   #
   # @api public

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2312,8 +2312,11 @@ class Formula
   # @api public
   sig { returns(T::Array[String]) }
   def std_shards_args
-    debug_or_no_debug = ENV.debug_symbols? ? "--debug" : "--no-debug"
-    ["--production", "--release", debug_or_no_debug]
+    [
+      "--production",
+      "--release",
+      ENV.debug_symbols? ? "--debug" : "--no-debug",
+    ]
   end
 
   # Standard parameters for Swift builds.

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -223,7 +223,7 @@ module Homebrew
           # depends_on "cmake" => :build
         <% end %>
 
-        <% if [:crystal, :node, :python].exclude? @mode %>
+        <% if [:node, :python].exclude? @mode %>
           deny_network_access!
 
         <% end %>
@@ -231,6 +231,11 @@ module Homebrew
           def fetch
             system "cabal", "v2-update"
             system "cabal", "v2-install", "--only-download", *std_cabal_v2_args
+          end
+
+        <% elsif @mode == :crystal %>
+          def fetch
+            system "shards", "install", "--production", "--skip-postinstall"
           end
 
         <% elsif @mode == :go %>
@@ -269,7 +274,7 @@ module Homebrew
             system "./configure", "--disable-silent-rules", *std_configure_args
             system "make", "install" # if this fails, try separate make/make install steps
         <% elsif @mode == :crystal %>
-            system "shards", "build", "--release"
+            system "shards", "build", *std_shards_args
             bin.install "bin/#{name}"
         <% elsif @mode == :go %>
             system "go", "build", *std_go_args

--- a/Library/Homebrew/test/formula_creator_spec.rb
+++ b/Library/Homebrew/test/formula_creator_spec.rb
@@ -106,6 +106,12 @@ RSpec.describe Homebrew::FormulaCreator do
                     includes: ["deny_network_access!", "std_cmake_args"],
                     excludes: ["unrecognized options", 'resource "']
 
+    it_behaves_like "expected", :crystal,
+                    includes: ["deny_network_access!",
+                               '"shards", "install", "--production", "--skip-postinstall"',
+                               '"shards", "build", *std_shards_args'],
+                    excludes: ["unrecognized options", 'resource "']
+
     it_behaves_like "expected", :go,
                     includes: ["deny_network_access!", "std_go_args", /"go".*"download"/],
                     excludes: ["unrecognized options", 'resource "']

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -3574,6 +3574,28 @@ RSpec.describe Formula do
     end
   end
 
+  describe "#std_shards_args" do
+    subject(:args) { f.std_shards_args }
+
+    let(:f) do
+      formula do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+    end
+
+    it "sets expected defaults" do
+      expect(args).to include("--production", "--release", "--no-debug")
+      expect(args).not_to include("--debug")
+    end
+
+    it "allows enabling debug symbols" do
+      allow(ENV).to receive(:debug_symbols?).and_return(true)
+      expect(args).to include("--debug")
+      expect(args).not_to include("--no-debug")
+    end
+  end
+
   describe "#std_swift_args" do
     let(:f) do
       formula do

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -3585,14 +3585,12 @@ RSpec.describe Formula do
     end
 
     it "sets expected defaults" do
-      expect(args).to include("--production", "--release", "--no-debug")
-      expect(args).not_to include("--debug")
+      expect(args).to contain_exactly("--production", "--release", "--no-debug")
     end
 
     it "allows enabling debug symbols" do
       allow(ENV).to receive(:debug_symbols?).and_return(true)
-      expect(args).to include("--debug")
-      expect(args).not_to include("--no-debug")
+      expect(args).to contain_exactly("--production", "--release", "--debug")
     end
   end
 


### PR DESCRIPTION
Testing out arguments in
- https://github.com/Homebrew/homebrew-core/pull/301831

As far as I can tell `shards install` mainly downloads/unpacks deps while `shards build` does the actual compilation. 

Arguments for fetch include:
* `--production` to require shards.lock and exclude dev dependencies, which is similar to defaults we use elsewhere.
* `--skip-postinstall` for similar security preference as npm. Can be removed if upstream drops support for these: `https://github.com/crystal-lang/shards/issues/700`

Also align the build arguments with most common set we use in core formulae, i.e.
* `--production` is same as above and makes sure dependency resolution is the same
* `--no-debug` is crystal argument to avoid debug symbols.

Ref: https://github.com/crystal-lang/shards/blob/master/docs/shards.adoc#commands

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
