### PR TITLE
tap: link completions only for canonical origins

### DIFF
--- a/Library/Homebrew/completions.rb
+++ b/Library/Homebrew/completions.rb
@@ -88,7 +88,7 @@ module Homebrew
     def self.unlink!
       Settings.write :linkcompletions, false
       Tap.installed.each do |tap|
-        next if tap.official?
+        next if tap.official_git_checkout?
 
         Utils::Link.unlink_completions tap.path
       end
@@ -102,7 +102,7 @@ module Homebrew
     sig { returns(T::Boolean) }
     def self.completions_to_link?
       Tap.installed.each do |tap|
-        next if tap.official?
+        next if tap.official_git_checkout?
 
         SHELLS.each do |shell|
           return true if (tap.path/"completions/#{shell}").exist?

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -821,7 +821,7 @@ class Tap
 
     require "completions"
     Homebrew::Completions.show_completions_message_if_needed
-    if official? || Homebrew::Completions.link_completions?
+    if official_git_checkout? || Homebrew::Completions.link_completions?
       Utils::Link.link_completions(path, command)
     else
       Utils::Link.unlink_completions(path)
@@ -1494,6 +1494,15 @@ class Tap
   sig { overridable.params(remote: T.nilable(String)).returns(T::Boolean) }
   def implicitly_trusted?(remote: self.remote)
     official? && canonical_remote?(remote)
+  end
+
+  # Executable checkout files require the actual Git origin, including in API mode.
+  sig { returns(T::Boolean) }
+  def official_git_checkout?
+    return false unless official?
+
+    origin = git_repository.origin_url
+    origin.present? && canonical_remote?(origin)
   end
 
   sig { overridable.params(remote: T.nilable(String)).returns(T::Boolean) }

--- a/Library/Homebrew/test/completions_spec.rb
+++ b/Library/Homebrew/test/completions_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe Homebrew::Completions do
       (completions_dir/shell).mkpath
     end
     internal_path.mkpath
+    allow(Tap.fetch("homebrew/bar").git_repository).to receive(:origin_url)
+      .and_return("https://github.com/Homebrew/homebrew-bar")
     external_path.mkpath
   end
 

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -30,6 +30,21 @@ RSpec.describe Tap do
     $stderr.extend(Utils::Output::Mixin)
   end
 
+  it "does not grant completion trust to a custom core checkout in API mode" do
+    tap = CoreTap.instance
+    allow(tap.git_repository).to receive(:origin_url).and_return("https://git.example.com/other/core")
+    allow(Homebrew::EnvConfig).to receive(:no_install_from_api?).and_return(false)
+
+    expect(tap.official_git_checkout?).to be(false)
+  end
+
+  it "does not read the origin of a third-party tap" do
+    tap = described_class.fetch("someone", "foo")
+    allow(tap.git_repository).to receive(:origin_url).and_raise("origin must not be read")
+
+    expect(tap.official_git_checkout?).to be(false)
+  end
+
   def setup_tap_files
     formula_file.dirname.mkpath
     formula_file.write <<~RUBY
@@ -1128,6 +1143,8 @@ RSpec.describe Tap do
     setup_completion link: false
     tap = described_class.fetch("Homebrew", "baz")
     tap.install clone_target: homebrew_foo_tap.path/".git"
+    system "git", "-C", tap.path.to_s, "remote", "set-url", "origin", tap.default_remote
+    tap.link_completions_and_manpages
     (HOMEBREW_PREFIX/"share/man/man1/brew-tap-cmd.1").delete
     (HOMEBREW_PREFIX/"etc/bash_completion.d/brew-tap-cmd").delete
     (HOMEBREW_PREFIX/"share/zsh/site-functions/_brew-tap-cmd").delete


### PR DESCRIPTION
Completion and manpage linking trusted any tap whose name looks official, so a tap named `homebrew/foo` cloned from a custom remote had its shell completions linked automatically even though the trust checks would not run its Ruby. Add `Tap#official_git_checkout?`, which requires the checkout's actual Git origin to be the canonical remote, and use it where completions are linked, unlinked and counted, so only canonical official checkouts get automatic completion trust.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

GPT-6 Astra and Claude Code (Fable 5.1) drafted the implementation and tests; I reviewed the diff, verified the new test fails without the change and the updated specs pass with it, and ran `brew lgtm --online` plus targeted specs.

-----
