### PR TITLE
patch: harden staged-tree target containment

### DIFF
--- a/Library/Homebrew/patch.rb
+++ b/Library/Homebrew/patch.rb
@@ -44,22 +44,43 @@ module Patch
   # Reject patch target paths (absolute or `..`-traversing) that escape the staged source tree.
   sig { params(text: String, strip: T.any(Symbol, String), base: Pathname).void }
   def self.ensure_targets_within!(text, strip:, base:)
+    # `patch` writes nothing for empty input.
+    return if text.blank?
+
     # Resolve targets with `patch --dry-run` so containment matches what `patch`
     # actually writes, covering `Index:`/`====` and non-selected context headers.
-    output = with_env(LC_ALL: "C", LANG: "C") do
+    output = with_env(LC_ALL: "C", LANG: "C", QUOTING_STYLE: "literal") do
       base.cd do
         Utils.popen_write("patch", "-g", "0", "-f", "-#{strip}", "--dry-run", err: :out) { |p| p.write(text) }
       end
     end
 
-    output.each_line do |line|
-      next unless (target = line.chomp[/\A(?:patching|checking) file (.+)\z/, 1])
+    # No output means `patch` named nothing, not that it will write nothing, so
+    # fail closed. An ed-format patch reports nothing at all and lands here.
+    raise "Unsupported patch format: no target paths to verify." if output.blank?
 
-      target = target.delete_prefix("'").delete_suffix("'") if target.start_with?("'") && target.end_with?("'")
-      Utils::Path.ensure_child_of!(
-        base, base/target,
-        message: "Patch target path escapes the staged source tree: #{target}"
-      )
+    output.each_line do |line|
+      # `patch` names a target for a hunk it applies and a reject file it writes.
+      line = line.chomp
+      named = line[/\A(?:patching|checking) (?:file|symbolic link) (.+)\z/, 1] ||
+              line[/hunks? ignored while patching (.+)\z/, 1]
+      next if named.nil?
+
+      # GNU patch appends the source it read, so a rename, copy or read names two
+      # paths. A filename may contain that text, so check every reading of it.
+      suffixed = named.match(/\A(.+) \((?:already )?(?:renamed|copied|read) from (.+)\)\z/)
+      targets = [named, *suffixed&.captures].uniq
+
+      targets.each do |target|
+        message = "Patch target path escapes the staged source tree: #{target}"
+
+        # Reject rather than resolve: `Pathname#/` collapses a `..` after a
+        # symlinked directory before anything below can resolve it.
+        target_path = Pathname(target)
+        raise message if target_path.absolute? || target_path.each_filename.include?("..")
+
+        Utils::Path.ensure_child_of!(base, base/target, message:)
+      end
     end
   end
 

--- a/Library/Homebrew/test/patch_spec.rb
+++ b/Library/Homebrew/test/patch_spec.rb
@@ -216,6 +216,123 @@ RSpec.describe Patch do
           .to raise_error(/escapes the staged source tree/)
       end
     end
