### PR TITLE
services: recognize both Linux service labels

### DIFF
--- a/Library/Homebrew/bundle/brew_services.rb
+++ b/Library/Homebrew/bundle/brew_services.rb
@@ -95,7 +95,7 @@ module Homebrew
             service_files = if Homebrew::Services::System.launchctl?
               formula.plist_names.map { |name| prefix/"#{name}.plist" }
             else
-              [prefix/"#{formula.service_name}.service"]
+              formula.service_names.map { |name| prefix/"#{name}.service" }
             end
 
             service_files.find(&:file?)

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1502,6 +1502,14 @@ class Formula
   sig { returns(String) }
   def service_name = service.service_name
 
+  # The generated systemd service names, including compatible defaults.
+  sig { returns(T::Array[String]) }
+  def service_names
+    return [service_name] if service_name != service.service_name
+
+    service.service_names
+  end
+
   # The generated launchd {.plist} file path.
   sig { returns(Pathname) }
   def launchd_service_path = launchd_service_paths.fetch(0)
@@ -1515,11 +1523,25 @@ class Formula
 
   # The generated systemd {.service} file path.
   sig { returns(Pathname) }
-  def systemd_service_path = (any_installed_prefix || opt_prefix)/"#{service_name}.service"
+  def systemd_service_path = systemd_service_paths.fetch(0)
+
+  # The generated systemd {.service} file paths, including compatible defaults.
+  sig { returns(T::Array[Pathname]) }
+  def systemd_service_paths
+    prefix = any_installed_prefix || opt_prefix
+    service_names.map { |name| prefix/"#{name}.service" }
+  end
 
   # The generated systemd {.timer} file path.
   sig { returns(Pathname) }
-  def systemd_timer_path = (any_installed_prefix || opt_prefix)/"#{service_name}.timer"
+  def systemd_timer_path = systemd_timer_paths.fetch(0)
+
+  # The generated systemd {.timer} file paths, including compatible defaults.
+  sig { returns(T::Array[Pathname]) }
+  def systemd_timer_paths
+    prefix = any_installed_prefix || opt_prefix
+    service_names.map { |name| prefix/"#{name}.timer" }
+  end
 
   # The service specification for the software.
   #

--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -63,6 +63,7 @@ module Homebrew
       @run_params = T.let(nil, T.any(RunParam, T::Hash[Symbol, RunParam]))
       @run_type = T.let(RUN_TYPE_IMMEDIATE, Symbol)
       @service_name = T.let(default_service_name, String)
+      @service_name_explicitly_set = T.let(false, T::Boolean)
       @sockets = T.let({}, Sockets)
       @stop_timeout = T.let(nil, T.nilable(Integer))
       @working_dir = T.let(nil, T.nilable(String))
@@ -105,7 +106,24 @@ module Homebrew
 
     sig { returns(String) }
     def default_service_name
+      legacy_service_name
+    end
+
+    sig { returns(String) }
+    def legacy_service_name
       "homebrew.#{@formula.name}"
+    end
+
+    sig { returns(String) }
+    def canonical_service_name
+      "sh.brew.#{@formula.name}"
+    end
+
+    sig { returns(T::Array[String]) }
+    def service_names
+      return [service_name] if @service_name_explicitly_set
+
+      [service_name, canonical_service_name, legacy_service_name].uniq
     end
 
     # A hash with the `launchd` service name on macOS and/or the `systemd`
@@ -121,7 +139,10 @@ module Homebrew
         @plist_name = macos
         @plist_name_explicitly_set = true
       end
-      @service_name = linux if linux
+      return unless linux
+
+      @service_name = linux
+      @service_name_explicitly_set = true
     end
 
     # The command to execute: an array with arguments or a path.
@@ -739,7 +760,7 @@ module Homebrew
     def to_hash
       name_params = {
         macos: (plist_name if @plist_name_explicitly_set),
-        linux: (service_name if service_name != default_service_name),
+        linux: (service_name if @service_name_explicitly_set),
       }.compact
 
       return { name: name_params }.compact_blank if @run_params.blank?

--- a/Library/Homebrew/services/cli.rb
+++ b/Library/Homebrew/services/cli.rb
@@ -54,16 +54,14 @@ module Homebrew
       sig { params(service: Services::FormulaWrapper, running_status: String).returns(T::Boolean) }
       def self.report_service_running_or_loaded?(service, running_status:)
         running = service.pid?
-        loaded_name = if System.launchctl?
-          if running
-            service.active_service_name
-          else
-            service.loaded_service_names.find { |name| name != service.service_name }
-          end
+        loaded_name = if running
+          service.active_service_name
+        else
+          service.loaded_service_names.find { |name| name != service.service_name }
         end
 
         if loaded_name.present? && loaded_name != service.service_name
-          if service.service_file_generated? && service.service_names.include?(loaded_name)
+          if System.launchctl? && service.service_file_generated? && service.service_names.include?(loaded_name)
             puts "Service `#{service.name}` is already loaded as `#{loaded_name}`; " \
                  "a service label migration is pending. Use `#{bin} restart #{service.name}` " \
                  "to migrate to `#{service.service_name}`."
@@ -119,6 +117,26 @@ module Homebrew
         end
 
         cleaned
+      end
+
+      sig {
+        params(
+          service:        Services::FormulaWrapper,
+          disabled_units: T::Array[String],
+        ).void
+      }
+      private_class_method def self.remove_service_files(service, disabled_units: [])
+        files = service.destinations
+        files += service.timer_destinations if System.systemctl? && service.timed?
+        files.each do |file|
+          next unless file.exist?
+
+          unit_name = file.basename.to_s
+          if System.systemctl? && disabled_units.exclude?(unit_name)
+            System::Systemctl.quiet_run("disable", unit_name)
+          end
+          rm file
+        end
       end
 
       # Run a service as defined in the formula. This does not clean the service file like `start` does.
@@ -206,15 +224,10 @@ module Homebrew
       }
       def self.stop(targets, verbose: false, no_wait: false, max_wait: 0, keep: false)
         targets.each do |service|
-          unless service.loaded?
-            unless keep
-              if System.systemctl?
-                rm service.dest if service.dest.exist?
-              else # System.launchctl?
-                service.destinations.each { |destination| rm destination if destination.exist? }
-              end
-              rm service.timer_dest if System.systemctl? && service.timed? && service.timer_dest.exist?
-            end
+          loaded = service.loaded?
+          running = !loaded && service.pid?
+          if !loaded && !running
+            remove_service_files(service) unless keep
             if service.service_file_present?
               odie <<~EOS
                 Service `#{service.name}` is started as `#{service.owner}`. Try:
