### PR TITLE
bottle: verify and extract from a snapshot

### DIFF
--- a/Library/Homebrew/bottle.rb
+++ b/Library/Homebrew/bottle.rb
@@ -246,8 +246,12 @@ class Bottle
   sig { void }
   def stage
     with_corrupt_download_retry do
-      verify_download_integrity(cached_download)
-      downloader.stage
+      with_verified_snapshot(cached_download) do |snapshot|
+        UnpackStrategy.detect(snapshot, prioritize_extension: true, temporary_directory: snapshot.dirname)
+                      .extract_nestedly(basename:             downloader.basename,
+                                        prioritize_extension: true,
+                                        verbose:              verbose? && !downloader.quiet?)
+      end
     end
   rescue ChecksumMismatchError
     # The retry's fresh download can itself fail verification, raising from
@@ -343,16 +347,14 @@ class Bottle
     # Stay quiet on the retry: the download queue is redrawing its own
     # progress lines while this runs in a worker thread.
     with_corrupt_download_retry(quiet: true) do
-      HOMEBREW_TEMP_CELLAR.mkpath
+      # Never reuse a marker or keg already here: sandboxed build and
+      # postinstall steps may have written them.
+      purge_staged_from_download_queue
 
-      next if bottle_poured_file.exist?
-
-      FileUtils.rm(bottle_poured_file) if bottle_poured_file.symlink?
-      FileUtils.rm_r(bottle_tmp_keg) if bottle_tmp_keg.directory?
-
-      verify_download_integrity(download)
-      UnpackStrategy.detect(download, prioritize_extension: true)
-                    .extract_nestedly(to: HOMEBREW_TEMP_CELLAR)
+      with_verified_snapshot(download) do |snapshot|
+        UnpackStrategy.detect(snapshot, prioritize_extension: true, temporary_directory: snapshot.dirname)
+                      .extract_nestedly(to: HOMEBREW_TEMP_CELLAR)
+      end
 
       # Create a separate file to mark a completed extraction. This avoids
       # a potential race condition if a user interrupts the install.
@@ -361,11 +363,39 @@ class Bottle
       FileUtils.ln_s(bottle_tmp_keg, bottle_poured_file)
     # Catch any exception type here to clean up partial queued extractions.
     rescue Exception # rubocop:disable Lint/RescueException
-      Utils::Interrupts.ignore do
-        FileUtils.rm_r(bottle_tmp_keg) if bottle_tmp_keg.directory?
-        Utils::Path.rmdir_if_possible(bottle_tmp_keg.parent)
-      end
+      Utils::Interrupts.ignore { purge_staged_from_download_queue }
       raise
+    end
+  end
+
+  # Whether the download queue left a keg here that `pour` may move into the
+  # Cellar: the marker must point at the expected keg and the keg must be a
+  # real directory, so entries planted by other processes are ignored.
+  sig { returns(T::Boolean) }
+  def staged_from_download_queue?
+    marker = staged_path_from_download_queue_marker
+    keg = staged_path_from_download_queue
+    marker.symlink? && marker.readlink == keg && !keg.symlink? && keg.directory?
+  end
+
+  sig { void }
+  def purge_staged_from_download_queue
+    keg = staged_path_from_download_queue
+    FileUtils.rm_rf([staged_path_from_download_queue_marker, keg])
+    Utils::Path.rmdir_if_possible(keg.parent)
+  end
+
+  # Verify a private copy of the download and hand it to the block, so the
+  # bytes extracted are the bytes verified even if the cached download is
+  # changed underneath by a process with write access to the cache.
+  sig { params(download: Pathname, _block: T.proc.params(snapshot: Pathname).void).void }
+  def with_verified_snapshot(download, &_block)
+    HOMEBREW_TEMP_CELLAR.mkpath
+    Dir.mktmpdir("verify-", HOMEBREW_TEMP_CELLAR) do |directory|
+      snapshot = Pathname(directory)/download.basename
+      FileUtils.copy_file(download, snapshot)
+      verify_download_integrity(snapshot)
+      yield snapshot
     end
   end
 

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1189,6 +1189,7 @@ on_request: installed_on_request?, options:)
           sandbox.allow_write_temp_and_cache
           sandbox.deny_all_network unless formula.network_access_allowed?(:build)
         end
