### PR TITLE
utils/tty: avoid caching an unfinished size

### DIFF
--- a/Library/Homebrew/test/utils/tty_spec.rb
+++ b/Library/Homebrew/test/utils/tty_spec.rb
@@ -79,6 +79,27 @@ RSpec.describe Tty do
       expect(described_class.size).to be_nil
       expect(described_class.size).to be_nil
     end
+
+    it "does not expose an unfinished size to another thread" do
+      probe_started = Queue.new
+      release_probe = Queue.new
+      allow(described_class).to receive(:`).with("/bin/stty size 2>/dev/null").and_invoke(
+        lambda { |_command|
+          probe_started << true
+          release_probe.pop
+          "40 160"
+        },
+        ->(_command) { "40 160" },
+      )
+
+      probing_thread = Thread.new { described_class.size }
+      probe_started.pop
+
+      expect(described_class.size).to eq([40, 160])
+    ensure
+      release_probe&.push(true)
+      probing_thread&.value
+    end
   end
 
   describe "::width" do

--- a/Library/Homebrew/utils/tty.rb
+++ b/Library/Homebrew/utils/tty.rb
@@ -140,7 +140,8 @@ module Tty
       return @size if defined?(@size)
 
       height, width = `/bin/stty size 2>/dev/null`.presence&.split&.map(&:to_i)
-      @size = T.let((height && width) ? [height, width] : nil, T.nilable([Integer, Integer]))
+      size = [height, width] if height && width
+      @size = T.let(size, T.nilable([Integer, Integer]))
     end
 
     sig { returns(Integer) }

--- a/Library/Homebrew/utils/tty.rb
+++ b/Library/Homebrew/utils/tty.rb
@@ -139,11 +139,8 @@ module Tty
     def size
       return @size if defined?(@size)
 
-      @size = T.let(nil, T.nilable([Integer, Integer]))
       height, width = `/bin/stty size 2>/dev/null`.presence&.split&.map(&:to_i)
-      @size = [height, width] if height && width
-
-      @size
+      @size = T.let((height && width) ? [height, width] : nil, T.nilable([Integer, Integer]))
     end
 
     sig { returns(Integer) }


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
I used OpenAI Codex with gpt-6-astra (xhigh) to help investigate and fix this issue and reviewed the changes. Homebrew could mistake an unfinished terminal-size check for a failed check, causing download progress to use the wrong width. We changed it to cache the result only after detection returns and added a regression test. The test failed before the fix and passed afterwards. Local `./bin/brew lgtm --online` checks also passed. I also tested downloads from the patched checkout in Ghostty and confirmed that the download status aligned correctly.