@@ -231,7 +244,10 @@ module Homebrew
           end
 
           systemctl_args = []
-          loaded_service_names = T.let([], T::Array[String])
+          systemctl_stop_results = T.let([], T::Array[T::Boolean])
+          disabled_units = T.let([], T::Array[String])
+          loaded_service_names = service.loaded_service_names
+          loaded_service_names = [service.active_service_name] if loaded_service_names.empty? && running
           if no_wait
             systemctl_args << "--no-block"
             puts "Stopping `#{service.name}`..."
@@ -240,17 +256,30 @@ module Homebrew
           end
 
           if System.systemctl?
-            if keep
-              System::Systemctl.quiet_run(*systemctl_args, "stop", service.timer_name) if service.timed?
-              System::Systemctl.quiet_run(*systemctl_args, "stop", service.service_name)
-            elsif service.timed?
-              System::Systemctl.quiet_run(*systemctl_args, "disable", "--now", service.timer_name)
-              System::Systemctl.quiet_run(*systemctl_args, "disable", "--now", service.service_name)
-            else
-              System::Systemctl.quiet_run(*systemctl_args, "disable", "--now", service.service_name)
+            loaded_service_names.each do |service_name|
+              if keep
+                if service.timed?
+                  systemctl_stop_results << System::Systemctl.quiet_run(
+                    *systemctl_args, "stop", "#{service_name}.timer"
+                  )
+                end
+                systemctl_stop_results << System::Systemctl.quiet_run(*systemctl_args, "stop", service_name)
+              elsif service.timed?
+                timer_name = "#{service_name}.timer"
+                result = System::Systemctl.quiet_run(*systemctl_args, "disable", "--now", timer_name)
+                systemctl_stop_results << result
+                disabled_units << timer_name if result
+
+                result = System::Systemctl.quiet_run(*systemctl_args, "disable", "--now", service_name)
+                systemctl_stop_results << result
+                disabled_units << "#{service_name}.service" if result
+              else
+                result = System::Systemctl.quiet_run(*systemctl_args, "disable", "--now", service_name)
+                systemctl_stop_results << result
+                disabled_units << "#{service_name}.service" if result
+              end
             end
           elsif System.launchctl?
-            loaded_service_names = service.loaded_service_names
             dont_wait_statuses = [
               Errno::ESRCH::Errno,
               System::LAUNCHCTL_DOMAIN_ACTION_NOT_SUPPORTED,
@@ -279,31 +308,27 @@ module Homebrew
                   System.launchctl_service_running?(service_name)
               end
             end
-            service.reset_cache!
           end
 
+          service.reset_cache!
+
           service_still_loaded = if System.systemctl?
-            service.loaded? || service.pid?
+            if no_wait && systemctl_stop_results.present? && systemctl_stop_results.all?
+              false
+            else
+              service.loaded? || service.pid?
+            end
           else # System.launchctl?
             loaded_service_names.any? { |service_name| System.launchctl_service_running?(service_name) }
           end
 
-          unless keep
-            if System.systemctl?
-              rm service.dest if service.dest.exist?
-            elsif !service_still_loaded # System.launchctl?
-              service.destinations.each { |destination| rm destination if destination.exist? }
-            end
-            rm service.timer_dest if System.systemctl? && service.timed? && service.timer_dest.exist?
+          if !keep && !service_still_loaded
+            remove_service_files(service, disabled_units:)
             # Run daemon-reload on systemctl to finish unloading stopped and deleted service.
             System::Systemctl.run(*systemctl_args, "daemon-reload") if System.systemctl?
           end
 
-          labels = if System.systemctl?
-            [service.service_name]
-          else # System.launchctl?
-            loaded_service_names.presence || service.service_names
-          end
+          labels = loaded_service_names.presence || service.service_names
           if service_still_loaded
             opoo "Unable to stop `#{service.name}` (label: #{labels.join(", ")})"
           else
@@ -322,22 +347,20 @@ module Homebrew
             puts "Service `#{service.name}` is set to automatically restart and can't be killed."
           else
             puts "Killing `#{service.name}`... (might take a while)"
-            killed_service_names = [service.service_name]
+            killed_service_names = service.loaded_service_names.presence || [service.active_service_name]
             if System.systemctl?
-              System::Systemctl.quiet_run("stop", service.service_name)
+              killed_service_names.each { |service_name| System::Systemctl.quiet_run("stop", service_name) }
             elsif System.launchctl?
-              killed_service_names = service.loaded_service_names
               killed_service_names.each do |service_name|
                 quiet_system System.launchctl, "stop", service_name
               end
-              service.reset_cache!
             end
+            service.reset_cache!
 
-            labels = killed_service_names.presence || [service.service_name]
             if service.pid?
-              opoo "Unable to kill `#{service.name}` (label: #{labels.join(", ")})"
+              opoo "Unable to kill `#{service.name}` (label: #{killed_service_names.join(", ")})"
             else
-              ohai "Successfully killed `#{service.name}` (label: #{labels.join(", ")})"
+              ohai "Successfully killed `#{service.name}` (label: #{killed_service_names.join(", ")})"
             end
           end
         end
@@ -494,7 +517,7 @@ module Homebrew
         end
         temp.flush
 
-        service.destinations.each { |destination| rm destination if destination.exist? }
+        remove_service_files(service)
         service.dest_dir.mkpath unless service.dest_dir.directory?
         cp T.must(temp.path), service.dest
 
@@ -503,8 +526,7 @@ module Homebrew
 
         chmod 0644, service.dest
         if System.systemctl? && service.timed?
-          rm service.timer_dest if service.timer_dest.exist?
-          cp service.timer_file, service.timer_dest
+          service.timer_dest.atomic_write(service.timer_contents)
           chmod 0644, service.timer_dest
         end
 

--- a/Library/Homebrew/services/formula_wrapper.rb
+++ b/Library/Homebrew/services/formula_wrapper.rb
@@ -63,6 +63,7 @@ module Homebrew
         @formula = formula
         @service_name_override = service_name
         @status_output_success_type = T.let(nil, T.nilable(StatusOutputSuccessType))
+        @loaded_service_names = T.let(nil, T.nilable(T::Array[String]))
 
         return if System.launchctl? || System.systemctl?
 
@@ -132,7 +133,7 @@ module Homebrew
           elsif System.launchctl?
             formula.plist_names
           else # System.systemctl?
-            [formula.service_name]
+            formula.service_names
           end, T.nilable(T::Array[String])
         )
       end