+        sandbox.deny_write_temp_cellar
       end
     end
 
@@ -1495,6 +1496,7 @@ on_request: installed_on_request?, options:)
         Keg.keg_link_directories.each do |dir|
           sandbox.allow_write_path "#{HOMEBREW_PREFIX}/#{dir}"
         end
+        sandbox.deny_write_temp_cellar
       end
     end
   # Handle all possible exceptions when postinstall does not complete.
@@ -1684,14 +1686,15 @@ on_request: installed_on_request?, options:)
 
       # Download queue may have already extracted the bottle to a temporary directory.
       # We cannot rely on `download_queue` here as dependencies may be poured by another installer.
-      if downloadable_object.is_a?(Bottle) &&
-         (bottle_poured_file = downloadable_object.staged_path_from_download_queue_marker).exist?
+      if downloadable_object.is_a?(Bottle) && downloadable_object.staged_from_download_queue?
         bottle_tmp_keg = downloadable_object.staged_path_from_download_queue
-        FileUtils.rm(bottle_poured_file)
+        FileUtils.rm(downloadable_object.staged_path_from_download_queue_marker)
         FileUtils.mv(bottle_tmp_keg, formula.prefix)
         rmdir_if_possible(bottle_tmp_keg.parent)
       elsif downloadable_object.is_a?(Bottle)
-        # Retries with a fresh download if the cached bottle turns out corrupt.
+        # Discard anything unexpected under the temporary Cellar path, then
+        # verify and extract afresh, refetching if the cached bottle is corrupt.
+        downloadable_object.purge_staged_from_download_queue
         downloadable_object.stage
       else
         downloadable_object.downloader.stage

--- a/Library/Homebrew/mktemp.rb
+++ b/Library/Homebrew/mktemp.rb
@@ -17,10 +17,15 @@ class Mktemp
 
   # With `path`, reuse that existing directory (e.g. one shared between the
   # fetch and build phases) rather than creating a temporary one.
-  sig { params(prefix: String, retain: T::Boolean, retain_in_cache: T::Boolean, path: T.nilable(Pathname)).void }
-  def initialize(prefix, retain: false, retain_in_cache: false, path: nil)
+  # Otherwise create the directory under `parent`, unless retaining it in cache.
+  sig {
+    params(prefix: String, retain: T::Boolean, retain_in_cache: T::Boolean, path: T.nilable(Pathname),
+           parent: Pathname).void
+  }
+  def initialize(prefix, retain: false, retain_in_cache: false, path: nil, parent: HOMEBREW_TEMP)
     @prefix = prefix
     @path = path
+    @parent = parent
     @retain_in_cache = retain_in_cache
     @retain = T.let(retain || @retain_in_cache, T::Boolean)
     @quiet = T.let(false, T::Boolean)
@@ -92,7 +97,7 @@ class Mktemp
       tmp_dir.mkpath
       tmp_dir
     else
-      Pathname.new(Dir.mktmpdir("#{prefix_name}-", HOMEBREW_TEMP))
+      Pathname.new(Dir.mktmpdir("#{prefix_name}-", @parent.to_s))
     end
 
     # Make sure files inside the temporary directory have the same group as the

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -519,6 +519,15 @@ class Sandbox
     allow_write_path formula.var
   end
 
+  # Deny writes to the download queue's temporary Cellar so sandboxed steps
+  # cannot plant kegs or markers that `pour` would move into the Cellar. Call
+  # this after `allow_write_cellar`: the temporary Cellar is inside the
+  # granted `var` tree and macOS applies the last matching rule.
+  sig { void }
+  def deny_write_temp_cellar
+    deny_write_path HOMEBREW_TEMP_CELLAR
+  end
+
   sig { void }
   def allow_write_xcode; end
 

--- a/Library/Homebrew/test/bottle_spec.rb
+++ b/Library/Homebrew/test/bottle_spec.rb
@@ -65,7 +65,8 @@ RSpec.describe Bottle do
                                    name: "foo", pkg_version: PkgVersion.new(Version.new("1.2.3"), 0))
       bottle.cached_download.dirname.mkpath
       bottle.cached_download.write("corrupt")
