### PR TITLE
Bump resources pinned to a git tag

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -637,10 +637,13 @@ module Homebrew
 
       sig {
         params(formula_or_resource: T.any(Formula, Resource), new_version: T.nilable(String), url: String,
-               specs: String).returns(T::Array[T.untyped])
+               specs: T.any(String, Symbol, T::Class[AbstractDownloadStrategy]))
+          .returns(T::Array[T.untyped])
       }
       def fetch_resource_and_forced_version(formula_or_resource, new_version, url, **specs)
-        resource = Resource.new
+        # Name it so each resource gets a distinct download cache path
+        resource_name = formula_or_resource.name if formula_or_resource.is_a?(Resource)
+        resource = Resource.new(resource_name)
         resource.url(url, **specs)
         resource.owner = if formula_or_resource.is_a?(Formula)
           Resource.new(formula_or_resource.name)
@@ -735,9 +738,8 @@ module Homebrew
         nil
       end
 
-      # TODO: Add support for resources using `tag` and/or `revision` instead of
-      # `url`+`sha256`, resource URLs with options, and resources inside `on_os`
-      # or `on_arch` blocks.
+      # TODO: Add support for resource URLs with options and resources inside
+      # `on_os` or `on_arch` blocks.
       sig {
         params(
           formula:     Formula,
@@ -750,6 +752,52 @@ module Homebrew
 
         old_url = resource.url
         raise ArgumentError, "resource \"#{resource.name}\" has no URL" if old_url.nil?
+
+        if (old_tag = resource.specs[:tag].presence) && resource.download_strategy <= GitDownloadStrategy
+          tag = update_url(old_tag, resource.version.to_s, new_version)
+          if tag == old_tag
+            opoo <<~EOS
+              You need to bump resource "#{resource.name}" manually since the new tag
+              and old tag are both:
+                #{tag}
+            EOS
+            return :tag_unchanged
+          end
+
+          # `specs` omits `using:`, so pass it through to keep an explicit strategy
+          git_specs = { tag: }
+          if (using = resource.using.presence)
+            git_specs[:using] = using
+          end
+          resource_path, forced_version = fetch_resource_and_forced_version(resource, new_version, old_url,
+                                                                            **git_specs)
+          new_revision = Utils.popen_read("git", "-C", resource_path.to_s, "rev-parse", "-q", "--verify",
+                                          "HEAD").strip
+          if new_revision.blank?
+            opoo "Could not resolve a revision for resource \"#{resource.name}\" tag #{tag}."
+            return :revision_unresolved
+          end
+
+          resource_name = resource.name.to_s
+          formula_ast = Utils::AST::FormulaAST.new(formula.path.read)
+          formula_ast.replace_resource_stanza_hash_value(resource_name, :url, :tag, tag)
+          if resource.specs[:revision].present?
+            formula_ast.replace_resource_stanza_hash_value(resource_name, :url, :revision, new_revision)
+          end
+
+          if forced_version
+            if formula_ast.resource_stanza?(resource_name, :version)
+              formula_ast.replace_resource_stanza_value(resource_name, :version, new_version)
+            else
+              formula_ast.add_stanzas_after(:url, [[:version, "version #{new_version.inspect}"]],
+                                            parent: formula_ast.resource(resource_name))
+            end
+          end
+
+          formula.path.atomic_write(formula_ast.process)
+
+          return :success
+        end
 
         new_url = update_url(old_url, resource.version.to_s, new_version)
 

--- a/Library/Homebrew/test/dev-cmd/bump-formula-pr_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-formula-pr_spec.rb
@@ -331,6 +331,88 @@ RSpec.describe Homebrew::DevCmd::BumpFormulaPr do
       expect(formula_path.read).to include("version #{payload.inspect}")
     end
 
+    it "updates tag and revision for a git resource" do
+      formula_path = CoreTap.instance.new_formula_path("gitresourceball")
+      formula_path.dirname.mkpath
+      formula_path.write <<~RUBY
+        class Gitresourceball < Formula
+          url "https://brew.sh/gitresourceball-1.0.tar.gz"
+
+          resource "foo" do
+            url "https://brew.sh/foo.git",
+                tag:      "v1.2.3",
+                revision: "#{"a" * 40}"
+          end
+        end
+      RUBY
+      CoreTap.instance.clear_cache
+      Formulary.clear_cache
+      Formula.clear_cache
+      formula = Formulary.from_contents("gitresourceball", formula_path, formula_path.read)
+
+      allow(bump_formula_pr).to receive(:fetch_resource_and_forced_version).and_return([mktmpdir, false])
+      allow(Utils).to receive(:popen_read).and_return("#{"b" * 40}\n")
+
+      resource_versions = { "foo" => { current_version: "1.2.3", latest_version: "2.0.0" } }
+
+      expect(bump_formula_pr.update_resources!(formula, resource_versions:)).to eq({ "foo" => :success })
+      expect(formula_path.read).to include('tag:      "v2.0.0"')
+      expect(formula_path.read).to include("revision: \"#{"b" * 40}\"")
+    end
+
+    it "updates the URL for a non-git resource carrying a tag" do
+      formula_path = CoreTap.instance.new_formula_path("tarballwithtag")
+      formula_path.dirname.mkpath
+      formula_path.write <<~RUBY
+        class Tarballwithtag < Formula
+          url "https://brew.sh/tarballwithtag-1.0.tar.gz"
+
+          resource "foo" do
+            url "https://brew.sh/foo-1.2.3.tar.gz", tag: "v1.2.3"
+            sha256 "#{"a" * 64}"
+          end
+        end
+      RUBY
+      CoreTap.instance.clear_cache
+      Formulary.clear_cache
+      Formula.clear_cache
+      formula = Formulary.from_contents("tarballwithtag", formula_path, formula_path.read)
+
+      resource_path = mktmpdir/"foo-2.0.0.tar.gz"
+      resource_path.write "test"
+      allow(bump_formula_pr).to receive(:fetch_resource_and_forced_version).and_return([resource_path, false])
+
+      resource_versions = { "foo" => { current_version: "1.2.3", latest_version: "2.0.0" } }
+
+      expect(bump_formula_pr.update_resources!(formula, resource_versions:)).to eq({ "foo" => :success })
+      expect(formula_path.read).to include("https://brew.sh/foo-2.0.0.tar.gz")
+      expect(formula_path.read).to include(%Q(sha256 "#{resource_path.sha256}"))
+    end
+
+    it "reports git resources whose tag does not change" do
+      formula_path = CoreTap.instance.new_formula_path("sametagball")
+      formula_path.dirname.mkpath
+      formula_path.write <<~RUBY
+        class Sametagball < Formula
+          url "https://brew.sh/sametagball-1.0.tar.gz"
+
+          resource "foo" do
+            url "https://brew.sh/foo.git",
+                tag:      "stable",
+                revision: "#{"a" * 40}"
+          end
+        end
+      RUBY
+      CoreTap.instance.clear_cache
+      Formulary.clear_cache
+      Formula.clear_cache
+      formula = Formulary.from_contents("sametagball", formula_path, formula_path.read)
+
+      resource_versions = { "foo" => { current_version: "1.2.3", latest_version: "2.0.0" } }
+
+      expect(bump_formula_pr.update_resources!(formula, resource_versions:)).to eq({ "foo" => :tag_unchanged })
+    end
+
     it "downgrades to requested version" do
       version = "0.1.2"
       resource_versions = { "foo" => { current_version: "1.2.3", latest_version: version } }

--- a/Library/Homebrew/test/utils/ast/formula_ast_spec.rb
+++ b/Library/Homebrew/test/utils/ast/formula_ast_spec.rb
@@ -214,6 +214,44 @@ RSpec.describe Utils::AST::FormulaAST do
     end
   end
 
+  describe "#replace_resource_stanza_hash_value" do
+    subject(:formula_ast) do
+      described_class.new <<~RUBY
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tar.gz"
+
+          resource "bar" do
+            url "https://brew.sh/bar.git",
+                tag:      "v1.0",
+                revision: "#{"a" * 40}"
+          end
+        end
+      RUBY
+    end
+
+    it "replaces keyword arguments of a resource stanza" do
+      formula_ast.replace_resource_stanza_hash_value("bar", :url, :tag, "v2.0")
+      formula_ast.replace_resource_stanza_hash_value("bar", :url, :revision, "b" * 40)
+
+      expect(formula_ast.process).to eq <<~RUBY
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tar.gz"
+
+          resource "bar" do
+            url "https://brew.sh/bar.git",
+                tag:      "v2.0",
+                revision: "#{"b" * 40}"
+          end
+        end
+      RUBY
+    end
+
+    it "raises when the keyword is missing" do
+      expect { formula_ast.replace_resource_stanza_hash_value("bar", :url, :branch, "main") }
+        .to raise_error(/Could not find 'branch' value/)
+    end
+  end
+
   describe "#replace_resource_stanzas" do
     it "inserts resource stanzas before the install method" do
       formula_ast = described_class.new <<~RUBY

--- a/Library/Homebrew/utils/ast.rb
+++ b/Library/Homebrew/utils/ast.rb
@@ -184,6 +184,18 @@ module Utils
         replace_stanza_value(resource_stanza(resource_name, name, old_value:), value)
       end
 
+      sig {
+        params(
+          resource_name: String,
+          name:          Symbol,
+          key:           Symbol,
+          value:         T.any(Numeric, String, Symbol),
+        ).void
+      }
+      def replace_resource_stanza_hash_value(resource_name, name, key, value)
+        replace_stanza_hash_value(resource_stanza(resource_name, name), key, value)
+      end
+
       sig { params(resource_name: String, name: Symbol).returns(T::Boolean) }
       def resource_stanza?(resource_name, name)
         matching_stanzas(body_children(resource(resource_name).body), name).present?


### PR DESCRIPTION
-----

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

AI-assisted: Claude Opus 5 drafted the patch and tests; I verified and reviewed the output myself.

-----

`update_resource_block!` substitutes the version into the resource URL, so a resource pinned with `tag:`/`revision:` always compares equal and bails out as `url_unchanged`. Rewrite `tag:` instead, then resolve and rewrite `revision:`, as a formula's own git URL already does. Covers part of the `TODO` above that method.