@@ -149,7 +150,7 @@ module Homebrew
           if System.launchctl?
             formula.launchd_service_paths
           else # System.systemctl?
-            [formula.systemd_service_path]
+            formula.systemd_service_paths
           end, T.nilable(T::Array[Pathname])
         )
       end
@@ -161,17 +162,23 @@ module Homebrew
 
       sig { returns(Pathname) }
       def timer_file
-        @timer_file ||= T.let(formula.systemd_timer_path, T.nilable(Pathname))
+        files = formula.systemd_timer_paths
+        files.find(&:exist?) || files.fetch(0)
       end
 
       sig { returns(String) }
       def timer_name
-        @timer_name ||= T.let(timer_file.basename.to_s, T.nilable(String))
+        "#{service_name}.timer"
       end
 
       sig { returns(Pathname) }
       def timer_dest
-        dest_dir + timer_file.basename
+        timer_destinations.fetch(0)
+      end
+
+      sig { returns(T::Array[Pathname]) }
+      def timer_destinations
+        service_names.map { |name| dest_dir/"#{name}.timer" }
       end
 
       # Whether the service should be launched at startup
@@ -200,19 +207,13 @@ module Homebrew
 
       sig { returns(T::Array[Pathname]) }
       def destinations
-        if System.launchctl?
-          service_names.map { |name| dest_dir/service_file_basename(name) }
-        else
-          [dest_dir/service_file.basename]
-        end
+        service_names.map { |name| dest_dir/service_file_basename(name) }
       end
 
       sig { returns(Pathname) }
       def registered_destination
-        if System.launchctl?
-          active_destination = dest_dir/service_file_basename(active_service_name)
-          return active_destination if active_destination.exist?
-        end
+        active_destination = dest_dir/service_file_basename(active_service_name)
+        return active_destination if active_destination.exist?
 
         destinations.find(&:exist?) || dest
       end
@@ -226,25 +227,33 @@ module Homebrew
       sig { void }
       def reset_cache!
         @status_output_success_type = nil
+        @loaded_service_names = nil
       end
 
       # Returns `true` if the service is loaded, else false.
       sig { params(cached: T::Boolean).returns(T::Boolean) }
       def loaded?(cached: false)
+        reset_cache! unless cached
+
         if System.launchctl?
-          reset_cache! unless cached
           status_success
         else # System.systemctl?
-          System::Systemctl.quiet_run("status", timed? ? timer_name : service_file.basename)
+          loaded_service_names.present?
         end
       end
 
       sig { returns(T::Array[String]) }
       def loaded_service_names
-        return [service_name] if System.systemctl? && loaded?
-        return [] unless System.launchctl?
-
-        launchctl_service_names.select { |name| System.launchctl_service_running?(name) }
+        @loaded_service_names ||= if System.systemctl?
+          service_names.select do |name|
+            (timed? && System::Systemctl.quiet_run("status", "#{name}.timer")) ||
+              System::Systemctl.quiet_run("status", "#{name}.service")
+          end
+        elsif System.launchctl?
+          launchctl_service_names.select { |name| System.launchctl_service_running?(name) }
+        else
+          []
+        end
       end
 
       sig { returns(String) }
@@ -371,6 +380,19 @@ module Homebrew
         end
       end
 
+      sig { returns(String) }
+      def timer_contents
+        if service_file_generated?
+          load_service.to_systemd_timer
+        else
+          timer_file.read.sub(
+            /^([ \t]*Unit[ \t]*=[ \t]*)#{Regexp.union(service_names.map { |name| "#{name}.service" })}([ \t]*)$/,
+          ) do
+            "#{Regexp.last_match(1)}#{service_name}.service#{Regexp.last_match(2)}"
+          end
+        end
+      end
+
       private
 
       # The purpose of this function is to lazy load the Homebrew::Service class
@@ -400,8 +422,8 @@ module Homebrew
 
       sig { returns(StatusOutputSuccessType) }
       def status_output_success_type
+        result = T.let(nil, T.nilable(StatusOutputSuccessType))
         @status_output_success_type ||= if System.launchctl?
-          result = T.let(nil, T.nilable(StatusOutputSuccessType))
           launchctl_service_names.each do |name|
             output, success, type = System.launchctl_find_service(name)
             next unless success
@@ -415,11 +437,19 @@ module Homebrew
           end
           result || StatusOutputSuccessType.new("", false, :launchctl_list, service_name)
         else # System.systemctl?
-          cmd = ["status", service_name]
-          output = System::Systemctl.popen_read(*cmd).chomp
-          success = T.cast($CHILD_STATUS.present? && $CHILD_STATUS.success? && output.present?, T::Boolean)
-          odebug [System::Systemctl.executable, System::Systemctl.scope, *cmd].join(" "), output
-          StatusOutputSuccessType.new(output, success, :systemctl, service_name)
+          (loaded_service_names + service_names).uniq.each do |name|
+            cmd = ["status", service_file_basename(name)]
+            output = System::Systemctl.popen_read(*cmd).chomp
+            success = ($CHILD_STATUS&.success? || false) && output.present?
+            odebug [System::Systemctl.executable, System::Systemctl.scope, *cmd].join(" "), output
+            candidate = StatusOutputSuccessType.new(output, success, :systemctl, name)
+            result ||= candidate
+            if status_pid(candidate)&.positive?
+              result = candidate
+              break
+            end
+          end
+          result || StatusOutputSuccessType.new("", false, :systemctl, service_name)
         end
       end
 

--- a/Library/Homebrew/test/bundle/brew_services_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_services_spec.rb
@@ -135,12 +135,13 @@ RSpec.describe Homebrew::Bundle::Brew::Services do
     let(:foo) do
       instance_double(
         Formula,
-        name:         "fooformula",
-        version:      "1.0",
-        rack:         HOMEBREW_CELLAR/"fooformula",
-        plist_name:   "sh.brew.fooformula",
-        plist_names:  ["sh.brew.fooformula", "homebrew.mxcl.fooformula"],
-        service_name: "fooformula",
+        name:          "fooformula",
+        version:       "1.0",
+        rack:          HOMEBREW_CELLAR/"fooformula",
+        plist_name:    "sh.brew.fooformula",
+        plist_names:   ["sh.brew.fooformula", "homebrew.mxcl.fooformula"],
+        service_name:  "homebrew.fooformula",
+        service_names: ["homebrew.fooformula", "sh.brew.fooformula"],
       )
     end
 