-      allow(bottle.downloader).to receive(:stage)
+      allow(UnpackStrategy).to receive(:detect)
+        .and_return(instance_double(UnpackStrategy::Tar, extract_nestedly: nil))
       expect(bottle).to receive(:fetch) { bottle.cached_download.write(valid_content) }
       # The mismatched verification has already hashed the corrupt file, so
       # discarding it must not hash it a second time: once for the corrupt
@@ -107,7 +108,10 @@ RSpec.describe Bottle do
       bottle.cached_download.dirname.mkpath
       bottle.cached_download.write("mismatched")
       staged_content = []
-      allow(bottle.downloader).to receive(:stage) { staged_content << bottle.cached_download.read }
+      allow(UnpackStrategy).to receive(:detect) do |path, **|
+        staged_content << path.read
+        instance_double(UnpackStrategy::Tar, extract_nestedly: nil)
+      end
       expect(bottle).to receive(:fetch) do
         bottle.cached_download.write(valid_content)
         bottle.verify_download_integrity(bottle.cached_download)
@@ -117,6 +121,65 @@ RSpec.describe Bottle do
 
       expect(staged_content).to eq([valid_content])
     ensure
+      bottle&.clear_cache
+    end
+
+    it "extracts a verified private copy from the temporary Cellar" do
+      valid_content = "valid"
+      bottle_spec = BottleSpecification.new
+      bottle_spec.root_url(HOMEBREW_BOTTLE_DEFAULT_DOMAIN)
+      bottle_spec.sha256(cellar: :any_skip_relocation, arm64_big_sur: Digest::SHA256.hexdigest(valid_content))
+      bottle = described_class.new(nil, bottle_spec, Utils::Bottles::Tag.from_symbol(:arm64_big_sur),
+                                   name: "foo", pkg_version: PkgVersion.new(Version.new("1.2.3"), 0))
+      bottle.cached_download.dirname.mkpath
+      bottle.cached_download.write(valid_content)
+      extracted = []
+      allow(UnpackStrategy).to receive(:detect) do |path, **|
+        extracted << [path.ascend.include?(HOMEBREW_TEMP_CELLAR), path == bottle.cached_download, path.read]
+        instance_double(UnpackStrategy::Tar, extract_nestedly: nil)
+      end
+
+      bottle.stage
+
+      expect(extracted).to eq([[true, false, valid_content]])
+    ensure
+      bottle&.clear_cache
+    end
+  end
+
+  test_each([false, true]) do |queue|
+    it "keeps bottle extraction intermediates in the temporary Cellar with queue=#{queue}" do
+      archive = TEST_FIXTURE_DIR/"bottles/testball_bottle-0.1.yosemite.bottle.tar.gz"
+      bottle_spec = BottleSpecification.new
+      bottle_spec.sha256(cellar: :any_skip_relocation, arm64_big_sur: Digest::SHA256.file(archive).hexdigest)
+      bottle = described_class.new(TestballBottle.new, bottle_spec, Utils::Bottles::Tag.from_symbol(:arm64_big_sur))
+      bottle.cached_download.dirname.mkpath
+      FileUtils.cp(archive, bottle.cached_download)
+      destination = mktmpdir
+      temporary_parents = []
+      allow(Dir).to receive(:mktmpdir).and_wrap_original do |original, *args, &block|
+        if args.first.to_s.start_with?("homebrew-unpack", "homebrew-tar")
+          temporary_parents << Pathname(args.fetch(1))
+        end
+        original.call(*args, &block)
+      end
+
+      if queue
+        bottle.stage_from_download_queue(bottle.cached_download, pour: true)
+        keg = bottle.staged_path_from_download_queue
+      else
+        destination.cd { bottle.stage }
+        keg = destination/"testball_bottle/0.1"
+      end
+
+      expect(
+        protected_parents: temporary_parents.map { |parent| parent.ascend.include?(HOMEBREW_TEMP_CELLAR) },
+        extracted:         (keg/"libexec/NOOP").file?,
+        queued:            bottle.staged_from_download_queue?,
+        snapshots:         HOMEBREW_TEMP_CELLAR.glob("verify-*"),
+      ).to eq(protected_parents: [true, true], extracted: true, queued: queue, snapshots: [])
+    ensure
+      bottle&.purge_staged_from_download_queue
       bottle&.clear_cache
     end
   end
