### PR TITLE
Escape dots in domain regexps

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -503,13 +503,13 @@ module Cask
       add_livecheck = "please add a livecheck. See #{Formatter.url(LIVECHECK_REFERENCE_URL)}"
 
       case url.to_s
-      when %r{sourceforge.net/(\S+)}
+      when %r{sourceforge\.net/(\S+)}
         return unless online?
 
         add_error "Download is hosted on SourceForge, #{add_livecheck}", location: url.location
-      when %r{dl.devmate.com/(\S+)}
+      when %r{dl\.devmate\.com/(\S+)}
         add_error "Download is hosted on DevMate, #{add_livecheck}", location: url.location
-      when %r{rink.hockeyapp.net/(\S+)}
+      when %r{rink\.hockeyapp\.net/(\S+)}
         add_error "Download is hosted on HockeyApp, #{add_livecheck}", location: url.location
       end
     end

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -965,7 +965,7 @@ module Homebrew
         return if stable_url_minor_version.even?
 
         problem "Stable: version (#{stable.version}) is a development release"
-      when %r{isc.org/isc/bind\d*/}i
+      when %r{isc\.org/isc/bind\d*/}i
         return if stable_url_minor_version.even?
 
         problem "Stable: version (#{stable.version}) is a development release"
@@ -983,7 +983,7 @@ module Homebrew
           error = SharedAudits.gitlab_release(owner, repo, tag, formula:)
           problem error if error
         end
-      when %r{^https://github.com/([\w-]+)/([\w-]+)}
+      when %r{^https://github\.com/([\w-]+)/([\w-]+)}
         owner = Regexp.last_match(1)
         repo = Regexp.last_match(2)
         raise "Could not determine the GitHub owner and repository from #{url}" if owner.nil? || repo.nil?

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -692,7 +692,7 @@ module Formulary
       Utils::Curl.curl_download url.to_s, to: path
       super
     rescue MethodDeprecatedError => e
-      if (match_data = url.to_s.match(%r{github.com/(?<user>[\w-]+)/(?<repo>[\w-]+)/}).presence)
+      if (match_data = url.to_s.match(%r{github\.com/(?<user>[\w-]+)/(?<repo>[\w-]+)/}).presence)
         e.issues_url = "https://github.com/#{match_data[:user]}/#{match_data[:repo]}/issues/new"
       end
       raise

--- a/Library/Homebrew/rubocops/patches.rb
+++ b/Library/Homebrew/rubocops/patches.rb
@@ -58,7 +58,7 @@ module RuboCop
         def patch_problems(patch_url_node, sha256_node)
           patch_url = string_content(patch_url_node)
 
-          if regex_match_group(patch_url_node, %r{https://github.com/[^/]*/[^/]*/pull})
+          if regex_match_group(patch_url_node, %r{https://github\.com/[^/]*/[^/]*/pull})
             problem "Use a commit hash URL rather than an unstable pull request URL: #{patch_url}"
           end
 
@@ -66,7 +66,7 @@ module RuboCop
             problem "Use a commit hash URL rather than an unstable merge request URL: #{patch_url}"
           end
 
-          if regex_match_group(patch_url_node, %r{https://github.com/[^/]*/[^/]*/commit/[a-fA-F0-9]*\.diff})
+          if regex_match_group(patch_url_node, %r{https://github\.com/[^/]*/[^/]*/commit/[a-fA-F0-9]*\.diff})
             problem "GitHub patches should end with .patch, not .diff: #{patch_url}" do |corrector|
               # Replace .diff with .patch, keeping either the closing quote or query parameter start
               correct = patch_url_node.source.sub(/\.diff(["?])/, '.patch\1')

--- a/Library/Homebrew/rubocops/shared/homepage_helper.rb
+++ b/Library/Homebrew/rubocops/shared/homepage_helper.rb
@@ -54,7 +54,7 @@ module RuboCop
             corrector.replace(homepage_parameter_node.source_range, "\"#{fixed}\"")
           end
 
-        when %r{^https://github.com.*\.git$}
+        when %r{^https://github\.com.*\.git$}
           problem "GitHub homepages should not end with .git" do |corrector|
             corrector.replace(homepage_parameter_node.source_range, "\"#{content.delete_suffix(".git")}\"")
           end

--- a/Library/Homebrew/rubocops/shared/url_helper.rb
+++ b/Library/Homebrew/rubocops/shared/url_helper.rb
@@ -278,7 +278,7 @@ module RuboCop
         # Don't use GitHub .zip files
         zip_gh_pattern = %r{https://.*github.*/(archive|releases)/.*\.zip$}
         audit_urls(urls, zip_gh_pattern) do |_, url|
-          next if url.match? %r{raw.githubusercontent.com/.*/.*/(main|master|HEAD)/}
+          next if url.match? %r{raw\.githubusercontent\.com/.*/.*/(main|master|HEAD)/}
           next if url.include?("releases/download")
           next if url.include?("desktop.githubusercontent.com/releases/")
 


### PR DESCRIPTION
These were flagged by github-advanced-security in https://github.com/Homebrew/brew/pull/23793#pullrequestreview-5118977744, so I thought I would just clean up all instances in a dedicated PR. (It's also a regexp pico-optimization 😛)

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Claude Code with Opus 5, with local review and testing.

-----
