### PR TITLE
tap: print invalid tap names instead of crashing

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -53,7 +53,8 @@ class Tap
     #{HOMEBREW_TAP_STYLE_EXCEPTIONS_DIR}/*.json
   ].freeze
 
-  class InvalidNameError < ArgumentError; end
+  # `RuntimeError` so `brew.rb` reports it as a user error rather than a bug.
+  class InvalidNameError < RuntimeError; end
 
   # Fetch a {Tap} by name.
   #

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -117,6 +117,10 @@ RSpec.describe Tap do
     end.to raise_error(Tap::InvalidNameError, /Invalid tap name/)
   end
 
+  specify "::fetch raises an error `brew.rb` prints without a backtrace" do
+    expect { described_class.fetch("foo") }.to raise_error(RuntimeError, /Invalid tap name/)
+  end
+
   describe "::from_path" do
     let(:tap) { described_class.fetch("Homebrew", "core") }
     let(:path) { tap.path }


### PR DESCRIPTION
- `Tap::InvalidNameError` inherited from `ArgumentError`, a typo such as `brew tap-info homebrew` fell through to the catch-all `rescue Exception` in `brew.rb` and printed a backtrace.
- `brew.rb` prints a `RuntimeError` as a single `onoe` line and only shows the backtrace under `--debug`, which is what every other tap error in `exceptions.rb` already relies on.
- Add a spec testing the `RuntimeError`

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Fable 5.1 with manual review, `brew lgtm --online`, manual testing.