@@ -134,21 +197,52 @@ RSpec.describe Bottle do
       bottle
     end
 
-    it "does not verify a bottle that was already queue-staged" do
+    it "replaces an existing marker and keg instead of trusting them" do
       staged_path = T.let(nil, T.nilable(Pathname))
       marker = T.let(nil, T.nilable(Pathname))
-      bottle = cached_bottle("0" * 64, "mismatched")
+      valid_content = "valid"
+      bottle = cached_bottle(Digest::SHA256.hexdigest(valid_content), valid_content)
       staged_path = bottle.staged_path_from_download_queue
       marker = bottle.staged_path_from_download_queue_marker
       staged_path.mkpath
+      (staged_path/"planted").write("planted")
       FileUtils.ln_s(staged_path, marker)
-      expect(bottle).not_to receive(:verify_download_integrity)
-      expect(UnpackStrategy).not_to receive(:detect)
+      unpack_strategy = instance_double(UnpackStrategy::Tar)
+      allow(unpack_strategy).to receive(:extract_nestedly) { staged_path.mkpath }
+      allow(UnpackStrategy).to receive(:detect).and_return(unpack_strategy)
 
       bottle.stage_from_download_queue(bottle.cached_download, pour: true)
+
+      expect([(staged_path/"planted").exist?, marker.symlink? && marker.readlink == staged_path]).to eq([false, true])
     ensure
       FileUtils.rm_f(marker) if marker
       FileUtils.rm_r(staged_path) if staged_path&.directory?
+      bottle&.clear_cache
+    end
+
+    it "accepts only a marker pointing at a real keg directory" do
+      keg = T.let(nil, T.nilable(Pathname))
+      marker = T.let(nil, T.nilable(Pathname))
+      bottle = cached_bottle("0" * 64, "cached")
+      keg = bottle.staged_path_from_download_queue
+      marker = bottle.staged_path_from_download_queue_marker
+      results = []
+      keg.mkpath
+      FileUtils.ln_s(keg, marker)
+      results << bottle.staged_from_download_queue?
+      FileUtils.rm(marker)
+      FileUtils.ln_s(mktmpdir, marker)
+      results << bottle.staged_from_download_queue?
+      FileUtils.rm(marker)
+      FileUtils.rm_r(keg)
+      FileUtils.ln_s(mktmpdir, keg)
+      FileUtils.ln_s(keg, marker)
+      results << bottle.staged_from_download_queue?
+
+      expect(results).to eq([true, false, false])
+    ensure
+      FileUtils.rm_f(marker) if marker
+      FileUtils.rm_rf(keg) if keg
       bottle&.clear_cache
     end
 
@@ -157,8 +251,8 @@ RSpec.describe Bottle do
       bottle = cached_bottle(Digest::SHA256.hexdigest(valid_content), "mismatched")
       unpack_strategy = instance_double(UnpackStrategy::Tar)
       staged_content = []
-      allow(UnpackStrategy).to receive(:detect) do
-        staged_content << bottle.cached_download.read
+      allow(UnpackStrategy).to receive(:detect) do |path, **|
+        staged_content << path.read
         unpack_strategy
       end
       allow(unpack_strategy).to receive(:extract_nestedly) { bottle.staged_path_from_download_queue.mkpath }

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -367,6 +367,44 @@ RSpec.describe FormulaInstaller do
       allow(f.bottle_specification).to receive(:skip_relocation?).with(tab:).and_return(true)
     end
 
