### PR TITLE
shims/super/cc: Keep dependency -L flags ahead of superenv paths

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -160,7 +160,10 @@ class Cmd
   end
 
   def refurbished_args
-    @lset = Set.new((library_paths + system_library_paths).map { canonical_path(it) })
+    # Keep explicit -L flags for declared dependencies so a formula can still
+    # put one ahead of the library paths superenv appends itself.
+    @lset = Set.new((library_paths + system_library_paths).map { canonical_path(it) }
+                                                           .reject { dependency_path?(it) })
     @iset = Set.new((isystem_paths + include_paths).map { canonical_path(it) })
 
     args = []
@@ -273,6 +276,10 @@ class Cmd
     args
   end
 
+  def dependency_path?(path)
+    path.start_with?(*@keg_dirs) && @deps.include?(path[keg_regex, 2])
+  end
+
   def keep?(path)
     # Allow references to self
     if @self_dir && path.start_with?(@self_dir)
@@ -280,8 +287,7 @@ class Cmd
     # first two paths: reject references to Cellar or opt paths
     # for unspecified dependencies
     elsif path.start_with?(*@keg_dirs)
-      dep = path[keg_regex, 2]
-      dep && @deps.include?(dep)
+      dependency_path?(path)
     elsif path.start_with?(*@prefix_dirs)
       true
     elsif path.start_with?("/opt/local", "/opt/boxen/homebrew", "/opt/X11", "/sw", "/usr/X11")

--- a/Library/Homebrew/test/shims/super/cc_spec.rb
+++ b/Library/Homebrew/test/shims/super/cc_spec.rb
@@ -80,6 +80,26 @@ RSpec.describe CcShim::Cmd do
     described_class.new("gcc", argv).args
   end
 
+  it "keeps an explicit dependency -L ahead of its own library paths" do
+    setup_env(real_prefix)
+    ENV["HOMEBREW_LIBRARY_PATHS"] = "#{real_prefix}/lib:#{real_prefix}/#{opt}/ocaml/lib"
+
+    argv = ["-o", "prog", "-L#{real_prefix}/#{opt}/ocaml/lib", "prog.o"]
+    args = described_class.new("gcc", argv).args
+
+    expect(args.index("-L#{real_prefix}/#{opt}/ocaml/lib")).to be < args.index("-L#{real_prefix}/lib")
+  end
+
+  it "drops an explicit -L for a library path it appends itself" do
+    setup_env(real_prefix)
+    ENV["HOMEBREW_LIBRARY_PATHS"] = "#{real_prefix}/#{cellar}/ocaml/5.5.0/lib:#{real_prefix}/lib"
+
+    argv = ["-o", "prog", "-L#{real_prefix}/lib", "prog.o"]
+    args = described_class.new("gcc", argv).args
+
+    expect(args.count("-L#{real_prefix}/lib")).to eq(1)
+  end
+
   it "targets x86_64 with Apple Clang under Rosetta 2" do
     setup_env(real_prefix)
     ENV["HOMEBREW_CC"] = "clang"


### PR DESCRIPTION
the `cc` shim canonicalises `-L` arguments before deduplicating them against `HOMEBREW_LIBRARY_PATHS`, so an explicit `-L` for a keg-only dependency now matches the shim's own entry and is dropped. The shim then appends its own `-L` flags in dependency-declaration order, and the formula loses control of which directory the linker searches first.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Fable 5.1 with manual review and testing.

-----

`portable-ruby` sets `XLDFLAGS=-L<portable-libxcrypt>/lib` to link `libcrypt.a`
statically, but `glibc@2.13` is declared first and ships `libcrypt.so.1`. The
4.0.6_1 Linux bottles vendored by #23703 link it dynamically, so `brew update`
fails on Linux hosts without `libcrypt.so.1` (e.g. Fedora):

    `bin/ruby: error while loading shared libraries: libcrypt.so.1: cannot open shared object file`

### Reproducing

Shipped bottle, on any host with Docker (or use macOS `container`):

    docker run --rm fedora:44 bash -c 'curl -sL -H "Authorization: Bearer QQ==" https://ghcr.io/v2/homebrew/core/portable-ruby/blobs/sha256:b192f87e0d0596dd7bb2e7ef91e7bae323ec879b405e1b778ee8d14798208e0f | tar xz -C /tmp && /tmp/portable-ruby/4.0.6_1/bin/ruby --version'

arm64_linux: `d0f04d327063be7ef72703c0e621eca33bc9bf388025d36671758ebac230364d`

End to end on Fedora 44: `brew install --build-from-source portable-ruby` with
`HOMEBREW_NO_INSTALL_FROM_API=1` produces a `bin/ruby` with no libcrypt
dependency. With the shim reverted, `configure` fails at `cannot compute sizeof
(long long)` because its `-lcrypt`-linked test binary cannot load
`libcrypt.so.1`.