+
+    it "rejects an ed-format diff, whose targets `patch` never reports" do
+      mktmpdir do |base|
+        (base/"src").mkpath
+        (base/"src/foo.c").write("old\n")
+        patch = <<~EOS
+          Index: a/src/foo.c
+          1c
+          owned
+          .
+        EOS
+
+        expect { described_class.ensure_targets_within!(patch, strip: :p1, base:) }
+          .to raise_error(/no target paths to verify/)
+      end
+    end
+
+    it "allows a normal-format diff, whose hunk headers resemble ed commands" do
+      mktmpdir do |base|
+        (base/"foo.c").write("old\n")
+        patch = <<~EOS
+          Index: foo.c
+          1c1
+          < old
+          ---
+          > new
+        EOS
+
+        expect { described_class.ensure_targets_within!(patch, strip: :p0, base:) }.not_to raise_error
+      end
+    end
+
+    it "accepts empty patch text, which `patch` writes nothing for" do
+      mktmpdir do |base|
+        expect { described_class.ensure_targets_within!("", strip: :p1, base:) }.not_to raise_error
+      end
+    end
+
+    it "rejects a patch that `patch` reports no targets for" do
+      mktmpdir do |base|
+        allow(Utils).to receive(:popen_write).and_return("")
+
+        expect { described_class.ensure_targets_within!("--- a/src/foo.c\n", strip: :p1, base:) }
+          .to raise_error(/no target paths to verify/)
+      end
+    end
+
+    it "accepts a target whose name `patch` would otherwise quote" do
+      mktmpdir do |base|
+        (base/"li'nk").mkpath
+        (base/"li'nk/v.c").write("old\n")
+        patch = <<~EOS
+          --- a/li'nk/v.c
+          +++ b/li'nk/v.c
+          @@ -1 +1 @@
+          -old
+          +new
+        EOS
+
+        expect { described_class.ensure_targets_within!(patch, strip: :p1, base:) }.not_to raise_error
+      end
+    end
+
+    it "rejects an escaping symbolic link, which GNU patch names differently" do
+      mktmpdir do |base|
+        allow(Utils).to receive(:popen_write).and_return("checking symbolic link ../escape.txt\n")
+
+        expect { described_class.ensure_targets_within!("--- a/link\n", strip: :p1, base:) }
+          .to raise_error(/escapes the staged source tree/)
+      end
+    end
+
+    it "rejects an escaping source named in a GNU patch copy diagnostic" do
+      mktmpdir do |base|
+        allow(Utils).to receive(:popen_write)
+          .and_return("checking file src/bar.c (copied from ../escape.txt)\n")
+
+        expect { described_class.ensure_targets_within!("--- a/src/bar.c\n", strip: :p1, base:) }
+          .to raise_error(/escapes the staged source tree/)
+      end
+    end
+
+    it "rejects an escaping target that `patch` only names as a reject file", :needs_macos do
+      mktmpdir do |base|
+        patch = <<~EOS
+          --- a/../escape.txt
+          +++ b/../escape.txt
+          @@ -1 +1 @@
+          -old
+          +owned
+        EOS
+
+        expect { described_class.ensure_targets_within!(patch, strip: :p1, base:) }
+          .to raise_error(/escapes the staged source tree/)
+      end
+    end
+
+    it "rejects a target reaching outside through a symlinked directory", :needs_macos do
+      mktmpdir do |base|
+        (base/"src").mkpath
+        outside = base.parent/"outside"
+        outside.mkpath
+        (outside/"victim.txt").write("old\n")
+        FileUtils.ln_s(outside.to_s, (base/"src/lnk").to_s)
+
+        patch = <<~EOS
+          --- a/src/lnk/../victim.txt
+          +++ b/src/lnk/../victim.txt
+          @@ -1 +1 @@
+          -old
+          +owned
+        EOS
+
+        expect { described_class.ensure_targets_within!(patch, strip: :p1, base:) }
+          .to raise_error(/escapes the staged source tree/)
+      end
+    end
   end
 
   describe "#resolves" do

--- a/Library/Homebrew/test/utils/path_spec.rb
+++ b/Library/Homebrew/test/utils/path_spec.rb
@@ -47,6 +47,48 @@ RSpec.describe Utils::Path do
     it "raises the provided message for a path that is not a child" do
       expect { described_class.ensure_child_of!("/foo", "/bar/baz", message: "outside") }.to raise_error("outside")
     end
+
+    it "raises for an existing path that reaches outside the parent through a symlink" do
+      mktmpdir do |dir|
+        (dir/"outside").mkpath
+        (dir/"outside/target").write("secret\n")
+        (dir/"parent").mkpath
+        FileUtils.ln_s(dir/"outside", dir/"parent/link")
+
+        expect { described_class.ensure_child_of!(dir/"parent", dir/"parent/link/target", message: "outside") }
+          .to raise_error("outside")
+      end
+    end
+
+    it "raises for a path that does not exist yet under a symlinked directory" do
+      mktmpdir do |dir|
+        (dir/"outside").mkpath
+        (dir/"parent").mkpath
+        FileUtils.ln_s(dir/"outside", dir/"parent/link")
+
+        expect { described_class.ensure_child_of!(dir/"parent", dir/"parent/link/new", message: "outside") }
+          .to raise_error("outside")
+      end
+    end
+
+    it "raises for a dangling symlink, which `exist?` reports as missing" do
+      mktmpdir do |dir|
+        (dir/"parent").mkpath
+        FileUtils.ln_s((dir/"outside/planted").to_s, (dir/"parent/dangle").to_s)
+
+        expect { described_class.ensure_child_of!(dir/"parent", dir/"parent/dangle", message: "outside") }
+          .to raise_error("outside")
+      end
+    end
+
+    it "allows a real path within the parent" do
+      mktmpdir do |dir|
+        (dir/"parent/src").mkpath
+
+        expect { described_class.ensure_child_of!(dir/"parent", dir/"parent/src/foo.c", message: "outside") }
+          .not_to raise_error
+      end
+    end
   end
 
   describe "::cp_path_sub" do

