### PR TITLE
Share Python dependency lookup with Formula#python3

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -918,18 +918,14 @@ class Formula
   # @api public
   sig { returns(Pathname) }
   def python3
-    python_deps = deps.filter_map do |dep|
-      name = Utils.name_from_full_name(dep.name)
-      name if name.match?(/\Apython@3\.\d+\z/)
-    end.uniq
+    python_deps = Language::Python.direct_dependency_paths(self, pattern: /\Apython@3\.\d+\z/)
 
     if python_deps.length != 1
-      found = python_deps.empty? ? "none" : python_deps.join(", ")
+      found = python_deps.empty? ? "none" : python_deps.keys.join(", ")
       raise "`#{full_name}` must have exactly one `python@3.x` dependency to use `python3`; found #{found}."
     end
 
-    python_dep = python_deps.fetch(0)
-    formula_opt_bin(python_dep)/python_dep.delete("@")
+    python_deps.values.fetch(0)
   end
 
   # The declared {Dependency}s for the currently active {SoftwareSpec} (i.e. including those provided by macOS).

--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -12,6 +12,26 @@ module Language
   module Python
     extend ::Utils::Output::Mixin
 
+    # Returns stable executable paths keyed by direct Python dependency name.
+    # @api private
+    sig {
+      params(
+        formula:  Formula,
+        pattern:  Regexp,
+        required: T::Boolean,
+      ).returns(T::Hash[String, Pathname])
+    }
+    def self.direct_dependency_paths(formula, pattern: /\Apython(?:@.+)?\z/, required: false)
+      formula.deps.filter_map do |dependency|
+        next if required && !dependency.required?
+
+        name = Utils.name_from_full_name(dependency.name)
+        next unless name.match?(pattern)
+
+        [name, Utils::Path.formula_opt_bin(name)/name.delete("@")]
+      end.to_h
+    end
+
     sig { params(python: T.any(String, Pathname)).returns(T.nilable(Version)) }
     def self.major_minor_version(python)
       version = `#{python} --version 2>&1`.chomp[/(\d\.\d+)/, 1]
@@ -117,14 +137,13 @@ module Language
         python_path = if use_python_from_path
           "/usr/bin/env python3"
         else
-          python_deps = formula.deps.select(&:required?).map(&:name).grep(/^python(@.+)?$/)
+          python_deps = Language::Python.direct_dependency_paths(formula, required: true)
           raise ShebangDetectionError.new("Python", "formula does not depend on Python") if python_deps.empty?
           if python_deps.length > 1
             raise ShebangDetectionError.new("Python", "formula has multiple Python dependencies")
           end
 
-          python_dep = python_deps.first
-          Utils::Path.formula_opt_bin(python_dep)/python_dep.sub("@", "")
+          python_deps.values.fetch(0)
         end
 
         python_shebang_rewrite_info(python_path)

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -186,15 +186,16 @@ RSpec.describe Formula do
       expect(f.python3).to eq HOMEBREW_PREFIX/"opt/python@3.14/bin/python3.14"
     end
 
-    it "fails when there is no direct Python dependency" do
-      f = formula "no-python-dependency" do
+    it "fails without a direct versioned Python 3 dependency" do
+      f = formula "unversioned-python" do
         url "foo-1.0"
+        depends_on "python"
         depends_on "boost-python3"
       end
 
       expect { f.python3 }
         .to raise_error(RuntimeError,
-                        "`no-python-dependency` must have exactly one `python@3.x` dependency to use `python3`; " \
+                        "`unversioned-python` must have exactly one `python@3.x` dependency to use `python3`; " \
                         "found none.")
     end
 

--- a/Library/Homebrew/test/language/python_spec.rb
+++ b/Library/Homebrew/test/language/python_spec.rb
@@ -4,6 +4,37 @@
 require "language/python"
 
 RSpec.describe Language::Python, :needs_python do
+  describe ".direct_dependency_paths", needs_python: false do
+    it "returns unique stable paths for tap-qualified direct Python dependencies" do
+      f = formula "foo" do
+        T.bind(self, T.class_of(Formula))
+        url "https://brew.sh/foo-1.0.tgz"
+
+        depends_on "homebrew/core/python@3.14" => :build
+        depends_on "homebrew/core/python@3.14" => :test
+        depends_on "python-setuptools"
+      end
+
+      expect(described_class.direct_dependency_paths(f)).to eq(
+        "python@3.14" => HOMEBREW_PREFIX/"opt/python@3.14/bin/python3.14",
+      )
+    end
+
+    it "can limit paths to required Python dependencies" do
+      f = formula "foo" do
+        T.bind(self, T.class_of(Formula))
+        url "https://brew.sh/foo-1.0.tgz"
+
+        depends_on "python@3.13"
+        depends_on "python@3.14" => :build
+      end
+
+      expect(described_class.direct_dependency_paths(f, required: true)).to eq(
+        "python@3.13" => HOMEBREW_PREFIX/"opt/python@3.13/bin/python3.13",
+      )
+    end
+  end
+
   describe "#major_minor_version" do
     it "returns a Version for Python 2" do
       expect(described_class).to receive(:major_minor_version).and_return(Version)


### PR DESCRIPTION
Follow-up to #23754 addressing @MikeMcQuaid's review request to share code between `Formula#python3` and the `language/python` shebang logic. Adds `Language::Python.direct_dependency_paths`, which maps a formula's direct Python dependency names to their stable `opt` executable paths, normalizing tap-qualified names and de-duplicating repeated declarations. `Formula#python3` calls it with a `python@3.x` pattern over all direct dependencies and `detected_python_shebang` calls it with `required: true`, so both keep their existing scope, exceptions and messages.

The one behavior change is in `detected_python_shebang`: a tap-qualified Python dependency, or the same Python dependency declared more than once, now resolves where it previously raised, matching `Formula#python3`.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Fable 5.1) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the change and pass with it, and ran `brew lgtm --online` plus targeted specs.

-----