+    context "with a bottle" do
+      let(:downloadable) do
+        bottle_spec = BottleSpecification.new
+        bottle_spec.root_url("https://example.com")
+        bottle_spec.sha256(cellar: :any_skip_relocation, Utils::Bottles.tag.to_sym => "0" * 64)
+        bottle = Bottle.new(nil, bottle_spec, Utils::Bottles.tag,
+                            name: "missing-bottle-tab", pkg_version: PkgVersion.new(Version.new("1.0"), 0))
+        allow(bottle).to receive(:downloader).and_return(downloader)
+        bottle
+      end
+
+      before { allow(keg).to receive(:optlinked?).and_return(false) }
+
+      it "moves a queue-staged keg into the Cellar when its marker and keg are genuine" do
+        keg = downloadable.staged_path_from_download_queue
+        marker = downloadable.staged_path_from_download_queue_marker
+        keg.mkpath
+        FileUtils.ln_s(keg, marker)
+
+        installer.pour
+
+        expect([f.prefix.directory?, keg.exist?, marker.symlink?]).to eq([true, false, false])
+      end
+
+      it "discards a marker that does not point at the keg before staging the bottle afresh" do
+        keg = downloadable.staged_path_from_download_queue
+        marker = downloadable.staged_path_from_download_queue_marker
+        keg.mkpath
+        FileUtils.ln_s(mktmpdir, marker)
+        calls = []
+        allow(downloadable).to receive(:stage) { calls << [:stage, marker.symlink?, keg.exist?] }
+
+        installer.pour
+
+        expect(calls).to eq([[:stage, false, false]])
+      end
+    end
+
     it "retargets absolute symlinks from the prefix the bottle was built for" do
       cellar = Utils::Bottles.tag.default_cellar
       expect(keg).to receive(:relativize_prefix_symlinks!).with(prefix: Pathname(cellar).parent.to_s, cellar:)
@@ -1736,6 +1774,31 @@ RSpec.describe FormulaInstaller do
   end
 
   describe "#build" do
+    it "denies build writes to the temporary Cellar after granting the formula's var", :needs_macos do
+      skip "Sandbox not available." unless Sandbox.available?
+      skip "Nested sandboxing is not supported." if Sandbox.nested_sandbox?
+
+      formula = Testball.new
+      installer = described_class.new(formula)
+      sandbox = Sandbox.new
+      allow(Sandbox).to receive_messages(new: sandbox, use_for?: true)
+      formula.var.mkpath
+      HOMEBREW_TEMP_CELLAR.mkpath
+      allow(installer).to receive(:build_args).and_return([
+        "/bin/sh", "-c", 'printf allowed > "$1/allowed"; printf planted > "$2/planted" 2>/dev/null; exit 0',
+        "sandbox-fixture", formula.var, HOMEBREW_TEMP_CELLAR
+      ])
+      allow(formula).to receive_messages(logs: mktmpdir, update_head_version: nil, prefix: mktmpdir,
+                                         network_access_allowed?: true)
+      allow(Keg).to receive(:new).and_return(instance_double(Keg, empty_installation?: false))
+
+      installer.build
+      written = [(formula.var/"allowed").exist?, (HOMEBREW_TEMP_CELLAR/"planted").exist?]
+      FileUtils.rm_rf([formula.var/"allowed", HOMEBREW_TEMP_CELLAR])
+
+      expect(written).to eq([true, false])
+    end
+
     it "attempts source download when formula is loaded from API" do
       formula = Testball.new
       allow(formula).to receive(:loaded_from_api?).and_return(true)
@@ -1820,7 +1883,7 @@ RSpec.describe FormulaInstaller do
       allow(sandbox).to receive_messages(record_log: nil, allow_read_if_exists: nil, allow_write_temp_and_cache: nil,
                                          allow_write_log: nil, allow_cvs: nil, allow_fossil: nil,
                                          allow_write_xcode: nil, allow_write_cellar: nil, deny_read_home: nil,
-                                         run: nil)
+                                         deny_write_temp_cellar: nil, run: nil)
       allow(formula).to receive_messages(logs: mktmpdir, update_head_version: nil, prefix: mktmpdir,
                                          network_access_allowed?: true)
       allow(Keg).to receive(:new).and_return(instance_double(Keg, empty_installation?: false))

--- a/Library/Homebrew/test/unpack_strategy/gzip_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/gzip_spec.rb
@@ -8,4 +8,23 @@ RSpec.describe UnpackStrategy::Gzip do
 
   include_examples "UnpackStrategy::detect"
   include_examples "#extract", children: ["container"], verbose: true