@@ -189,6 +190,18 @@ RSpec.describe Homebrew::Bundle::Brew::Services do
       let(:service_basename) { "#{foo.service_name}.service" }
 
       include_examples "returns the versioned service file"
+
+      it "returns the compatible versioned service file" do
+        expect(Formula).to receive(:[]).with(foo.name).and_return(foo)
+        expect(Homebrew::Bundle).to receive(:formula_versions_from_env).with(foo.name).and_return(foo.version)
+
+        prefix = foo.rack/foo.version
+        prefix.mkpath
+        service_file = prefix/"sh.brew.fooformula.service"
+        service_file.write("service")
+
+        expect(described_class.versioned_service_file(foo.name)).to eq(service_file)
+      end
     end
   end
 end

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1553,6 +1553,7 @@ RSpec.describe Formula do
       expect(f.plist_name).to eq("custom.macos.beanstalkd")
       expect(f.plist_names).to eq(["custom.macos.beanstalkd"])
       expect(f.service_name).to eq("custom.linux.beanstalkd")
+      expect(f.service_names).to eq(["custom.linux.beanstalkd"])
       expect(f.service.to_hash.keys).to contain_exactly(:name)
     end
 
@@ -1583,6 +1584,33 @@ RSpec.describe Formula do
       ])
     end
 
+    specify "explicit default and compatible systemd service names remain explicit when serialized" do
+      legacy_formula = formula "legacy_name" do
+        url "https://brew.sh/legacy-1.0.tbz"
+        service do
+          name linux: "homebrew.legacy_name"
+        end
+      end
+      canonical_formula = formula "canonical_name" do
+        url "https://brew.sh/canonical-1.0.tbz"
+        service do
+          name linux: "sh.brew.canonical_name"
+        end
+      end
+
+      expect([
+        legacy_formula.service.to_hash,
+        legacy_formula.service_names,
+        canonical_formula.service.to_hash,
+        canonical_formula.service_names,
+      ]).to eq([
+        { name: { linux: "homebrew.legacy_name" } },
+        ["homebrew.legacy_name"],
+        { name: { linux: "sh.brew.canonical_name" } },
+        ["sh.brew.canonical_name"],
+      ])
+    end
+
     specify "service with an overridden plist_name" do
       f = formula do
         T.bind(self, T.class_of(Formula))
@@ -1596,6 +1624,19 @@ RSpec.describe Formula do
       expect(f.launchd_service_paths).to eq([HOMEBREW_PREFIX/"opt/formula_name/custom.override.name.plist"])
     end
 
+    specify "service with an overridden service_name" do
+      f = formula do
+        T.bind(self, T.class_of(Formula))
+        url "https://brew.sh/test-1.0.tbz"
+
+        def service_name = "custom.override.name"
+      end
+
+      expect(f.service_name).to eq("custom.override.name")
+      expect(f.service_names).to eq(["custom.override.name"])
+      expect(f.systemd_service_paths).to eq([HOMEBREW_PREFIX/"opt/formula_name/custom.override.name.service"])
+    end
+
     specify "service helpers return data" do
       f = formula do
         T.bind(self, T.class_of(Formula))
@@ -1605,13 +1646,22 @@ RSpec.describe Formula do
       expect(f.plist_name).to eq("sh.brew.formula_name")
       expect(f.plist_names).to eq(["sh.brew.formula_name", "homebrew.mxcl.formula_name"])
       expect(f.service_name).to eq("homebrew.formula_name")
+      expect(f.service_names).to eq(["homebrew.formula_name", "sh.brew.formula_name"])
       expect(f.launchd_service_path).to eq(HOMEBREW_PREFIX/"opt/formula_name/sh.brew.formula_name.plist")
       expect(f.launchd_service_paths).to eq([
         HOMEBREW_PREFIX/"opt/formula_name/sh.brew.formula_name.plist",
         HOMEBREW_PREFIX/"opt/formula_name/homebrew.mxcl.formula_name.plist",
       ])
       expect(f.systemd_service_path).to eq(HOMEBREW_PREFIX/"opt/formula_name/homebrew.formula_name.service")
+      expect(f.systemd_service_paths).to eq([
+        HOMEBREW_PREFIX/"opt/formula_name/homebrew.formula_name.service",
+        HOMEBREW_PREFIX/"opt/formula_name/sh.brew.formula_name.service",
+      ])
       expect(f.systemd_timer_path).to eq(HOMEBREW_PREFIX/"opt/formula_name/homebrew.formula_name.timer")
+      expect(f.systemd_timer_paths).to eq([
+        HOMEBREW_PREFIX/"opt/formula_name/homebrew.formula_name.timer",
+        HOMEBREW_PREFIX/"opt/formula_name/sh.brew.formula_name.timer",
+      ])
     end
   end
 

--- a/Library/Homebrew/test/services/cli_spec.rb
+++ b/Library/Homebrew/test/services/cli_spec.rb
@@ -75,12 +75,16 @@ RSpec.describe Homebrew::Services::Cli do
         service_string,
         name:                 "example_service",
         service_name:         "homebrew.example_service",
+        active_service_name:  "homebrew.example_service",
         pid?:                 true,
         dest:                 Pathname("this_path_does_not_exist"),
         keep_alive?:          false,
         loaded_service_names: [],
       )
       allow(service).to receive(:reset_cache!)
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+      expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
+        .with("stop", "homebrew.example_service")
       allow(Homebrew::Services::FormulaWrapper).to receive(:from).and_return(service)
       allow(services_cli).to receive(:running).and_return(["example_service"])
       expect do
@@ -183,7 +187,13 @@ RSpec.describe Homebrew::Services::Cli do
       allow(Homebrew::Services::System).to receive(:launchctl?).and_return(false)
       expected_output = "Service `example_service` already running, " \
                         "use `brew services restart example_service` to restart.\n"
-      service = instance_double(service_string, name: "example_service", pid?: true)
+      service = instance_double(
+        service_string,
+        name:                "example_service",
+        service_name:        "homebrew.example_service",
+        active_service_name: "homebrew.example_service",
+        pid?:                true,
+      )
       expect do
         services_cli.run([service])
       end.to output(expected_output).to_stdout
