### PR TITLE
cask: skip cask loader when no casks are installed

### DIFF
--- a/Library/Homebrew/cask/caskroom.rb
+++ b/Library/Homebrew/cask/caskroom.rb
@@ -227,6 +227,8 @@ module Cask
     # @api internal
     sig { params(config: T.nilable(Config)).returns(T::Array[Cask]) }
     def self.casks(config: nil)
+      return [] unless any_casks_installed?
+
       require "cask/cask_loader"
 
       tokens.sort.filter_map do |token|

--- a/Library/Homebrew/test/cask/caskroom_spec.rb
+++ b/Library/Homebrew/test/cask/caskroom_spec.rb
@@ -150,6 +150,15 @@ RSpec.describe Cask::Caskroom do
       })
     end
 
+    it "does not load the cask loader when no casks are installed" do
+      Dir.mktmpdir do |dir|
+        allow(described_class).to receive(:path).and_return(Pathname(dir))
+        expect(described_class).not_to receive(:require)
+
+        described_class.casks
+      end
+    end
+
     it "includes casks installed from untrusted taps without loading cask files" do
       token = "untrusted-cask"
       tap = Tap.fetch("thirdparty", "foo")


### PR DESCRIPTION
`Caskroom.casks` required `cask/cask_loader` (96 files, ~25 ms) before checking the Caskroom, so `leaves`, `missing`, `autoremove` and `doctor` paid for it on hosts with no casks installed.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Fable 5.1 with manual review.