### PR TITLE
completions: match Bash candidates literally

### DIFF
--- a/Library/Homebrew/completions/bash.erb
+++ b/Library/Homebrew/completions/bash.erb
@@ -33,65 +33,56 @@ __brewcomp_words_include() {
   return 1
 }
 
-__brewcomp() {
-  # break $1 on space, tab, and newline characters,
-  # and turn it into a newline separated list of words
-  local list s sep=$'\n' IFS=$' \t\n'
-  local cur=${COMP_WORDS[COMP_CWORD]}
-
-  for s in $1
+__brewcomp_words() {
+  local line
+  local -a words
+  while IFS= read -r line
   do
-    __brewcomp_words_include "${s}" || list+="${s}${sep}"
-  done
+    IFS=$' \t' read -r -a words <<< "${line}"
+    [[ ${#words[@]} -gt 0 ]] && printf '%s\n' "${words[@]}"
+  done <<< "$1"
+}
 
-  list=${list%"${sep}"}
+__brewcomp_lines() {
+  local line
+  while IFS= read -r line
+  do
+    [[ -n ${line} && ${line} == "${COMP_WORDS[COMP_CWORD]}"* ]] && COMPREPLY+=("${line}")
+  done <<< "$1"
+}
 
-  IFS="${sep}"
-  while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${list}" -- "${cur}")
+__brewcomp() {
+  local line
+  while IFS= read -r line
+  do
+    __brewcomp_words_include "${line}" || __brewcomp_lines "${line}"
+  done < <(__brewcomp_words "$1")
 }
 
 # Don't use __brewcomp() in any of the __brew_complete_foo functions, as
 # it is too slow and is not worth it just for duplicate elimination.
 __brew_complete_formulae() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  local formulae
-  formulae="$(HOMEBREW_COMPLETION=1 brew formulae)"
-  while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${formulae}" -- "${cur}")
+  __brewcomp_lines "$(HOMEBREW_COMPLETION=1 brew formulae)"
 }
 
 __brew_complete_casks() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  local casks
-  casks="$(HOMEBREW_COMPLETION=1 brew casks)"
-  while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${casks}" -- "${cur}")
+  __brewcomp_lines "$(HOMEBREW_COMPLETION=1 brew casks)"
 }
 
 __brew_complete_installed_formulae() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  local installed_formulae
-  installed_formulae="$(command ls "${HOMEBREW_CELLAR:-$(brew --cellar)}" 2>/dev/null)"
-  while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${installed_formulae}" -- "${cur}")
+  __brewcomp_lines "$(command ls "${HOMEBREW_CELLAR:-$(brew --cellar)}" 2>/dev/null)"
 }
 
 __brew_complete_installed_casks() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  local installed_casks
-  installed_casks="$(command ls "$(brew --caskroom)" 2>/dev/null)"
-  while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${installed_casks}" -- "${cur}")
+  __brewcomp_lines "$(command ls "$(brew --caskroom)" 2>/dev/null)"
 }
 
 __brew_complete_outdated_formulae() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  local outdated_formulae
-  outdated_formulae="$(HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --formula --quiet)"
-  while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${outdated_formulae}" -- "${cur}")
+  __brewcomp_lines "$(HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --formula --quiet)"
 }
 
 __brew_complete_outdated_casks() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  local outdated_casks
