### PR TITLE
Restore inherited streams for safe_system

### DIFF
--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "English"
 require "shellwords"
 require "stringio"
 
@@ -146,6 +147,9 @@ class SystemCommand
         debug:, verbose:, secrets:, chdir:, reset_uid:, run_as_real_uid:, timeout:)
   end
 
+  # Run a command attached to the caller's standard streams and terminal,
+  # raising if it fails. Unlike {SystemCommand.run!} nothing is captured, so
+  # interactive programs such as editors and pagers work.
   sig {
     params(
       executable: T.nilable(T.any(String, Pathname)),
@@ -158,17 +162,19 @@ class SystemCommand
     raise ArgumentError, "Missing executable" if executable.nil?
     raise ArgumentError, "Invalid nil command argument" if args.any?(&:nil?)
 
-    run = proc do
-      run!(executable, args: args.compact, env:, print_stdout: true, print_stderr: true, debug: true)
+    args = args.compact
+    if Context.current.verbose?
+      command = "#{executable} #{args * " "}".gsub(RUBY_PATH.to_s, "ruby")
+                                             .gsub($LOAD_PATH.join(File::PATH_SEPARATOR), "$LOAD_PATH")
+      ((out == :err) ? $stderr : $stdout).puts Formatter.redact_secrets(command, secrets)
     end
+    return if attached_success?(executable, args, env:, out:)
 
-    if out == :err
-      Utils::Output.redirect_stdout($stderr, &run)
-    else
-      run.call
-    end
+    raise ErrorDuringExecution.new([executable, *args], status: $CHILD_STATUS, secrets:)
   end
 
+  # Run a command attached to the caller's standard input with its output
+  # discarded, returning whether it succeeded.
   # Preserve the existing Formula DSL method name.
   # rubocop:disable Naming/PredicateMethod
   sig {
@@ -181,10 +187,44 @@ class SystemCommand
   def self.quiet_system(executable, *args, env: {})
     return false if executable.nil? || args.any?(&:nil?)
 
-    run(executable, args: args.compact, env:, print_stdout: false, print_stderr: false, debug: false,
-                    verbose: false).success?
+    # Redirect output streams to `/dev/null` instead of closing as some programs
+    # will fail to execute if they can't write to an open stream.
+    attached_success?(executable, args.compact, env:, out: File::NULL, err: File::NULL)
   end
   # rubocop:enable Naming/PredicateMethod
+
+  sig { returns(T::Array[String]) }
+  private_class_method def self.secrets
+    require "extend/ENV"
+    ENV.sensitive_environment.values
+  end
+
+  sig {
+    params(
+      executable: T.any(String, Pathname),
+      args:       T::Array[T.any(String, Pathname)],
+      env:        T::Hash[String, T.nilable(T.any(String, T::Boolean, PATH))],
+      out:        T.nilable(T.any(String, Symbol)),
+      err:        T.nilable(String),
+    ).returns(T::Boolean)
+  }
+  private_class_method def self.attached_success?(executable, args, env:, out: nil, err: nil)
+    # Like `system(3)`, keep the terminal's interrupt from raising in the parent
+    # so a command that handles it, such as an editor, keeps running. Trapping
+    # with a block rather than `IGNORE` leaves the child its default handler.
+    old_sigint_handler = Signal.trap(:INT) { nil }
+    old_sigquit_handler = Signal.trap(:QUIT) { nil }
+    begin
+      Kernel.system(env.transform_values { |value| value&.to_s }, executable.to_s, *args.map(&:to_s),
+                    **{ out:, err: }.compact)
+    ensure
+      Signal.trap(:INT, old_sigint_handler)
+      Signal.trap(:QUIT, old_sigquit_handler)
+    end
+    raise Interrupt if $CHILD_STATUS.termsig == Signal.list.fetch("INT") || $CHILD_STATUS.exitstatus == 130
+
+    $CHILD_STATUS.success? || false
+  end
 
   sig { returns(SystemCommand::Result) }
   def run!

--- a/Library/Homebrew/test/system_command_spec.rb
+++ b/Library/Homebrew/test/system_command_spec.rb
@@ -1,12 +1,68 @@
 # typed: false
 # frozen_string_literal: true
 
+require "pty"
 require "system_command"
 
 RSpec.describe SystemCommand do
   describe ".safe_system" do
+    include Context
+
     it "raises when the command fails" do
       expect { described_class.safe_system("false") }.to raise_error(ErrorDuringExecution)
+    end
+
+    it "raises for a nil argument" do
+      expect { described_class.safe_system("true", nil) }.to raise_error(ArgumentError)
+    end
+
+    it "exits with 127 when the command cannot be run" do
+      expect { described_class.safe_system("brew-missing-command") }
+        .to raise_error(ErrorDuringExecution, /exited with 127\./)
+    end
+
+    it "keeps running when the command handles an interrupt" do
+      expect do
+        described_class.safe_system("sh", "-c", 'trap "" INT; kill -INT $PPID; sleep 0.2; kill -INT $$')
+      end.not_to raise_error
+    end
+
+    it "raises Interrupt when the command is interrupted" do
+      expect { described_class.safe_system("sh", "-c", "kill -INT $$") }.to raise_error(Interrupt)
+    end
+
+    it "runs the command attached to the terminal" do
+      PTY.open do |_control, terminal|
+        $stdin.reopen(terminal)
+
+        expect { described_class.safe_system("sh", "-c", "test -t 0") }.not_to raise_error
+      end
+    end
+
+    it "sets the given environment" do
+      expect do
+        described_class.safe_system("sh", "-c", 'test "$BREW_TEST_VARIABLE" = value',
+                                    env: { "BREW_TEST_VARIABLE" => "value" })
+      end.not_to raise_error
+    end
+
+    it "redirects standard output to standard error" do
+      expect { described_class.safe_system("echo", "redirected", out: :err) }
+        .to output("redirected\n").to_stderr_from_any_process
+    end
+
+    it "prints the command when verbose" do
+      with_context(verbose: true) do
+        expect { described_class.safe_system("true", "--version") }.to output("true --version\n").to_stdout
+      end
+    end
+
+    it "redacts secrets when verbose" do
+      ENV["HOMEBREW_TEST_TOKEN"] = "hunter2"
+
+      with_context(verbose: true) do
+        expect { described_class.safe_system("true", "hunter2") }.to output("true ******\n").to_stdout
+      end
     end
   end
 
@@ -14,6 +70,24 @@ RSpec.describe SystemCommand do
     it "returns the command status" do
       expect(described_class.quiet_system("true")).to be true
       expect(described_class.quiet_system("false")).to be false
+    end
+
+    it "returns false for a nil executable" do
+      expect(described_class.quiet_system(nil)).to be false
+    end
+
+    it "sets the child status" do
+      described_class.quiet_system("sh", "-c", "exit 3")
+
+      expect($CHILD_STATUS.exitstatus).to eq(3)
+    end
+
+    it "discards the command output" do
+      reader, writer = IO.pipe
+      Utils::Output.redirect_stdout(writer) { described_class.quiet_system("echo", "discarded") }
+      writer.close
+
+      expect(reader.read).to be_empty
     end
   end
 

--- a/Library/Homebrew/test/utils/editor_spec.rb
+++ b/Library/Homebrew/test/utils/editor_spec.rb
@@ -1,6 +1,7 @@
 # typed: true
 # frozen_string_literal: true
 
+require "pty"
 require "utils/editor"
 
 RSpec.describe Utils::Editor do
@@ -9,6 +10,25 @@ RSpec.describe Utils::Editor do
       ENV["HOMEBREW_EDITOR"] = "vemate -w"
 
       expect(described_class.command).to eq("vemate -w")
+    end
+  end
+
+  describe ".open" do
+    it "runs the editor attached to the terminal" do
+      ENV["HOMEBREW_EDITOR"] = "sh -c 'test -t 0 && test -t 1'"
+
+      PTY.open do |_control, terminal|
+        $stdin.reopen(terminal)
+        $stdout.reopen(terminal)
+
+        expect { described_class.open("#{TEST_TMPDIR}/testball.rb") }.not_to raise_error
+      end
+    end
+
+    it "raises when the editor fails" do
+      ENV["HOMEBREW_EDITOR"] = "false"
+
+      expect { described_class.open("#{TEST_TMPDIR}/testball.rb") }.to raise_error(ErrorDuringExecution)
     end
   end
 end


### PR DESCRIPTION
- The runtime helper migration reimplemented `SystemCommand.safe_system` and `quiet_system` on top of `SystemCommand.run`, which captures the child's output through pipes in a new process group and prefixes the command with `/usr/bin/env`. Every caller, including `brew edit`, `brew cat`, `brew sh`, `Utils::Browser.open` and the `brew` commands run through `Utils::BrewCommand`, lost the terminal: TUI editors such as `vim`, `nvim`, `helix` and `emacs` hung or refused to start, pagers and coloured output broke, prompts could not read input, the verbose command echo moved to stderr, `$CHILD_STATUS` was no longer set and failures repeated the captured output.
- Run them with a fork and exec that inherit the caller's standard streams again, as `Homebrew.safe_system` and `Homebrew.quiet_system` did, keeping the verbose echo, `out: :err` redirection, silent exit status 1 on a missing command and the `env:` keyword callers migrated to.

Fixes #23807

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude with Fable 5.1 at Extra High effort, with local review and testing.

-----