### PR TITLE
create: insert metadata after ERB parsing

### DIFF
--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -162,27 +162,27 @@ module Homebrew
 
     sig { returns(String) }
     def template
-      <<~ERB
+      <<~'ERB'
         # Documentation: https://docs.brew.sh/Formula-Cookbook
         #                https://docs.brew.sh/rubydoc/Formula
         # PLEASE REMOVE ALL GENERATED COMMENTS BEFORE SUBMITTING YOUR PULL REQUEST!
-        class #{Formulary.class_s(name)} < Formula
+        class <%= Formulary.class_s(name) %> < Formula
         <% if @mode == :python %>
           include Language::Python::Virtualenv
 
         <% end %>
-          desc "#{@desc}"
-          homepage "#{@homepage}"
+          desc <%= @desc.to_s.inspect %>
+          homepage <%= @homepage.to_s.inspect %>
         <% unless @head %>
-          url "#{@url}"
+          url <%= @url.inspect %>
         <% unless @version.detected_from_url? %>
-          version "#{@version.to_s.delete_prefix("v")}"
+          version <%= @version.to_s.delete_prefix("v").inspect %>
         <% end %>
-          sha256 "#{@sha256}"
+          sha256 <%= @sha256.to_s.inspect %>
         <% end %>
-          license "#{@license}"
+          license <%= @license.to_s.inspect %>
         <% if @head %>
-          head "#{@url}"
+          head <%= @url.inspect %>
         <% end %>
 
         <% if @mode == :cabal %>
@@ -211,7 +211,7 @@ module Homebrew
           #   sha256 ""
           # end
         <% elsif @mode == :python %>
-          depends_on "#{latest_versioned_formula("python")}"
+          depends_on <%= latest_versioned_formula("python").inspect %>
         <% elsif @mode == :ruby %>
           depends_on "ruby"
         <% elsif @mode == :rust %>
@@ -274,7 +274,7 @@ module Homebrew
             system "make", "install" # if this fails, try separate make/make install steps
         <% elsif @mode == :crystal %>
             system "shards", "build", *std_shards_args
-            bin.install "bin/#{name}"
+            bin.install <%= "bin/#{name}".inspect %>
         <% elsif @mode == :go %>
             system "go", "build", *std_go_args
         <% elsif @mode == :meson %>
@@ -290,7 +290,7 @@ module Homebrew
 
             # Stage additional dependency (`Makefile.PL` style).
             # resource("").stage do
-            #   system "perl", "Makefile.PL", "INSTALL_BASE=\#{libexec}"
+            #   system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
             #   system "make"
             #   system "make", "install"
             # end
@@ -310,10 +310,10 @@ module Homebrew
             ENV["GEM_HOME"] = libexec
 
             system "bundle", "install", "--local"
-            system "gem", "build", "\#{name}.gemspec"
-            system "gem", "install", "--ignore-dependencies", "\#{name}-\#{version}.gem"
+            system "gem", "build", "#{name}.gemspec"
+            system "gem", "install", "--ignore-dependencies", "#{name}-#{version}.gem"
 
-            bin.install libexec/"bin/\#{name}"
+            bin.install libexec/"bin/#{name}"
             bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV["GEM_HOME"])
         <% elsif @mode == :rust %>
             system "cargo", "install", *std_cargo_args
@@ -332,7 +332,7 @@ module Homebrew
             #
             # This test will fail and we won't accept that! For Homebrew/homebrew-core
             # this will need to be a test that verifies the functionality of the
-            # software. Run the test with `brew test #{name}`.
+            # software. Run the test with `brew test <%= name %>`.
             #
             # The installed folder is not in the path, so use the entire path to any
             # executables being tested: `system bin/"program", "do", "something"`.

--- a/Library/Homebrew/test/formula_creator_spec.rb
+++ b/Library/Homebrew/test/formula_creator_spec.rb
@@ -80,6 +80,21 @@ RSpec.describe Homebrew::FormulaCreator do
   end
 
   describe "#write_formula!" do
+    it "writes upstream metadata as literal Ruby strings" do
+      allow(GitHub).to receive(:repository).with("example", "foo").and_return(
+        "description" => 'A "quoted" description <%# metadata %>',
+        "homepage"    => 'https://example.com/a"b',
+        "license"     => { "spdx_id" => 'License "example"' },
+      )
+      formula = described_class.new(url: "https://github.com/example/foo.git", version: "1", fetch: true)
+
+      expect(formula.write_formula!.read).to include(
+        %Q(desc #{'A "quoted" description <%# metadata %>'.inspect}),
+        %Q(homepage #{'https://example.com/a"b'.inspect}),
+        %Q(license #{'License "example"'.inspect}),
+      )
+    end
+
     shared_examples "expected" do |mode, includes:, excludes:|
       sig { returns(Pathname) }
       subject(:formula) do


### PR DESCRIPTION
`brew create` interpolated the fetched description, homepage, URL, version, checksum and license into the ERB template string before ERB parsed it, so upstream metadata containing ERB tags was evaluated as Ruby while generating the formula. Quote the template heredoc and insert those values through `<%= %>` with `inspect`, so metadata is emitted as string literals after parsing. The new spec generates a formula whose metadata contains an ERB tag and checks it is written out literally.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

GPT-6 Astra and Claude Code (Fable 5.1) drafted the implementation and tests; I reviewed the diff, verified the new test fails without the change and passes with it, and ran `brew lgtm --online` plus targeted specs.

-----