-  outdated_casks="$(HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --cask --quiet 2>/dev/null)"
-  while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${outdated_casks}" -- "${cur}")
+  __brewcomp_lines "$(HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --cask --quiet 2>/dev/null)"
 }
 
 __brew_complete_tapped() {
@@ -111,7 +102,7 @@ __brew_complete_tapped() {
 __brew_complete_commands() {
   # Auto-complete Homebrew commands
 
-  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local line
   local cmds
   local maintainer_cmds
   local user_aliases
@@ -131,21 +122,18 @@ __brew_complete_commands() {
     maintainer_cmds="<%= maintainer_commands.join(" ") %>"
   fi
   user_aliases="$(__brew_list_aliases)"
-  while read -r line
+  while IFS= read -r line
   do
     [[ $(__brew_internal_command_alias "${line}") == "${line}" ]] || continue
-    COMPREPLY+=("${line}")
-  done < <(compgen -W "${cmds} ${maintainer_cmds} ${user_aliases}" -- "${cur}")
+    __brewcomp_lines "${line}"
+  done < <(__brewcomp_words "${cmds} ${maintainer_cmds} ${user_aliases}")
   export __HOMEBREW_COMMANDS=${cmds}
 }
 
 __brew_complete_services() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  local services
-  services="$(command find "$(brew --cellar)" -mindepth 3 -maxdepth 3 -name '*.service' \
+  __brewcomp_lines "$(command find "$(brew --cellar)" -mindepth 3 -maxdepth 3 -name '*.service' \
     | awk -F'homebrew.|.service' '{print $3}' \
     | sort -d)"
-  while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${services}" -- "${cur}")
 }
 
 # compopt is only available in newer versions of bash

--- a/Library/Homebrew/test/completions_spec.rb
+++ b/Library/Homebrew/test/completions_spec.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "completions"
+require "open3"
 
 RSpec.describe Homebrew::Completions do
   let(:completions_dir) { HOMEBREW_REPOSITORY/"completions" }
@@ -381,6 +382,34 @@ RSpec.describe Homebrew::Completions do
     end
 
     describe ".generate_bash_completion_file" do
+      it "completes literal package names without invoking an expanding wordlist" do
+        script = described_class.generate_bash_completion_file(%w[install]) + <<~'BASH'
+          compgen() { return 99; }
+          brew() { printf '%s\n' 'alpha' 'alpine' 'beta'; }
+          COMP_WORDS=(brew install al)
+          COMP_CWORD=2
+          COMPREPLY=()
+          __brew_complete_formulae
+          printf '%s\n' "${COMPREPLY[@]}"
+        BASH
+
+        expect(Open3.capture3("/bin/bash", "-c", script).first).to eq("alpha\nalpine\n")
+      end
+
+      it "preserves literal characters and spaces in package completion records" do
+        script = described_class.generate_bash_completion_file(%w[install]) + <<~'BASH'
+          compgen() { return 99; }
+          brew() { printf '%s\n' 'alpha*' 'alpha space' 'alpha\path' 'beta'; }
+          COMP_WORDS=(brew install alpha)
+          COMP_CWORD=2
+          COMPREPLY=()
+          __brew_complete_formulae
+          printf '%s\n' "${COMPREPLY[@]}"
+        BASH
+
+        expect(Open3.capture3("/bin/bash", "-c", script).first).to eq("alpha*\nalpha space\nalpha\\path\n")
+      end
+
       it "returns the correct completion file" do
         file = described_class.generate_bash_completion_file(%w[install missing update])
         expect(file).to match(/^__brewcomp\(\) {$/)
@@ -406,7 +435,7 @@ RSpec.describe Homebrew::Completions do
         expect(file).not_to match(/^ {4}up\) _brew_up ;;/)
         expect(file).to include('[[ $(__brew_internal_command_alias "${line}") == "${line}" ]] || continue')
         expect(file).to include('cmd="$(__brew_internal_command_alias "${cmd}")"')
-        expect(file).to include('compgen -W "${cmds} ${maintainer_cmds} ${user_aliases}" -- "${cur}"')
+        expect(file).to include('__brewcomp_words "${cmds} ${maintainer_cmds} ${user_aliases}"')
         expect(file).to match(/^ {4}up\) echo "update" ;;$/)
         expect(file).to match(/^ {4}update\) _brew_update ;;$/)
       end

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -18,65 +18,56 @@ __brewcomp_words_include() {
   return 1
 }
 