@@ -206,6 +216,23 @@ RSpec.describe Homebrew::Services::Cli do
         services_cli.run([service])
       end.to output(/already loaded as `homebrew.mxcl.name`/).to_stdout
     end
+
+    it "does not run a service already loaded with the compatible systemd label" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+      service = instance_double(
+        service_string,
+        name:                 "name",
+        service_name:         "homebrew.name",
+        active_service_name:  "sh.brew.name",
+        loaded_service_names: ["sh.brew.name"],
+        pid?:                 true,
+      )
+      expect(services_cli).not_to receive(:service_load)
+
+      expect do
+        services_cli.run([service])
+      end.to output(/already running \(label: sh\.brew\.name\)/).to_stdout
+    end
   end
 
   describe "#start" do
@@ -226,7 +253,13 @@ RSpec.describe Homebrew::Services::Cli do
       allow(Homebrew::Services::System).to receive(:launchctl?).and_return(false)
       expected_output = "Service `example_service` already started, " \
                         "use `brew services restart example_service` to restart.\n"
-      service = instance_double(service_string, name: "example_service", pid?: true)
+      service = instance_double(
+        service_string,
+        name:                "example_service",
+        service_name:        "homebrew.example_service",
+        active_service_name: "homebrew.example_service",
+        pid?:                true,
+      )
       expect do
         services_cli.start([service])
       end.to output(expected_output).to_stdout
@@ -323,25 +356,27 @@ RSpec.describe Homebrew::Services::Cli do
       services_cli.stop([])
     end
 
-    it "stops timed systemd timers before services when kept" do
+    it "stops compatible systemd timers before services when kept" do
       allow(Homebrew::Services::System).to receive(:systemctl?).and_return(true)
       expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
-        .with("stop", "homebrew.name.timer")
+        .with("stop", "sh.brew.name.timer")
         .ordered
         .and_return(true)
       expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
-        .with("stop", "homebrew.name")
+        .with("stop", "sh.brew.name")
         .ordered
         .and_return(true)
       service = instance_double(
         Homebrew::Services::FormulaWrapper,
-        name:         "name",
-        service_name: "homebrew.name",
-        timed?:       true,
-        timer_name:   "homebrew.name.timer",
-        pid?:         false,
+        name:                 "name",
+        service_name:         "homebrew.name",
+        service_names:        ["homebrew.name", "sh.brew.name"],
+        loaded_service_names: ["sh.brew.name"],
+        timed?:               true,
+        pid?:                 false,
       )
       allow(service).to receive(:loaded?).and_return(true, false)
+      allow(service).to receive(:reset_cache!)
 
       expect do
         services_cli.stop([service], keep: true)
@@ -365,20 +400,131 @@ RSpec.describe Homebrew::Services::Cli do
       timer_dest.write("timer")
       service = instance_double(
         Homebrew::Services::FormulaWrapper,
-        name:         "name",
-        service_name: "homebrew.name",
-        dest:         service_dest,
-        timed?:       true,
-        timer_name:   "homebrew.name.timer",
-        timer_dest:,
-        pid?:         false,
+        name:                 "name",
+        service_name:         "homebrew.name",
+        service_names:        ["homebrew.name", "sh.brew.name"],
+        loaded_service_names: ["homebrew.name"],
+        destinations:         [service_dest],
+        timed?:               true,
+        timer_destinations:   [timer_dest],
+        pid?:                 false,
       )
       allow(service).to receive(:loaded?).and_return(true, false)
+      allow(service).to receive(:reset_cache!)
 
       expect do
         services_cli.stop([service])
       end.to output(/Successfully stopped `name`/).to_stdout
       expect(timer_dest).not_to exist
+    end
+
+    it "stops and removes the compatible systemd service label" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+      expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
+        .with("disable", "--now", "sh.brew.name").and_return(true)
+      expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
+        .with("disable", "homebrew.name.service").and_return(true)
+      expect(Homebrew::Services::System::Systemctl).to receive(:run).with("daemon-reload")
+
+      dest_dir = mktmpdir
+      destinations = [dest_dir/"homebrew.name.service", dest_dir/"sh.brew.name.service"]
+      destinations.each { |destination| destination.write("service") }
+      service = instance_double(
+        Homebrew::Services::FormulaWrapper,
+        name:                 "name",
+        service_name:         "homebrew.name",
+        service_names:        ["homebrew.name", "sh.brew.name"],
+        loaded_service_names: ["sh.brew.name"],
+        destinations:,
+        timed?:               false,
+        pid?:                 false,
+      )
+      allow(service).to receive(:loaded?).and_return(true, false)
+      allow(service).to receive(:reset_cache!)
+
+      expect do
+        services_cli.stop([service])
+      end.to output(/Successfully stopped `name` \(label: sh\.brew\.name\)/).to_stdout
+      expect(destinations).not_to include(an_object_satisfying(&:exist?))
+    end
+
+    it "preserves a compatible systemd service file when stopping fails" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+      expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
+        .with("disable", "--now", "sh.brew.name").and_return(false)
+      expect(Homebrew::Services::System::Systemctl).not_to receive(:run)
+
+      destination = mktmpdir/"sh.brew.name.service"
+      destination.write("service")
+      service = instance_double(
+        Homebrew::Services::FormulaWrapper,
+        name:                 "name",
+        service_name:         "homebrew.name",
+        service_names:        ["homebrew.name", "sh.brew.name"],
+        loaded_service_names: ["sh.brew.name"],
+        destinations:         [destination],
+        timed?:               false,
+        pid?:                 false,
+      )
+      allow(service).to receive(:loaded?).and_return(true)
+      allow(service).to receive(:reset_cache!)
+
+      expect do
+        services_cli.stop([service])
+      end.to output(/Unable to stop `name` \(label: sh\.brew\.name\)/).to_stderr
+      expect(destination).to exist
+    end
+
+    it "cleans up after an accepted asynchronous systemd stop" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+      expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
+        .with("--no-block", "disable", "--now", "sh.brew.name").and_return(true)
+      expect(Homebrew::Services::System::Systemctl).to receive(:run).with("--no-block", "daemon-reload")
+
+      destination = mktmpdir/"sh.brew.name.service"
+      destination.write("service")
+      service = instance_double(
+        Homebrew::Services::FormulaWrapper,
+        name:                 "name",
+        service_name:         "homebrew.name",
+        service_names:        ["homebrew.name", "sh.brew.name"],
+        loaded_service_names: ["sh.brew.name"],
+        destinations:         [destination],
+        timed?:               false,
+        pid?:                 true,
+      )
+      allow(service).to receive(:loaded?).and_return(true)
+      allow(service).to receive(:reset_cache!)
+
+      expect do
+        services_cli.stop([service], no_wait: true)
+      end.to output(/Successfully stopped `name` \(label: sh\.brew\.name\)/).to_stdout
+      expect(destination).not_to exist
+    end
+
+    it "stops a compatible systemd service whose timer is inactive" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+      expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
+        .with("stop", "sh.brew.name.timer").ordered.and_return(true)
+      expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
+        .with("stop", "sh.brew.name").ordered.and_return(true)
+      service = instance_double(
+        Homebrew::Services::FormulaWrapper,
+        name:                  "name",
+        service_name:          "homebrew.name",
+        service_names:         ["homebrew.name", "sh.brew.name"],
+        active_service_name:   "sh.brew.name",
+        loaded_service_names:  [],
+        service_file_present?: false,
+        timed?:                true,
+      )
+      allow(service).to receive(:loaded?).and_return(false)
+      allow(service).to receive(:pid?).and_return(true, false)
+      allow(service).to receive(:reset_cache!)
+
+      expect do
+        services_cli.stop([service], keep: true)
+      end.to output(/Successfully stopped `name` \(label: sh\.brew\.name\)/).to_stdout
     end
 
     it "stops and removes both compatible macOS service labels" do
