### PR TITLE
Avoid evaluating cached and installed recipes

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1438,12 +1438,10 @@ on_request: installed_on_request?, options:)
     # * We're installing a local bottle file
     # * We're building from source
     # * The formula doesn't exist in the tap (or the tap isn't installed)
-    # * The formula in the tap has a different `pkg_version``.
+    # * The installed keg has a different version from the selected formula.
     #
-    # In all other cases, including if the formula from the keg is unreadable
-    # (third-party taps may `require` some of their own libraries) or if there
-    # is no formula present in the keg (as is the case with very old bottles),
-    # use the formula from the tap.
+    # Otherwise use the selected tap formula, without evaluating the keg's
+    # recipe while choosing the path.
     tap_formula_path = formula_path
     installed_prefix = formula.any_installed_prefix
     return tap_formula_path if installed_prefix.nil?
@@ -1459,15 +1457,9 @@ on_request: installed_on_request?, options:)
 
     return keg_formula_path unless tap_formula_path.exist?
 
-    begin
-      keg_formula = Formulary.factory(keg_formula_path)
-      tap_formula = Formulary.factory(tap_formula_path)
-      return keg_formula_path if keg_formula.pkg_version != tap_formula.pkg_version
+    return keg_formula_path if Keg.new(installed_prefix).version != formula.pkg_version
 
-      tap_formula_path
-    rescue FormulaUnavailableError, FormulaUnreadableError
-      tap_formula_path
-    end
+    tap_formula_path
   end
 
   sig { void }

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -1235,7 +1235,6 @@ module Formulary
       FromPathLoader,
       FromNameLoader,
       FromKegLoader,
-      FromCacheLoader,
     ].each do |loader_class|
       if (loader = loader_class.try_new(ref, from:, warn:))
         $stderr.puts "#{$PROGRAM_NAME} (#{loader_class}): loading #{ref}" if verbose? && debug?

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -269,6 +269,21 @@ RSpec.describe FormulaInstaller do
   end
 
   describe "#post_install_formula_path" do
+    it "compares installed versions without evaluating installed recipes" do
+      formula = formula("installed-version") do
+        T.bind(self, T.class_of(Formula))
+        url "foo-1.0"
+      end
+      installer = described_class.new(formula)
+      (formula.prefix/".brew").mkpath
+      formula.path.dirname.mkpath
+      formula.path.write("# current recipe")
+      allow(formula).to receive(:any_installed_prefix).and_return(formula.prefix)
+      allow(Formulary).to receive(:factory).and_raise("Recipe evaluation is not permitted")
+
+      expect(installer.post_install_formula_path).to eq(formula.path)
+    end
+
     it "uses the API formula for structured-only post-installs" do
       formula = formula("api-install-steps") do
         T.bind(self, T.class_of(Formula))

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -950,6 +950,14 @@ RSpec.describe Formulary do
   end
 
   describe "::loader_for" do
+    it "does not select formulae from the download cache by name" do
+      stub_const("HOMEBREW_CACHE_FORMULA", HOMEBREW_CACHE/"Formula")
+      HOMEBREW_CACHE_FORMULA.mkpath
+      (HOMEBREW_CACHE_FORMULA/"cached-only.rb").write("# cache data")
+
+      expect(described_class.loader_for("cached-only")).to be_a(described_class::NullLoader)
+    end
+
     context "when given a relative path with two slashes" do
       it "returns a `FromPathLoader`" do
         mktmpdir.cd do


### PR DESCRIPTION
Name resolution fell back to `FromCacheLoader`, which evaluates `$(brew --cache)/Formula/<name>.rb` for any name no tap provides, and `post_install_formula_path` evaluated both the keg's archived recipe and the tap formula only to compare their versions. The download cache and the keg are both writable by sandboxed build and postinstall steps, so either path ran Ruby from a location a package process can write. Drop the cache loader, which nothing writes to any more, and compare the keg's version with the selected formula's version instead of evaluating the archived recipe. `FromKegLoader` stays so installed formulae that have left their tap still resolve by name.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

GPT-6 Astra and Claude Code (Fable 5.1) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the change and pass with it, and ran `brew lgtm --online` plus targeted specs.

-----
