### PR TITLE
Stop the uses_from_macos cop crashing

### DIFF
--- a/Library/Homebrew/rubocops/uses_from_macos.rb
+++ b/Library/Homebrew/rubocops/uses_from_macos.rb
@@ -103,7 +103,7 @@ module RuboCop
 
           depends_on_linux = depends_on?(:linux)
 
-          find_method_with_args(body_node, :uses_from_macos, /^".+"/).each do |method|
+          find_every_method_call_by_name(body_node, :uses_from_macos).each do |method|
             @offensive_node = method
             problem "`uses_from_macos` should not be used when Linux is required." if depends_on_linux
 
@@ -113,6 +113,8 @@ module RuboCop
             elsif first_argument.instance_of?(RuboCop::AST::HashNode)
               first_argument.keys.first
             end
+
+            next if dep.nil?
 
             dep_name = string_content(dep)
             next if ALLOWED_USES_FROM_MACOS_DEPS.include? dep_name

--- a/Library/Homebrew/test/rubocops/uses_from_macos_spec.rb
+++ b/Library/Homebrew/test/rubocops/uses_from_macos_spec.rb
@@ -47,6 +47,31 @@ RSpec.describe RuboCop::Cop::FormulaAudit::UsesFromMacos do
         end
       RUBY
     end
+
+    it "does not report an offense for a dependency name that is not a plain string" do
+      expect_no_offenses(<<~'RUBY')
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
+
+          uses_from_macos :postgresql
+          uses_from_macos "postgresql#{version}"
+        end
+      RUBY
+    end
+
+    it "still reports the Linux offense for a name that is not a plain string" do
+      expect_offense(<<~'RUBY')
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
+
+          depends_on :linux
+          uses_from_macos "postgresql#{version}"
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/UsesFromMacos: `uses_from_macos` should not be used when Linux is required.
+        end
+      RUBY
+    end
   end
 
   include_examples "formulae exist", RuboCop::Cop::FormulaAudit::UsesFromMacos::ALLOWED_USES_FROM_MACOS_DEPS


### PR DESCRIPTION
`FormulaAudit/UsesFromMacos` crashes on a dependency name that is not a plain string literal, and RuboCop then discards every offence in the file:

```
$ cat > /tmp/foo.rb <<'RUBY'
class Foo < Formula
  url "https://brew.sh/foo-1.0.tgz"
  homepage "https://brew.sh"

  uses_from_macos "postgresql#{version}"
end
RUBY
$ brew style --only-cops=FormulaAudit/UsesFromMacos /tmp/foo.rb
An error occurred while FormulaAudit/UsesFromMacos cop was inspecting /tmp/foo.rb:1:0.
Errors are usually caused by RuboCop bugs.
...
1 file inspected, no offenses detected
```

`DstrNode` subclasses `StrNode`, but the check used `instance_of?`, which is exact, so an interpolated name fell past both branches and left `dep` as nil for `string_content`, whose signature does not accept nil. A bare symbol such as `uses_from_macos :postgresql` does the same.

The reason the cop reached those arguments at all is that it was only auditing anything by accident. Its filter was `find_method_with_args(body_node, :uses_from_macos, /^".+"/)`, and that pattern can never match, because `regex_match_group` tests it against `string_content`, which has already stripped the quotes. Called without a block, `find_method_with_args` returns `[]` as soon as one call matches and otherwise falls through to the return value of `methods.each`, which is every call. So the cop worked precisely because its own filter never matched, and correcting the pattern to match would have returned `[]` and made it silently audit nothing.

So the filter goes rather than getting fixed, in favour of calling `find_every_method_call_by_name` directly, and a name that is neither a plain string nor a hash key is now skipped instead of raising. The audit behaviour for every argument form that worked before is unchanged, and the `depends_on :linux` offence is now reported for these names rather than being lost with the rest of the file.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

AI/LLM disclosure: Claude Opus 5 via Claude Code found and fixed this while triaging findings from the regexp capture audit; I reviewed it and confirmed the crash and the fix by running `brew style` against formulae using each argument form.

-----
