### PR TITLE
Base macOS migration advice on binary packages

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -93,6 +93,27 @@ module Homebrew
       def add_info(*args)
         ohai(*args) if @verbose
       end
+
+      sig { params(version: MacOSVersion, intel: T::Boolean).returns(T.nilable(String)) }
+      def macos_bottle_remediation(version, intel:)
+        return if !intel && !version.outdated_release?
+        return if version > :tahoe
+
+        remediation = +"Homebrew no longer builds bottles for this configuration.\n"
+        # At the time of writing, MacPorts does not provide a full set of binary packages
+        # for Intel Tahoe:
+        # https://build.macports.org/builders/ports-26_x86_64-builder
+        remediation << if intel && version >= :tahoe
+          <<~EOS
+            Existing bottles may still work, but updated formulae may build from source.
+          EOS
+        else
+          <<~EOS
+            Consider MacPorts, which provides binary packages for this macOS version:
+              #{Formatter.url("https://www.macports.org")}
+          EOS
+        end
+      end
       ############# @!endgroup END HELPERS
 
       sig { returns(T::Array[String]) }

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -134,24 +134,14 @@ module OS
 
           tier = 2
           who = +"We"
-          remediation = nil
           version = MacOS.version
-          macports_url = Formatter.url("https://www.macports.org")
           what = if OS::Mac.version.outdated_release?
             tier = 3
             who << " (and Apple)"
-            remediation = <<~EOS
-              You will have better luck with MacPorts which still supports older versions of macOS:
-                #{macports_url}
-            EOS
             "old version."
           elsif ::Hardware::CPU.intel?
             tier = 3
             version = "on Intel x86_64"
-            remediation = <<~EOS
-              You will have better luck with MacPorts which still supports macOS Intel x86_64:
-                #{macports_url}
-            EOS
             <<~EOS
               platform (as-of September 2026, announced August 2025).
 
@@ -173,7 +163,7 @@ module OS
               You are using macOS #{version}.
               #{who} do not provide support for this #{what.chomp}
             EOS
-            remediation:,
+            remediation: macos_bottle_remediation(MacOS.version, intel: ::Hardware::CPU.intel?),
             tier:,
           )
         end

--- a/Library/Homebrew/test/diagnostic/macos_bottle_remediation_spec.rb
+++ b/Library/Homebrew/test/diagnostic/macos_bottle_remediation_spec.rb
@@ -1,0 +1,47 @@
+# typed: true
+# frozen_string_literal: true
+
+require "diagnostic"
+
+RSpec.describe Homebrew::Diagnostic::Checks do
+  subject(:checks) { described_class.new }
+
+  describe "#macos_bottle_remediation" do
+    it "recommends MacPorts binaries on outdated Intel macOS" do
+      expect(checks.macos_bottle_remediation(MacOSVersion.new("13"), intel: true)).to eq <<~EOS
+        Homebrew no longer builds bottles for this configuration.
+        Consider MacPorts, which provides binary packages for this macOS version:
+          https://www.macports.org
+      EOS
+    end
+
+    it "recommends MacPorts binaries on Intel Sequoia" do
+      expect(checks.macos_bottle_remediation(MacOSVersion.new("15.7"), intel: true))
+        .to include("MacPorts")
+    end
+
+    it "explains bottle availability without recommending a replacement on Intel Tahoe" do
+      expect(checks.macos_bottle_remediation(MacOSVersion.new("26.1"), intel: true)).to eq <<~EOS
+        Homebrew no longer builds bottles for this configuration.
+        Existing bottles may still work, but updated formulae may build from source.
+      EOS
+    end
+
+    it "recommends MacPorts binaries on outdated Apple Silicon macOS" do
+      expect(checks.macos_bottle_remediation(MacOSVersion.new("13"), intel: false))
+        .to include("MacPorts")
+    end
+
+    it "does not recommend alternatives when Homebrew builds bottles" do
+      expect(checks.macos_bottle_remediation(MacOSVersion.new("26"), intel: false)).to be_nil
+    end
+
+    it "does not assume binary availability on future Intel macOS versions" do
+      expect(checks.macos_bottle_remediation(MacOSVersion.new("30"), intel: true)).to be_nil
+    end
+
+    it "does not recommend alternatives on pre-release Apple Silicon macOS" do
+      expect(checks.macos_bottle_remediation(MacOSVersion.new("30"), intel: false)).to be_nil
+    end
+  end
+end

--- a/Library/Homebrew/test/os/mac/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/mac/diagnostic_spec.rb
@@ -30,10 +30,13 @@ RSpec.describe Homebrew::Diagnostic::Checks do
       allow(OS::Mac).to receive_messages(version: macos_version, full_version: macos_version)
       allow(OS::Mac.version).to receive_messages(outdated_release?: false, prerelease?: false)
 
-      finding = checks.check_for_unsupported_macos
-      expect(finding).to have_attributes(
-        tier: 3,
-        text: match("We do not provide support for this platform"),
+      expect(checks.check_for_unsupported_macos).to have_attributes(
+        tier:        3,
+        text:        match("We do not provide support for this platform"),
+        remediation: have_attributes(text: <<~EOS),
+          Homebrew no longer builds bottles for this configuration.
+          Existing bottles may still work, but updated formulae may build from source.
+        EOS
       )
     end
 

--- a/docs/Support-Tiers.md
+++ b/docs/Support-Tiers.md
@@ -127,6 +127,10 @@ If you are using a Homebrew wrapper, get support from and file issues with that 
 
 macOS Tahoe 26 is the final version of macOS to run on Intel hardware. In alignment with this change, Homebrew has stopped building new bottles for Intel systems, and will remove the ability to run Homebrew on Intel systems in or after September 2027.
 
+Where Homebrew no longer builds bottles, `brew doctor` suggests [MacPorts](https://www.macports.org) for Intel macOS Sequoia 15 and earlier or older Apple Silicon macOS versions.
+At the time of writing, MacPorts does not provide a full set of binary packages for Intel Tahoe ([builder status](https://build.macports.org/builders/ports-26_x86_64-builder)).
+On Intel Tahoe, `brew doctor` explains that existing bottles may still work, but updated formulae may build from source.
+
 The following timeline outlines expected Tier classifications based on Apple’s release cycle and Homebrew’s CI coverage.
 
 - As of September 2026:


### PR DESCRIPTION
- Avoid recommending MacPorts on Intel Tahoe without binary builds.
- Explain existing bottle reuse and link the current MacPorts status.
- Keep documentation aligned with `brew doctor` advice.

Fixes #23803

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Codex with GPT 6 Astra at Extra High effort, with local language tweaking, review and testing.

-----