@@ -494,6 +640,45 @@ RSpec.describe Homebrew::Services::Cli do
         services_cli.kill([service])
       end.to output(/Successfully killed `name` \(label: homebrew\.mxcl\.name\)/).to_stdout
     end
+
+    it "reports the compatible systemd label that was killed" do
+      service = instance_double(
+        service_string,
+        name:                 "name",
+        service_name:         "homebrew.name",
+        keep_alive?:          false,
+        loaded_service_names: ["sh.brew.name"],
+      )
+      allow(service).to receive(:pid?).and_return(true, false)
+      allow(service).to receive(:reset_cache!)
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+      expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
+        .with("stop", "sh.brew.name").and_return(true)
+
+      expect do
+        services_cli.kill([service])
+      end.to output(/Successfully killed `name` \(label: sh\.brew\.name\)/).to_stdout
+    end
+
+    it "kills a compatible systemd service whose timer is inactive" do
+      service = instance_double(
+        service_string,
+        name:                 "name",
+        service_name:         "homebrew.name",
+        active_service_name:  "sh.brew.name",
+        keep_alive?:          false,
+        loaded_service_names: [],
+      )
+      allow(service).to receive(:pid?).and_return(true, false)
+      allow(service).to receive(:reset_cache!)
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+      expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
+        .with("stop", "sh.brew.name").and_return(true)
+
+      expect do
+        services_cli.kill([service])
+      end.to output(/Successfully killed `name` \(label: sh\.brew\.name\)/).to_stdout
+    end
   end
 
   describe "#take_root_ownership?" do
@@ -563,16 +748,53 @@ RSpec.describe Homebrew::Services::Cli do
       expect([primary_dest.read, compatible_dest.exist?]).to eq(["service", false])
     end
 
+    it "disables compatible systemd service files before replacing them" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+      allow(Homebrew::Services::System::Systemctl).to receive(:quiet_run).and_return(true)
+      expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
+        .with("disable", "sh.brew.name.service")
+      allow(Homebrew::Services::System::Systemctl).to receive(:run).with("daemon-reload")
+
+      source_dir = mktmpdir
+      dest_dir = mktmpdir
+      service_file = source_dir/"homebrew.name.service"
+      primary_dest = dest_dir/"homebrew.name.service"
+      compatible_dest = dest_dir/"sh.brew.name.service"
+      service_file.write("service")
+      primary_dest.write("old service")
+      compatible_dest.write("compatible service")
+      service = instance_double(
+        Homebrew::Services::FormulaWrapper,
+        name:                "name",
+        service_name:        "homebrew.name",
+        installed?:          true,
+        source_service_file: service_file,
+        service_contents:    "service",
+        dest:                primary_dest,
+        destinations:        [primary_dest, compatible_dest],
+        dest_dir:,
+        timed?:              false,
+      )
+
+      services_cli.install_service_file(service, nil)
+
+      expect([primary_dest.read, compatible_dest.exist?]).to eq(["service", false])
+    end
+
     it "installs timed systemd timer files" do
       allow(Homebrew::Services::System).to receive(:systemctl?).and_return(true)
+      expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
+        .with("disable", "sh.brew.name.timer").and_return(true)
       allow(Homebrew::Services::System::Systemctl).to receive(:run).with("daemon-reload")
 
       source_dir = mktmpdir
       dest_dir = mktmpdir
       service_file = source_dir/"homebrew.name.service"
       timer_file = source_dir/"homebrew.name.timer"
+      compatible_timer_dest = dest_dir/"sh.brew.name.timer"
       service_file.write("service")
-      timer_file.write("timer")
+      timer_file.write("legacy timer")
+      compatible_timer_dest.write("old timer")
       service = instance_double(
         Homebrew::Services::FormulaWrapper,
         name:                "name",
@@ -586,12 +808,14 @@ RSpec.describe Homebrew::Services::Cli do
         dest_dir:,
         timed?:              true,
         timer_file:,
+        timer_contents:      "timer",
         timer_dest:          dest_dir/timer_file.basename,
+        timer_destinations:  [dest_dir/timer_file.basename, compatible_timer_dest],
       )
 
       services_cli.install_service_file(service, nil)
 
-      expect(service.timer_dest.read).to eq("timer")
+      expect([service.timer_dest.read, compatible_timer_dest.exist?]).to eq(["timer", false])
     end
 
     context "when given `--sudo-service-user`" do

--- a/Library/Homebrew/test/services/formula_wrapper_spec.rb
+++ b/Library/Homebrew/test/services/formula_wrapper_spec.rb
@@ -14,10 +14,15 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
                     plist_name:             "sh.brew.mysql",
                     plist_names:            ["sh.brew.mysql"],
                     service_name:           "homebrew.mysql",
+                    service_names:          ["homebrew.mysql", "sh.brew.mysql"],
                     launchd_service_path:   Pathname.new("/usr/local/opt/mysql/sh.brew.mysql.plist"),
                     launchd_service_paths:  [Pathname.new("/usr/local/opt/mysql/sh.brew.mysql.plist")],
                     systemd_service_path:   Pathname.new("/usr/local/opt/mysql/homebrew.mysql.service"),