--- a/Library/Homebrew/utils/path.rb
+++ b/Library/Homebrew/utils/path.rb
@@ -26,8 +26,11 @@ module Utils
 
       sig { params(parent: T.any(Pathname, String), child: T.any(Pathname, String), message: String).void }
       def ensure_child_of!(parent, child, message:)
-        return if child_of?(parent, child)
+        return if child_of?(resolve_symlinks(parent), resolve_symlinks(child))
 
+        raise message
+      rescue SystemCallError
+        # Fail closed: an unresolvable symlink leaves containment unproven.
         raise message
       end
 
@@ -102,6 +105,18 @@ module Utils
         yield
       ensure
         path.chmod saved_perms if saved_perms
+      end
+
+      private
+
+      # `child_of?` is lexical, so resolve the deepest existing component first.
+      # Stop at a symlink too: `exist?` follows one, hiding a dangling link.
+      sig { params(path: T.any(Pathname, String)).returns(Pathname) }
+      def resolve_symlinks(path)
+        pathname = Pathname(path).expand_path
+        existing = pathname
+        existing = existing.parent until existing.exist? || existing.symlink? || existing.root?
+        (existing.realpath/pathname.relative_path_from(existing)).cleanpath
       end
     end
 


### PR DESCRIPTION
`Patch.ensure_targets_within!` took its targets only from `patch --dry-run` lines reading `patching file X`, so anything `patch` writes but names another way went unchecked. A hunk against `../escape.txt` is named as `1 out of 1 hunks ignored while patching '../escape.txt'`, and the real run creates that file outside the staged tree with patch-controlled content. GNU patch additionally names a symlink as `checking symbolic link X` and appends the source it read as `(renamed from X)`, `(copied from X)` or `(read from X)`, none of which parsed. All of those are now read, and the dry run runs under `QUOTING_STYLE=literal` so a name containing an apostrophe arrives raw rather than double quoted.

`Utils::Path.ensure_child_of!` compared paths lexically, so a symlinked directory looked contained while writes through it landed outside. It now resolves the deepest existing component, stopping at a symlink because `Pathname#exist?` follows one and would report a dangling link as merely missing. Resolution alone is not enough, because `expand_path` collapses `..` before any `realpath` runs and `Pathname#/` collapses it again while joining, so an absolute or `..`-bearing target is rejected on the raw name `patch` reported, which is where GNU patch checks it in `filename_is_safe`.

This is a stopgap and not complete, so it is worth being explicit about the limit. Containment here is derived from `patch --dry-run` prose, and that prose is a human-readable format which differs between implementations in its nouns, its suffixes and its quoting. Under `QUOTING_STYLE=literal` a name containing a newline is not line-delimited, and under `c` Apple's patch is lossy: `café.c` reports as `"caf\xff\xff.c"` where the real bytes are `\303\251`, so the name cannot be recovered. No quoting style yields a recoverable path on both. Ed-format detection is left out for the same reason, beyond the empty-output check which already refuses a patch that is only an ed script.

Measured against GNU patch 2.8, every escape above is refused natively: `..` and absolute targets by `filename_is_safe`, and a symlinked directory because it does not follow symlinks, where Apple's patch writes through it. Homebrew already ships `gpatch`, so using it on macOS would let this method be deleted rather than extended, and I will propose that separately. Until then this closes the reachable shapes.

Reaching any of this needs no configuration, but the bar is a formula author or third-party tap, who can already run arbitrary code from `install`, so it is hardening of the staged tree rather than a privilege boundary. It extends the containment added for GHSA-r7qx-325v-4ccx, which covered only the reported line format. The check and the write are separate `patch` invocations and cannot be atomic, which is a same-user window that crosses no boundary.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

AI/LLM disclosure: Claude Opus 5 via Claude Code drafted this; I reproduced each escape and each fix myself against both Apple and GNU patch.

-----
