### PR TITLE
cask/audit: fix repo names ending in git

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -1457,7 +1457,7 @@ module Cask
       _, user, repo = *regex.match(cask.homepage) unless user
       return if !user || !repo
 
-      repo.gsub!(/.git$/, "")
+      repo.delete_suffix!(".git")
 
       [user, repo]
     end

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -1363,6 +1363,22 @@ RSpec.describe Cask::Audit, :cask do
       end
     end
 
+    describe "GitHub repository archived check" do
+      let(:online) { true }
+      let(:only) { ["github_repository_archived"] }
+      let(:cask) do
+        Cask::Cask.new("sourcegit") do
+          url "https://github.com/sourcegit-scm/sourcegit/releases/download/v1.0/sourcegit.zip"
+        end
+      end
+
+      it "keeps a repository name ending in git intact" do
+        allow(SharedAudits).to receive(:github_repo_data).with("sourcegit-scm", "sourcegit")
+                                                         .and_return({ "archived" => true })
+        expect(run).to error_with("GitHub repo is archived")
+      end
+    end
+
     describe "Rosetta checks" do
       let(:online) { true }
       let(:only) { ["rosetta"] }


### PR DESCRIPTION
`get_repo_data` used `gsub!(/.git$/)` with an unescaped dot, so a repository whose name ends in \"git\" (e.g. sourcegit) lost its last character and the archived/prerelease/notability checks silently skipped on 404. Use delete_suffix! like `FormulaAuditor#get_repo_data`.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Fable 5 with review.