+                    systemd_service_paths:  [Pathname.new("/usr/local/opt/mysql/homebrew.mysql.service"),
+                                             Pathname.new("/usr/local/opt/mysql/sh.brew.mysql.service")],
                     systemd_timer_path:     Pathname.new("/usr/local/opt/mysql/homebrew.mysql.timer"),
+                    systemd_timer_paths:    [Pathname.new("/usr/local/opt/mysql/homebrew.mysql.timer"),
+                                             Pathname.new("/usr/local/opt/mysql/sh.brew.mysql.timer")],
                     opt_prefix:             Pathname.new("/usr/local/opt/mysql"),
                     any_version_installed?: true,
                     service?:               false)
@@ -103,6 +108,26 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
 
       expect(service.source_service_file).to eq(service_files.first)
     end
+
+    it "uses the compatible systemd service file when it is the only one present" do
+      service_files = [mktmpdir/"homebrew.mysql.service", mktmpdir/"sh.brew.mysql.service"]
+      service_files.last.write("service")
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+      allow(formula).to receive(:systemd_service_paths).and_return(service_files)
+
+      expect(service.source_service_file).to eq(service_files.last)
+    end
+  end
+
+  describe "#timer_file" do
+    it "uses the compatible systemd timer file when it is the only one present" do
+      timer_files = [mktmpdir/"homebrew.mysql.timer", mktmpdir/"sh.brew.mysql.timer"]
+      timer_files.last.write("timer")
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+      allow(formula).to receive(:systemd_timer_paths).and_return(timer_files)
+
+      expect([service.timer_file, service.timer_name]).to eq([timer_files.last, "homebrew.mysql.timer"])
+    end
   end
 
   describe "#name" do
@@ -146,6 +171,44 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
     end
   end
 
+  describe "#timer_contents" do
+    it "generates a timer from the formula service block" do
+      allow(service).to receive(:service?).and_return(true)
+      allow(service_object).to receive_messages(command?: true, to_systemd_timer: "timer contents")
+
+      expect(service.timer_contents).to eq("timer contents")
+    end
+
+    it "reads a package-provided timer file" do
+      timer_file = mktmpdir/"homebrew.mysql.timer"
+      timer_file.write("package timer")
+      allow(service).to receive_messages(service?: false, timer_file:)
+
+      expect(service.timer_contents).to eq("package timer")
+    end
+
+    it "rewrites a compatible package-provided timer unit for the destination label" do
+      timer_file = mktmpdir/"homebrew.mysql.timer"
+      timer_file.write("[Timer]\nUnit=homebrew.mysql.service\n")
+      allow(service).to receive_messages(
+        service?:      false,
+        service_name:  "sh.brew.mysql",
+        service_names: ["sh.brew.mysql", "homebrew.mysql"],
+        timer_file:,
+      )
+
+      expect(service.timer_contents).to eq("[Timer]\nUnit=sh.brew.mysql.service\n")
+    end
+
+    it "preserves an unrelated package-provided timer unit" do
+      timer_file = mktmpdir/"homebrew.mysql.timer"
+      timer_file.write("[Timer]\nUnit=custom.mysql.service\n")
+      allow(service).to receive_messages(service?: false, timer_file:)
+
+      expect(service.timer_contents).to eq("[Timer]\nUnit=custom.mysql.service\n")
+    end
+  end
+
   describe "#service_name" do
     it "macOS - outputs the service name" do
       allow(Homebrew::Services::System).to receive(:launchctl?).and_return(true)
@@ -172,6 +235,12 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
       allow(formula).to receive(:plist_names).and_return(["sh.brew.mysql", "homebrew.mxcl.mysql"])
 
       expect(service.service_names).to eq(["sh.brew.mysql", "homebrew.mxcl.mysql"])
+    end
+
+    it "includes both compatible default systemd labels" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+
+      expect(service.service_names).to eq(["homebrew.mysql", "sh.brew.mysql"])
     end
   end
 
@@ -217,6 +286,26 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
     it "systemD - outputs the destination for the service file" do
       allow(Homebrew::Services::System).to receive(:systemctl?).and_return(true)
       expect(service.dest.to_s).to eq("/tmp_home/.config/systemd/user/homebrew.mysql.service")
+    end
+
+    it "systemD - includes both compatible destinations" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+
+      expect(service.destinations.map(&:to_s)).to eq([
+        "/tmp_home/.config/systemd/user/homebrew.mysql.service",
+        "/tmp_home/.config/systemd/user/sh.brew.mysql.service",
+      ])
+    end
+  end
+
+  describe "#timer_destinations" do
+    it "includes both compatible systemd timer destinations" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+
+      expect(service.timer_destinations.map(&:to_s)).to eq([
+        "/tmp_home/.config/systemd/user/homebrew.mysql.timer",
+        "/tmp_home/.config/systemd/user/sh.brew.mysql.timer",
+      ])
     end
   end
 
@@ -306,8 +395,68 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
       expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
         .with("status", "homebrew.mysql.timer")
         .and_return(true)
+      expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
+        .with("status", "sh.brew.mysql.timer")
+        .and_return(false)
+      expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
+        .with("status", "sh.brew.mysql.service")
+        .and_return(false)
 
       expect(service.loaded?).to be(true)
+    end
+
+    it "finds a timed compatible systemd service running while its timer is inactive" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+      allow(service).to receive(:timed?).and_return(true)
+      allow(Homebrew::Services::System::Systemctl).to receive(:quiet_run).and_return(false)
+      expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
+        .with("status", "sh.brew.mysql.service").and_return(true)
+
+      expect(service.loaded_service_names).to eq(["sh.brew.mysql"])
+    end
+
+    it "finds a service loaded with the compatible systemd label" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+      expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
+        .with("status", "homebrew.mysql.service").and_return(false)
+      expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
+        .with("status", "sh.brew.mysql.service").and_return(true)
+
+      expect(service.loaded_service_names).to eq(["sh.brew.mysql"])
+    end
+
+    it "caches compatible systemd loaded-name probes" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+      expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
+        .with("status", "homebrew.mysql.service").once.and_return(false)
+      expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
+        .with("status", "sh.brew.mysql.service").once.and_return(true)
+
+      expect([
+        service.loaded?,
+        service.loaded?(cached: true),
+        service.loaded_service_names,
+      ]).to eq([true, true, ["sh.brew.mysql"]])
+    end
+
+    it "reports the active compatible systemd label" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+      allow(Homebrew::Services::System::Systemctl).to receive(:popen_read)
+        .with("status", "sh.brew.mysql.service").and_return("Main PID: 123 (mysqld)")
+      allow(service).to receive(:loaded_service_names).and_return(["sh.brew.mysql"])
+
+      expect(service.active_service_name).to eq("sh.brew.mysql")
+    end
+
+    it "finds a running compatible systemd service when its timer is inactive" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+      allow(service).to receive_messages(timed?: true, loaded_service_names: [])
+      allow(Homebrew::Services::System::Systemctl).to receive(:popen_read)
+        .with("status", "homebrew.mysql.service").and_return("Active: inactive (dead)")
+      allow(Homebrew::Services::System::Systemctl).to receive(:popen_read)
+        .with("status", "sh.brew.mysql.service").and_return("Main PID: 123 (mysqld)")
+
+      expect(service.active_service_name).to eq("sh.brew.mysql")
     end
 
     it "Other - raises an error" do