+
+  it "preserves the temporary directory through nested decompression" do
+    temporary_directory = mktmpdir
+    unpack_dir = mktmpdir
+    archive = mktmpdir/"container.gz"
+    FileUtils.cp(path, archive)
+    system "bzip2", archive.to_s
+    strategy = UnpackStrategy::Bzip2.new(Pathname("#{archive}.bz2"), temporary_directory:)
+    temporary_parents = []
+    allow(Dir).to receive(:mktmpdir).and_wrap_original do |original, *args, &block|
+      temporary_parents << Pathname(args.fetch(1)) if args.first.to_s.start_with?("homebrew-unpack")
+      original.call(*args, &block)
+    end
+
+    strategy.extract_nestedly(to: unpack_dir)
+
+    expect([temporary_parents, (unpack_dir/"container").file?, temporary_directory.children])
+      .to eq([[temporary_directory, temporary_directory], true, []])
+  end
 end

--- a/Library/Homebrew/test/unpack_strategy/tar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/tar_spec.rb
@@ -9,6 +9,23 @@ RSpec.describe UnpackStrategy::Tar do
   include_examples "UnpackStrategy::detect"
   include_examples "#extract", children: ["container"]
 
+  it "keeps decompression intermediates in the configured temporary directory" do
+    temporary_directory = mktmpdir
+    unpack_dir = mktmpdir
+    strategy = described_class.new(TEST_FIXTURE_DIR/"tarballs/testball-0.1.tbz", temporary_directory:)
+    allow(DependencyCollector).to receive(:tar_needs_bzip2_dependency?).and_return(true)
+    temporary_parents = []
+    allow(Dir).to receive(:mktmpdir).and_wrap_original do |original, *args, &block|
+      temporary_parents << Pathname(args.fetch(1)) if args.first.to_s.start_with?("homebrew-tar")
+      original.call(*args, &block)
+    end
+
+    strategy.extract(to: unpack_dir)
+
+    expect([temporary_parents, (unpack_dir/"test-0.1/libexec/NOOP").file?, temporary_directory.children])
+      .to eq([[temporary_directory], true, []])
+  end
+
   context "when TAR archive is corrupted" do
     subject(:path) do
       (mktmpdir/"test.tar").tap do |path|

--- a/Library/Homebrew/unpack_strategy.rb
+++ b/Library/Homebrew/unpack_strategy.rb
@@ -116,9 +116,10 @@ module UnpackStrategy
 
   sig {
     params(path: Pathname, prioritize_extension: T::Boolean, type: T.nilable(Symbol), ref_type: T.nilable(Symbol),
-           ref: T.nilable(String), merge_xattrs: T::Boolean).returns(UnpackStrategy)
+           ref: T.nilable(String), merge_xattrs: T::Boolean, temporary_directory: Pathname).returns(UnpackStrategy)
   }
-  def self.detect(path, prioritize_extension: false, type: nil, ref_type: nil, ref: nil, merge_xattrs: false)
+  def self.detect(path, prioritize_extension: false, type: nil, ref_type: nil, ref: nil, merge_xattrs: false,
+                  temporary_directory: HOMEBREW_TEMP)
     strategy = from_type(type) if type
 
     if prioritize_extension && path.extname.present?
@@ -135,7 +136,7 @@ module UnpackStrategy
       odeprecated strategy.to_s, replacement
     end
 
-    strategy.new(path, ref_type:, ref:, merge_xattrs:)
+    strategy.new(path, ref_type:, ref:, merge_xattrs:, temporary_directory:)
   end
 
   sig { returns(Pathname) }
@@ -144,15 +145,20 @@ module UnpackStrategy
   sig { returns(T::Boolean) }
   attr_reader :merge_xattrs
 
+  # Parent directory for nested archive staging and tar decompression.
+  sig { returns(Pathname) }
+  attr_reader :temporary_directory
+
   sig {
     params(path: T.any(String, Pathname), ref_type: T.nilable(Symbol), ref: T.nilable(String),
-           merge_xattrs: T::Boolean).void
+           merge_xattrs: T::Boolean, temporary_directory: Pathname).void
   }
-  def initialize(path, ref_type: nil, ref: nil, merge_xattrs: false)
+  def initialize(path, ref_type: nil, ref: nil, merge_xattrs: false, temporary_directory: HOMEBREW_TEMP)
     @path = T.let(Pathname(path).expand_path, Pathname)
     @ref_type = ref_type
     @ref = ref
     @merge_xattrs = merge_xattrs
