### PR TITLE
Re-sign node-gyp addons after stripping them

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -654,12 +654,12 @@ class Keg
     strip = which("strip")
     return if strip.nil?
 
+    stripped_files = []
     path.find do |pn|
       next if pn.symlink? || pn.extname != ".node" || pn.to_s.exclude?("/node_modules/")
 
       # node-gyp addons' `N_OSO`/`N_SO` stab strings embed keg build paths,
-      # which pin bottles; stripping debug entries removes them and Apple
-      # `strip` re-signs ad hoc, so no separate codesign step is needed.
+      # which pin bottles; stripping debug entries removes them.
       # Strip to a temporary file so a failure (e.g. an addon `strip` cannot
       # parse) leaves the addon untouched.
       stripped = Pathname("#{pn}.stripped")
@@ -667,10 +667,14 @@ class Keg
         mode = pn.stat.mode
         FileUtils.mv stripped, pn
         pn.chmod mode
+        stripped_files << pn
       else
         FileUtils.rm_f stripped
       end
     end
+
+    # `strip -o` writes a new file instead of editing in place, so it never re-signs: reapply the ad-hoc signature.
+    codesign_patched_binaries(stripped_files)
   end
 
   sig { void }

--- a/Library/Homebrew/test/keg_spec.rb
+++ b/Library/Homebrew/test/keg_spec.rb
@@ -496,6 +496,25 @@ RSpec.describe Keg do
 
       expect(addon.read).to eq "unstripped"
     end
+
+    it "re-signs addons that were stripped" do
+      allow(keg).to receive(:quiet_system) do |*command|
+        File.write(command.fetch(3), "stripped")
+        true
+      end
+
+      expect(keg).to receive(:codesign_patched_binaries).with([addon])
+
+      keg.strip_node_gyp_addons!
+    end
+
+    it "does not re-sign addons when strip fails" do
+      allow(keg).to receive(:quiet_system).and_return(false)
+
+      expect(keg).to receive(:codesign_patched_binaries).with([])
+
+      keg.strip_node_gyp_addons!
+    end
   end
 
   describe "#homebrew_created_file?" do


### PR DESCRIPTION
-----

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

AI-assisted: Claude Opus 5 helped locate the failing code path, draft the patch and the tests. I reproduced the bug and verified the fix myself on macOS 15 arm64 with the commands below.

-----

`strip_node_gyp_addons!` assumes Apple `strip` re-signs ad hoc, but that only holds for in-place edits, with `-o` it writes a fresh, unsigned file. On Apple Silicon dyld then SIGKILLs anything loading the addon, with no output, so `brew test` reports `Expected: 0 / Actual: nil`. Only formulae that `deuniversalize_machos` an fsevents-style addon are affected, and only after `brew bottle` runs, which is why local `brew install` + `brew test` pass while CI fails.

Related PRs
- https://github.com/Homebrew/homebrew-core/pull/302496
- https://github.com/Homebrew/homebrew-core/pull/301953
- https://github.com/Homebrew/homebrew-core/pull/301941
