### PR TITLE
pkg: seed the API cache as the install user

### DIFF
--- a/package/scripts/postinstall
+++ b/package/scripts/postinstall
@@ -157,9 +157,10 @@ user_home_dir="$(homebrew-user-home "${homebrew_pkg_user}")" ||
   }
 user_cache_dir="${user_home_dir}/Library/Caches/Homebrew"
 user_api_cache_dir="${user_cache_dir}/api"
-mkdir -vp "${user_api_cache_dir}"
-cp -vpR "${homebrew_directory}/cache_api/." "${user_api_cache_dir}"
-chown -R "${homebrew_pkg_user}:staff" "${user_cache_dir}"
+# Seed the cache as the install user: as root, `cp` follows a symlink planted at the
+# destination, and the `chown -R` this removes would reach anything hard-linked into the tree.
+sudo -u "${homebrew_pkg_user}" mkdir -vp "${user_api_cache_dir}"
+sudo -u "${homebrew_pkg_user}" cp -vpR "${homebrew_directory}/cache_api/." "${user_api_cache_dir}"
 rm -vrf "${homebrew_directory}/cache_api"
 
 # create paths.d file for /opt/homebrew installs


### PR DESCRIPTION
The installer seeds the user's API cache by having root `mkdir -p` and `cp` into `~/Library/Caches/Homebrew`, then `chown -R` the result to the install user. All three run as root inside a directory that user controls. The `cp` follows a symlink planted at the destination, and `chown -R` reaches the inode behind any hard link placed in the tree, so a file elsewhere on the system can have its ownership transferred to that user. Measured on macOS 26.6.2: `chown -R` leaves a symlink's target alone, which is the BSD `-P` default, but a hard link's target does change owner.

Running `mkdir` and `cp` as the install user removes both. The files are then created with the right ownership to begin with, which is what the `chown -R` was for: it arrived in e0ac5459b3 alongside the root `mkdir`/`cp` it was compensating for, so dropping the privileges makes it redundant rather than merely safer.

Reaching this needs a second local account, so a single-user Mac is unaffected, and it needs that account to plant an entry before the install runs. No configuration is involved either way.

`cache_api` is readable by the install user at that point in every branch, since it is inside the tree the preceding `chown -R` has already handed over, either as `Homebrew` for `/usr/local` installs or as `.` otherwise.

Two checklist items are left unticked deliberately. No `brew` command is involved, so there are no steps to reproduce: it needs a second local account and a `.pkg` install. And the installer scripts have no test harness, so this is verified with `shellcheck -x` and by re-running both `postinstall` guards from `release.yml`.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Claude Code with Opus 5, with local review and testing.

-----
