### PR TITLE
unpack_strategy: skip symlinks in each_directory

### DIFF
--- a/Library/Homebrew/test/unpack_strategy_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy_spec.rb
@@ -21,6 +21,18 @@ RSpec.describe UnpackStrategy do
     end
   end
 
+  describe "#each_directory" do
+    it "only yields directories owned by the extracted tree" do
+      root = mktmpdir
+      (root/"directory").mkpath
+      (root/"link").make_symlink(mktmpdir)
+      directories = []
+      described_class.detect(root).each_directory(root) { |path| directories << path }
+
+      expect(directories).to contain_exactly(root, root/"directory")
+    end
+  end
+
   describe "#extract_nestedly" do
     subject(:strategy) { described_class.detect(path) }
 

--- a/Library/Homebrew/unpack_strategy.rb
+++ b/Library/Homebrew/unpack_strategy.rb
@@ -224,7 +224,7 @@ module UnpackStrategy
   }
   def each_directory(pathname, &_block)
     pathname.find do |path|
-      yield path if path.directory?
+      yield path if !path.symlink? && path.directory?
     end
   end
 end


### PR DESCRIPTION
`UnpackStrategy#each_directory` walks an extracted tree to make its directories writable and followed symlinks while doing so, so a symlink inside an archive that points outside the extraction directory had its target's permissions changed instead. Skip symlinks when yielding directories so permission normalization stays inside the extracted tree.

This is a small prerequisite for the bottle staging change in #23815, which reuses `each_directory` on a directory it extracted itself.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

GPT-6 Astra and Claude Code (Fable 5.1) drafted the implementation and tests; I reviewed the diff, verified the new test fails without the change and passes with it, and ran `brew lgtm --online` plus targeted specs.

-----
