### PR TITLE
generate-cask-ci-matrix: skip runners the cask is disabled on

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -640,7 +640,11 @@ module Cask
       return if url.nil?
 
       return if !cask.tap&.official? && !signing?
-      return if cask.deprecated? && cask.deprecation_reason != :fails_gatekeeper_check
+
+      deprecated_or_disabled = cask.deprecated? || cask.disabled?
+      deprecate_disable_reason = cask.disabled? ? cask.disable_reason : cask.deprecation_reason
+      gatekeeper_failure_expected = deprecate_disable_reason == :fails_gatekeeper_check
+      return if deprecated_or_disabled && !gatekeeper_failure_expected
 
       unless Quarantine.available?
         odebug "Quarantine support is not available, skipping signing audit"
@@ -705,7 +709,7 @@ module Cask
           end
 
           next false if result.success?
-          next true if cask.deprecated? && cask.deprecation_reason == :fails_gatekeeper_check
+          next true if gatekeeper_failure_expected
           next true if is_in_skiplist
 
           signing_failure_message = <<~EOS
@@ -729,11 +733,10 @@ module Cask
 
         add_error "Cask is in the signing audit skiplist, but does not need to be skipped!" if is_in_skiplist
 
-        return unless cask.deprecated?
-        return if cask.deprecation_reason != :fails_gatekeeper_check
+        return unless gatekeeper_failure_expected
 
         add_error <<~EOS
-          Cask is deprecated because it failed Gatekeeper checks but all artifacts now pass!
+          Cask is deprecated/disabled because it failed Gatekeeper checks but all artifacts now pass!
           Remove the deprecate/disable stanza or update the deprecate/disable reason.
         EOS
       end

--- a/Library/Homebrew/dev-cmd/generate-cask-ci-matrix.rb
+++ b/Library/Homebrew/dev-cmd/generate-cask-ci-matrix.rb
@@ -148,14 +148,18 @@ module Homebrew
           end
         end
 
-        return filtered_runners unless cask.supports_linux?
-
-        linux_archs = architectures(cask:, os: :linux)
-        linux_runners = LINUX_RUNNERS.select do |runner, _|
-          linux_archs.include?(runner.fetch(:arch))
+        if cask.supports_linux?
+          linux_archs = architectures(cask:, os: :linux)
+          filtered_runners.merge!(LINUX_RUNNERS.select do |runner, _|
+            linux_archs.include?(runner.fetch(:arch))
+          end)
         end
 
-        filtered_runners.merge(linux_runners)
+        # A cask that is disabled doesn't need to be tested
+        filtered_runners.reject do |runner, _|
+          tag = Utils::Bottles::Tag.new(system: runner.fetch(:symbol).to_sym, arch: runner.fetch(:arch).to_sym)
+          cask.refresh_for_tag(tag) { cask.disabled? }
+        end
       end
 
       sig { params(cask: Cask::Cask).returns(T::Array[T::Hash[Symbol, T.any(Symbol, String)]]) }

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -683,6 +683,55 @@ RSpec.describe Cask::Audit, :cask do
           expect(run).not_to error_with(/Signature verification failed/)
         end
       end
+
+      context "when cask is disabled because it fails Gatekeeper checks" do
+        let(:cask) do
+          tmp_cask "signing-cask-test", <<~RUBY
+            cask 'signing-cask-test' do
+              version '1.0'
+              url "https://brew.sh/"
+              pkg 'Audit.pkg'
+              disable! date: '2020-01-01', because: :fails_gatekeeper_check
+            end
+          RUBY
+        end
+        let(:failed_result) do
+          instance_double(SystemCommand::Result, success?: false, merged_output: "not notarized")
+        end
+
+        before do
+          allow(cask).to receive(:tap).and_return(tap)
+          allow(Cask::Quarantine).to receive_messages(available?: true, detect: true)
+          allow(audit).to receive(:system_command).and_return(failed_result)
+          allow(audit).to receive(:extract_artifacts).and_yield(cask.artifacts.to_a, mktmpdir)
+        end
+
+        it "tolerates the signature verification failure" do
+          expect(run).not_to error_with(/Signature verification failed/)
+        end
+      end
+
+      context "when cask is disabled for a reason other than Gatekeeper" do
+        let(:cask) do
+          tmp_cask "signing-cask-test", <<~RUBY
+            cask 'signing-cask-test' do
+              version '1.0'
+              url "https://brew.sh/"
+              app 'Audit.app'
+              disable! date: '2020-01-01', because: :discontinued
+            end
+          RUBY
+        end
+
+        before do
+          allow(cask).to receive(:tap).and_return(tap)
+        end
+
+        it "skips the signing audit" do
+          expect(Cask::Quarantine).not_to receive(:available?)
+          run
+        end
+      end
     end
 
     describe "homepage domain age" do

--- a/Library/Homebrew/test/dev-cmd/generate-cask-ci-matrix_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-cask-ci-matrix_spec.rb
@@ -216,6 +216,33 @@ RSpec.describe Homebrew::DevCmd::GenerateCaskCiMatrix do
       end
     end
   end
+  let(:c_disabled_on_macos) do
+    Cask::Cask.new("test-disabled-on-macos") do
+      os macos: "darwin", linux: "linux"
+      version "0.0.1,2"
+
+      url "https://brew.sh/test-0.0.1.dmg"
+      name "Test"
+      desc "Test cask"
+      homepage "https://brew.sh"
+
+      on_macos do
+        disable! date: "2020-01-01", because: :fails_gatekeeper_check
+      end
+    end
+  end
+  let(:c_disabled) do
+    Cask::Cask.new("test-disabled") do
+      version "0.0.1,2"
+
+      url "https://brew.sh/test-0.0.1.dmg"
+      name "Test"
+      desc "Test cask"
+      homepage "https://brew.sh"
+
+      disable! date: "2020-01-01", because: :discontinued
+    end
+  end
   let(:c) do
     Cask::Cask.new("test-font") do
       version "0.0.1,2"
@@ -325,6 +352,20 @@ RSpec.describe Homebrew::DevCmd::GenerateCaskCiMatrix do
             { arch: :arm, name: arm_linux_runner, symbol: :linux }  => 1.0,
             { arch: :intel, name: "ubuntu-latest", symbol: :linux } => 1.0,
           })
+      end
+    end
+
+    context "when cask is disabled" do
+      it "excludes the runners the cask is disabled on" do
+        expect(generate_matrix.filter_runners(c_disabled_on_macos))
+          .to eq({
+            { arch: :arm, name: arm_linux_runner, symbol: :linux }  => 1.0,
+            { arch: :intel, name: "ubuntu-latest", symbol: :linux } => 1.0,
+          })
+      end
+
+      it "excludes every runner for a cask disabled everywhere" do
+        expect(generate_matrix.filter_runners(c_disabled)).to eq({})
       end
     end
 


### PR DESCRIPTION
- Casks can be disabled on some systems but not others. CI still generated jobs for those systems, where the cask can be neither audited nor installed, so they could only ever fail. `filter_runners` now drops any runner the cask is disabled on.
- Separately, audit_signing only ever read `deprecated?`/`deprecation_reason`. `disable!` sets those while its date is in the future, but switches to `disabled?`/`disable_reason` once it passes. So make the audit resilient to this in case a contributor runs the audit directly locally.

Fixes #23789

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

I used `claude-code` with Opus 5 to generate the fix, and reviewed the logic myself.