@@ -426,6 +575,14 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
 
       expect(service.registered_destination.basename.to_s).to eq("homebrew.mxcl.mysql.plist")
     end
+
+    it "prefers the systemd service file matching the active compatible label" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, root?: false, systemctl?: true)
+      allow(service).to receive_messages(active_service_name: "sh.brew.mysql", dest_dir: mktmpdir)
+      service.destinations.each { |destination| destination.write("service") }
+
+      expect(service.registered_destination.basename.to_s).to eq("sh.brew.mysql.service")
+    end
   end
 
   describe ".from" do
@@ -455,7 +612,7 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
           </plist>
         XML
       end
-      allow(Homebrew::Services::System).to receive(:launchctl?).and_return(true)
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: true, systemctl?: false)
       allow(formula).to receive(:launchd_service_paths).and_return(service_files)
       allow(Formulary).to receive(:factory).with("mysql").and_return(formula)
       expect(Homebrew::Services::System).to receive(:launchctl_service_running?)
@@ -467,6 +624,16 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
       raise "Expected service to be discovered" unless discovered_service
 
       expect(discovered_service.loaded_service_names).to be_empty
+    end
+
+    it "keeps the exact compatible systemd label it discovers" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+      allow(Formulary).to receive(:factory).with("mysql").and_return(formula)
+
+      discovered_service = described_class.from("/tmp/sh.brew.mysql.service")
+      raise "Expected service to be discovered" unless discovered_service
+
+      expect(discovered_service.service_names).to eq(["sh.brew.mysql"])
     end
   end
 

--- a/Library/Homebrew/test/utils/service_spec.rb
+++ b/Library/Homebrew/test/utils/service_spec.rb
@@ -51,6 +51,21 @@ RSpec.describe Utils::Service do
         .and_return(true)
       expect(described_class.running?(f)).to be true
     end
+
+    it "checks the compatible systemd label when the current label is not running" do
+      f = formula do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      systemctl = Pathname("/bin/systemctl")
+      allow(described_class).to receive_messages(launchctl: nil, systemctl?: true, systemctl:)
+      expect(described_class).to receive(:quiet_system)
+        .with(systemctl, "is-active", "--quiet", "homebrew.formula_name").and_return(false)
+      expect(described_class).to receive(:quiet_system)
+        .with(systemctl, "is-active", "--quiet", "sh.brew.formula_name").and_return(true)
+
+      expect(described_class.running?(f)).to be true
+    end
   end
 
   describe "::installed?" do
@@ -61,6 +76,20 @@ RSpec.describe Utils::Service do
       end
       allow(described_class).to receive(:launchctl?).and_return(true)
       allow(f).to receive(:launchd_service_paths).and_return([
+        instance_double(Pathname, exist?: false),
+        instance_double(Pathname, exist?: true),
+      ])
+
+      expect(described_class.installed?(f)).to be(true)
+    end
+
+    it "finds a compatible systemd service file" do
+      f = formula do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      allow(described_class).to receive_messages(launchctl?: false, systemctl?: true)
+      allow(f).to receive(:systemd_service_paths).and_return([
         instance_double(Pathname, exist?: false),
         instance_double(Pathname, exist?: true),
       ])

--- a/Library/Homebrew/utils/service.rb
+++ b/Library/Homebrew/utils/service.rb
@@ -14,7 +14,9 @@ module Utils
           Homebrew::Services::System.launchctl_service_running?(name)
         end
       elsif systemctl?
-        quiet_system(systemctl, "is-active", "--quiet", formula.service_name)
+        formula.service_names.any? do |name|
+          quiet_system(systemctl, "is-active", "--quiet", name)
+        end
       else
         false
       end
@@ -24,7 +26,7 @@ module Utils
     sig { params(formula: Formula).returns(T::Boolean) }
     def self.installed?(formula)
       (launchctl? && formula.launchd_service_paths.any?(&:exist?)) ||
-        (systemctl? && formula.systemd_service_path.exist?)
+        (systemctl? && formula.systemd_service_paths.any?(&:exist?))
     end
 
     # Path to launchctl binary.


### PR DESCRIPTION
`brew services` assumes a Linux service is always named `homebrew.<formula>`. This is phase one of moving that default to `sh.brew.<formula>`, mirroring #23741 for macOS: discovery and control now accept either systemd unit name, so both forms can coexist safely before the default is flipped. The unit name written to disk does not change here.

Formulae using the default Linux name expose both names. An explicit `name linux:` stays single valued even when it matches a default, and now serializes explicitly so it survives the later default change; a `Formula` subclass overriding `service_name` keeps its custom identity. Status probes every compatible unit and reports the one holding the PID; `stop` and `kill` act on the exact units found, including a running service whose timer is inactive; `start` and `run` will not register a second unit when the alternate name is already loaded; orphan cleanup stays pinned to the unit it discovered. `brew bundle` version pinned lookup and the `Utils::Service` probes accept either unit filename.

Unit files are only removed after `systemctl disable`, so replacing or unregistering the alternate name cannot leave a dangling `.wants` symlink. Timers are regenerated from the formula, and a package-provided timer only has its `Unit=` rewritten when it names a compatible label. An accepted `--no-wait` stop still cleans up. Status probes are cached per wrapper and invalidated after every mutation. macOS and launchd behavior is unchanged.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Fable 5.1) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the change and pass with it, and ran `brew lgtm --online`.

-----
