### PR TITLE
Stop brew tests dirtying the working tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /Library/Homebrew/test/.gem
 /Library/Homebrew/test/.cargo/
 /Library/Homebrew/test/.homebrew/
+/Library/Homebrew/test/.local/share/
 /Library/Homebrew/test/.subversion
 /Library/Homebrew/test/coverage
 /Library/Homebrew/test/junit

--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -274,6 +274,8 @@ module Homebrew
         ENV["HOME"] = "#{HOMEBREW_LIBRARY_PATH}/test"
         # Keep generic tool caches (e.g. RuboCop) out of the sandboxed test home.
         ENV["XDG_CACHE_HOME"] = "#{HOMEBREW_CACHE}/tests"
+        # Same for tool state, e.g. `mise` writes `.local/state/mise` under `$HOME`.
+        ENV["XDG_STATE_HOME"] = "#{HOMEBREW_CACHE}/tests-state"
         # Sandbox the config home too, so the spec teardown can't delete the real `trust.json`.
         ENV["HOMEBREW_USER_CONFIG_HOME"] = "#{Dir.home}/.homebrew"
 

--- a/Library/Homebrew/test/dev-cmd/tests_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tests_spec.rb
@@ -191,6 +191,13 @@ RSpec.describe Homebrew::DevCmd::Tests do
       expect(ENV.fetch("XDG_CACHE_HOME")).not_to start_with("#{Dir.home}/")
     end
 
+    it "keeps generic tool state out of the sandboxed test home" do
+      tests.setup_environment!
+
+      expect(ENV.fetch("XDG_STATE_HOME")).to eq("#{HOMEBREW_CACHE}/tests-state")
+      expect(ENV.fetch("XDG_STATE_HOME")).not_to start_with("#{Dir.home}/")
+    end
+
     it "can disable Sorbet runtime" do
       ENV["HOMEBREW_TESTS_NO_SORBET_RUNTIME"] = "1"
       tests.setup_environment!


### PR DESCRIPTION
`brew tests` points `HOME` at `Library/Homebrew/test` so local configuration cannot affect a run, which means any tool a spec shells out to writes into the checkout. `mise` left `.local/state/mise/tracked-configs` and `.local/share/mise/migrations` behind, untracked and never cleaned up. The tool is incidental, since anything that respects `$HOME` can do this, and it cannot be fixed from the other side: `bin/brew` filters the environment down to an allowlist, so exported `XDG_*` and `MISE_*` never reach the spec subprocesses.

The fix has two halves, each matching how brew already handles this. `XDG_CACHE_HOME` is redirected out of the test home on the line above, in 38ff3626da, so `XDG_STATE_HOME` is redirected the same way; nothing in brew reads it. `XDG_DATA_HOME` is deliberately not redirected, because unlike a cache or state directory it holds live tool installs, and pointing it elsewhere left a `mise` shim unable to resolve its own Ruby at all. What lands under it is gitignored instead, joining the six entries already there for tools that write into the test home: `test/.gem`, `.cargo/`, `.homebrew/`, `.subversion`, `.npm/` and `.rdbg_history`. The entry is `test/.local/share/` rather than `test/.local/` on purpose, so that `.local/state/` stays visible and a regression in the redirect still surfaces in `git status` instead of being silently ignored.

Repro, with `mise` installed:

```
HOME="$PWD/Library/Homebrew/test" mise current
ls Library/Homebrew/test/.local
```

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

AI/LLM disclosure: Claude Opus 5 via Claude Code helped trace the leak and draft the change; I reviewed it and confirmed the checkout stays clean across full test runs.

-----