-__brewcomp() {
-  # break $1 on space, tab, and newline characters,
-  # and turn it into a newline separated list of words
-  local list s sep=$'\n' IFS=$' \t\n'
-  local cur=${COMP_WORDS[COMP_CWORD]}
-
-  for s in $1
+__brewcomp_words() {
+  local line
+  local -a words
+  while IFS= read -r line
   do
-    __brewcomp_words_include "${s}" || list+="${s}${sep}"
-  done
+    IFS=$' \t' read -r -a words <<< "${line}"
+    [[ ${#words[@]} -gt 0 ]] && printf '%s\n' "${words[@]}"
+  done <<< "$1"
+}
 
-  list=${list%"${sep}"}
+__brewcomp_lines() {
+  local line
+  while IFS= read -r line
+  do
+    [[ -n ${line} && ${line} == "${COMP_WORDS[COMP_CWORD]}"* ]] && COMPREPLY+=("${line}")
+  done <<< "$1"
+}
 
-  IFS="${sep}"
-  while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${list}" -- "${cur}")
+__brewcomp() {
+  local line
+  while IFS= read -r line
+  do
+    __brewcomp_words_include "${line}" || __brewcomp_lines "${line}"
+  done < <(__brewcomp_words "$1")
 }
 
 # Don't use __brewcomp() in any of the __brew_complete_foo functions, as
 # it is too slow and is not worth it just for duplicate elimination.
 __brew_complete_formulae() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  local formulae
-  formulae="$(HOMEBREW_COMPLETION=1 brew formulae)"
-  while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${formulae}" -- "${cur}")
+  __brewcomp_lines "$(HOMEBREW_COMPLETION=1 brew formulae)"
 }
 
 __brew_complete_casks() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  local casks
-  casks="$(HOMEBREW_COMPLETION=1 brew casks)"
-  while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${casks}" -- "${cur}")
+  __brewcomp_lines "$(HOMEBREW_COMPLETION=1 brew casks)"
 }
 
 __brew_complete_installed_formulae() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  local installed_formulae
-  installed_formulae="$(command ls "${HOMEBREW_CELLAR:-$(brew --cellar)}" 2>/dev/null)"
-  while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${installed_formulae}" -- "${cur}")
+  __brewcomp_lines "$(command ls "${HOMEBREW_CELLAR:-$(brew --cellar)}" 2>/dev/null)"
 }
 
 __brew_complete_installed_casks() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  local installed_casks
-  installed_casks="$(command ls "$(brew --caskroom)" 2>/dev/null)"
-  while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${installed_casks}" -- "${cur}")
+  __brewcomp_lines "$(command ls "$(brew --caskroom)" 2>/dev/null)"
 }
 
 __brew_complete_outdated_formulae() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  local outdated_formulae
-  outdated_formulae="$(HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --formula --quiet)"
-  while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${outdated_formulae}" -- "${cur}")
+  __brewcomp_lines "$(HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --formula --quiet)"
 }
 
 __brew_complete_outdated_casks() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  local outdated_casks
-  outdated_casks="$(HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --cask --quiet 2>/dev/null)"
-  while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${outdated_casks}" -- "${cur}")
+  __brewcomp_lines "$(HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --cask --quiet 2>/dev/null)"
 }
 
 __brew_complete_tapped() {
@@ -96,7 +87,7 @@ __brew_complete_tapped() {
 __brew_complete_commands() {
   # Auto-complete Homebrew commands
 
-  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local line
   local cmds
   local maintainer_cmds
   local user_aliases
@@ -116,21 +107,18 @@ __brew_complete_commands() {
     maintainer_cmds="advisory-match determine-test-runners dispatch-build-bottle formula-analytics generate-advisories-api generate-analytics-api generate-cask-api generate-cask-ci-matrix generate-formula-api generate-internal-api generate-vulns-advisories pr-automerge pr-publish pr-pull pr-upload release update-license-data update-maintainers update-portable-ruby update-report update-sponsors vendor-install"
   fi
   user_aliases="$(__brew_list_aliases)"
-  while read -r line
+  while IFS= read -r line
   do
     [[ $(__brew_internal_command_alias "${line}") == "${line}" ]] || continue
-    COMPREPLY+=("${line}")
-  done < <(compgen -W "${cmds} ${maintainer_cmds} ${user_aliases}" -- "${cur}")
+    __brewcomp_lines "${line}"
+  done < <(__brewcomp_words "${cmds} ${maintainer_cmds} ${user_aliases}")
   export __HOMEBREW_COMMANDS=${cmds}
 }
 
 __brew_complete_services() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  local services
-  services="$(command find "$(brew --cellar)" -mindepth 3 -maxdepth 3 -name '*.service' \
+  __brewcomp_lines "$(command find "$(brew --cellar)" -mindepth 3 -maxdepth 3 -name '*.service' \
     | awk -F'homebrew.|.service' '{print $3}' \
     | sort -d)"
-  while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${services}" -- "${cur}")
 }
 
 # compopt is only available in newer versions of bash


### PR DESCRIPTION
The Bash completion script handed dynamic candidates such as formula, cask, installed, outdated, service and command names to `compgen -W`, which performs shell expansion on its word list. Some of those lists come from files that sandboxed package processes may write, so a crafted name could run a command in the user's shell at the moment they pressed tab.

The generated script now reads candidates one per line and keeps those that start with the current word, comparing literally, so candidate text is never expanded. Names containing spaces, backslashes and glob characters complete as written. New tests execute the generated script under `/bin/bash` with a stubbed `compgen` and `brew` to check both the filtering and that `compgen` is no longer involved, and `completions/bash/brew` is regenerated.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

GPT-6 Astra and Claude Code (Fable 5.1) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the change and pass with it, and ran `brew lgtm --online` plus targeted specs.

-----
