### PR TITLE
Fix brew edit crash for an uninstalled tap

### DIFF
--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -121,11 +121,8 @@ module Homebrew
       def raise_with_message!(path, cask)
         name = path.basename(".rb").to_s
 
-        if (tap_match = Regexp.new("#{HOMEBREW_TAP_DIR_REGEX.source}$").match(path.to_s))
-          raise TapUnavailableError, CoreTap.instance.name if core_formula_tap?(path)
-          raise TapUnavailableError, CoreCaskTap.instance.name if core_cask_tap?(path)
-
-          raise TapUnavailableError, "#{tap_match[:user]}/#{tap_match[:repo]}"
+        if Regexp.new("#{HOMEBREW_TAP_DIR_REGEX.source}$").match?(path.to_s)
+          raise TapUnavailableError, Tap.from_path(path)&.name || path.to_s
         elsif cask || core_cask_path?(path)
           if !CoreCaskTap.instance.installed? && Homebrew::API.cask_token?(name)
             command = "brew tap --force #{CoreCaskTap.instance.name}"

--- a/Library/Homebrew/test/dev-cmd/edit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/edit_spec.rb
@@ -24,6 +24,16 @@ RSpec.describe Homebrew::DevCmd::Edit do
       .and be_a_success
   end
 
+  it "names the canonical tap when the tap is not installed" do
+    (HOMEBREW_REPOSITORY/".git").mkpath
+
+    allow(CoreTap.instance).to receive(:installed?).and_return(true)
+    allow(CoreCaskTap.instance).to receive(:installed?).and_return(true)
+
+    expect { described_class.new(["someuser/sometap"]).run }
+      .to raise_error(TapUnavailableError, %r{No available tap someuser/sometap\.})
+  end
+
   it "auto-taps core when editing an API-known formula without the tap installed" do
     (HOMEBREW_REPOSITORY/".git").mkpath
 


### PR DESCRIPTION
`brew edit <user>/<tap>` for a tap that is not installed dies with an internal error instead of the advice it was written to give:

```
$ brew edit someuser/sometap
Error: undefined group name reference: repo
/opt/homebrew/Library/Homebrew/dev-cmd/edit.rb:128:in 'MatchData#[]'
/opt/homebrew/Library/Homebrew/dev-cmd/edit.rb:128:in 'Homebrew::DevCmd::Edit#raise_with_message!'
...
Please report this issue:
  https://docs.brew.sh/Troubleshooting
```

`raise_with_message!` read `tap_match[:repo]`, but 94416e82f0 renamed that capture to `repository` in `HOMEBREW_TAP_DIR_REGEX` and missed this caller, which was added earlier in b3ecd91f97. `MatchData#[]` raises `IndexError` for an unknown group name, so the branch has been dead since 4.4.0, and the "Please report this issue" footer invites bug reports for what is only an untapped tap. Every third-party and non-core official tap hits it, because the two guards above only cover `homebrew/core` and `homebrew/cask`.

The message now comes from `Tap.from_path` rather than the capture. Swapping the key alone would print the on-disk directory `someuser/homebrew-sometap`, whereas the two raises above it print canonical names, so this keeps all three consistent:

```
$ brew edit someuser/sometap
Error: No available tap someuser/sometap.
Run brew tap-new someuser/sometap to create a new someuser/sometap tap!
```

That also makes the two core tap raises redundant, since `Tap.from_path` returns those same singletons and `TapUnavailableError` already special-cases their names to suggest `brew tap --force`, so they are dropped. No spec covered this branch, which is how it survived eleven months, and there is one now.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

AI/LLM disclosure: Claude Opus 5 via Claude Code found and fixed this while auditing regexp capture groups; I reviewed it and confirmed the crash and the fix by running `brew edit` directly.

-----
