### PR TITLE
keg: scope node-gyp debris to build trees

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -641,14 +641,16 @@ class Keg
     # leaves its intermediate objects and static archives behind; they embed
     # build paths that pin bottles and are never needed at run time (addons
     # load the linked `.node` files, not the objects they were linked from).
+    # It always writes them into the package's `build` directory, so anything
+    # matching elsewhere under `node_modules` is shipped by the package.
     path.find do |pn|
       next unless pn.to_s.include?("/node_modules/")
+      next unless pn.to_s.include?("/build/")
 
       if pn.directory? && pn.basename.to_s == "obj.target"
         FileUtils.rm_rf pn
         Find.prune
-      elsif %w[.o .d].include?(pn.extname) ||
-            (pn.extname == ".a" && pn.to_s.include?("/build/"))
+      elsif %w[.o .d .a].include?(pn.extname) && pn.file?
         pn.delete
       end
     end

--- a/Library/Homebrew/test/keg_spec.rb
+++ b/Library/Homebrew/test/keg_spec.rb
@@ -455,6 +455,9 @@ RSpec.describe Keg do
       touch build_dir/"leveldb.a"
       (keg_path/"libexec/lib/node_modules/foo/lib").mkpath
       touch keg_path/"libexec/lib/node_modules/foo/lib/shipped.a"
+      touch keg_path/"libexec/lib/node_modules/foo/lib/shipped.o"
+      (keg_path/"libexec/lib/node_modules/foo/test/obj.target").mkpath
+      touch keg_path/"libexec/lib/node_modules/foo/test/obj.target/fixture.txt"
       (keg_path/"lib").mkpath
       touch keg_path/"lib/crt1.o"
 
@@ -465,7 +468,19 @@ RSpec.describe Keg do
       expect(build_dir/"leveldb.a").not_to exist
       expect(build_dir/"addon.node").to exist
       expect(keg_path/"libexec/lib/node_modules/foo/lib/shipped.a").to exist
+      expect(keg_path/"libexec/lib/node_modules/foo/lib/shipped.o").to exist
+      expect(keg_path/"libexec/lib/node_modules/foo/test/obj.target").to exist
       expect(keg_path/"lib/crt1.o").to exist
+    end
+
+    it "keeps directories that share an intermediate object's extension" do
+      fixture = HOMEBREW_CELLAR/"foo/1.0/libexec/lib/node_modules/foo/build/Release/name.d"
+      fixture.mkpath
+      touch fixture/"name.txt"
+
+      keg.delete_node_gyp_debris!
+
+      expect(fixture).to exist
     end
   end
 


### PR DESCRIPTION
-----

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

AI-assisted: Claude Opus 5 helped draft the patch and the tests. I reproduced the bug and verified the fix myself on macOS 26 arm64 with the commands below.

-----

`delete_node_gyp_debris!` matched `.o` and `.d` anywhere under `node_modules`, unlike `.a` which #23645 already scoped to `build` trees. `@fastify/send` ships a `test/fixtures/name.d` directory, so `Pathname#delete` raised `Errno::ENOTEMPTY` and `brew bottle` failed for formulae that vendor it.

Scoping all three to `build` loses nothing: node-gyp runs gyp with `--generator-output build`, so every object, dependency file and archive lands there. A built `leveldown`, which vendors leveldb and snappy under `deps`, comes out identical either way.