+    @temporary_directory = temporary_directory
   end
 
   sig { abstract.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
@@ -180,7 +186,7 @@ module UnpackStrategy
     ).void
   }
   def extract_nestedly(to: nil, basename: nil, verbose: false, prioritize_extension: false)
-    Mktemp.new("homebrew-unpack").run(chdir: false) do |unpack_dir|
+    Mktemp.new("homebrew-unpack", parent: temporary_directory).run(chdir: false) do |unpack_dir|
       tmp_unpack_dir = unpack_dir.tmpdir
       raise "Failed to create a temporary directory to unpack #{path}" if tmp_unpack_dir.nil?
 
@@ -192,7 +198,7 @@ module UnpackStrategy
         first_child = children.first
         next if first_child.nil?
 
-        s = UnpackStrategy.detect(first_child, prioritize_extension:)
+        s = UnpackStrategy.detect(first_child, prioritize_extension:, temporary_directory:)
 
         s.extract_nestedly(to:, verbose:, prioritize_extension:)
 

--- a/Library/Homebrew/unpack_strategy/directory.rb
+++ b/Library/Homebrew/unpack_strategy/directory.rb
@@ -18,15 +18,17 @@ module UnpackStrategy
 
     sig {
       params(
-        path:         T.any(String, Pathname),
-        ref_type:     T.nilable(Symbol),
-        ref:          T.nilable(String),
-        merge_xattrs: T::Boolean,
-        move:         T::Boolean,
+        path:                T.any(String, Pathname),
+        ref_type:            T.nilable(Symbol),
+        ref:                 T.nilable(String),
+        merge_xattrs:        T::Boolean,
+        move:                T::Boolean,
+        temporary_directory: Pathname,
       ).void
     }
-    def initialize(path, ref_type: nil, ref: nil, merge_xattrs: false, move: false)
-      super(path, ref_type:, ref:, merge_xattrs:)
+    def initialize(path, ref_type: nil, ref: nil, merge_xattrs: false, move: false,
+                   temporary_directory: HOMEBREW_TEMP)
+      super(path, ref_type:, ref:, merge_xattrs:, temporary_directory:)
       @move = move
     end
 

--- a/Library/Homebrew/unpack_strategy/tar.rb
+++ b/Library/Homebrew/unpack_strategy/tar.rb
@@ -37,7 +37,7 @@ module UnpackStrategy
 
     sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
     def extract_to_dir(unpack_dir, basename:, verbose:)
-      Dir.mktmpdir("homebrew-tar", HOMEBREW_TEMP) do |tmpdir|
+      Dir.mktmpdir("homebrew-tar", temporary_directory.to_s) do |tmpdir|
         tar_path = if DependencyCollector.tar_needs_xz_dependency? && Xz.can_extract?(path)
           subextract(Xz, Pathname(tmpdir), verbose)
         elsif DependencyCollector.tar_needs_bzip2_dependency? && Bzip2.can_extract?(path)


### PR DESCRIPTION
Bottle installation verified the cached archive in `HOMEBREW_CACHE` and then extracted it from that same path, and it trusted any `.poured` marker and pre-extracted keg it found under the temporary Cellar. Sandboxed build and postinstall steps may write to the cache and, through the `var` grant, to the temporary Cellar, so a package process left running by an earlier install could substitute the archive or the keg that a later ordinary install moved into the Cellar without any further trust decision.

Bottles are now verified from a private copy under the temporary Cellar and extracted from that copy, both for direct pours and for the download queue's pre-extraction, which stays in place. Extraction and tar decompression intermediates stay beside that copy instead of under `HOMEBREW_TEMP`, which sandboxed steps may write. Pre-extraction discards any existing marker or keg instead of reusing it, `pour` only moves a pre-extracted keg whose marker points at a real keg directory and otherwise purges the entry and stages afresh, and the build and postinstall sandboxes deny writes to the temporary Cellar after the `var` grant, which macOS applies as the last matching rule. Landlock on Linux cannot exclude the temporary Cellar from the granted `var` tree, so I will address the Linux policy separately. I verified real bottle pours on macOS through both the queue and the serial path with the new code.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

GPT-6 Astra and Claude Code (Fable 5.1) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the change and pass with it, and ran `brew lgtm --online` plus real bottle installs through the new staging path.

-----
