### PR TITLE
version-install: keep the requested provider

### DIFF
--- a/Library/Homebrew/cmd/version-install.rb
+++ b/Library/Homebrew/cmd/version-install.rb
@@ -67,11 +67,6 @@ module Homebrew
           return
         end
 
-        existing_tap = Tap.installed
-                          .sort_by(&:name)
-                          .find { |tap| tap.formula_files_by_name.key?(versioned_name) }
-        install_target = "#{existing_tap}/#{versioned_name}" if existing_tap
-
         versioned_formula = begin
           Formulary.factory(versioned_ref, warn: false)
         rescue TapFormulaAmbiguityError, FormulaUnavailableError, TapFormulaUnavailableError,
@@ -79,24 +74,22 @@ module Homebrew
           nil
         end
 
-        if install_target.nil?
-          install_target = if versioned_formula
-            versioned_formula.full_name
-          else
-            current_formula = begin
-              Formulary.factory(formula_input, warn: false)
-            rescue FormulaUnavailableError, TapFormulaUnavailableError, TapFormulaUnreadableError
-              nil
+        install_target = if versioned_formula
+          versioned_formula.full_name
+        else
+          current_formula = begin
+            Formulary.factory(formula_input, warn: false)
+          rescue FormulaUnavailableError, TapFormulaUnavailableError, TapFormulaUnreadableError
+            nil
+          end
+
+          if current_formula && current_formula.version.to_s == version_input
+            if installed_formula_names.include?(current_formula.name)
+              ohai "#{current_formula.full_name} is already installed"
+              return
             end
 
-            if current_formula && current_formula.version.to_s == version_input
-              if installed_formula_names.include?(current_formula.name)
-                ohai "#{current_formula.full_name} is already installed"
-                return
-              end
-
-              current_formula.full_name
-            end
+            current_formula.full_name
           end
         end
 

--- a/Library/Homebrew/test/cmd/version-install_spec.rb
+++ b/Library/Homebrew/test/cmd/version-install_spec.rb
@@ -57,9 +57,36 @@ RSpec.describe Homebrew::Cmd::VersionInstall do
     end
     let(:installed_taps) { [existing_tap] }
     let(:install_target) { "#{existing_tap_name}/#{versioned_name}" }
+    let(:formulary_factory) do
+      lambda do |ref, **_opts|
+        return instance_double(Formula, full_name: install_target) if ref == versioned_name
+
+        raise FormulaUnavailableError, ref
+      end
+    end
 
     before do
       allow(existing_tap).to receive(:to_s).and_return(existing_tap_name)
+    end
+
+    context "when a different provider was requested" do
+      let(:args) { ["homebrew/core/foo", version] }
+      let(:install_target) { "homebrew/core/#{versioned_name}" }
+      let(:versioned_formula) { instance_double(Formula, full_name: install_target) }
+      let(:formulary_factory) do
+        lambda do |ref, **_opts|
+          return versioned_formula if ref == install_target
+
+          raise FormulaUnavailableError, ref
+        end
+      end
+
+      it "keeps the requested provider" do
+        expect(SystemCommand).to receive(:safe_system)
+          .with(HOMEBREW_BREW_FILE, "install", install_target).once
+
+        version_install.run
+      end
     end
 
     it "installs from the existing tap extraction" do


### PR DESCRIPTION
`brew version-install` scanned every installed tap, alphabetically, for a formula file matching the versioned name and installed the first match, so a third-party tap could supply the formula even when the request named another provider such as homebrew/core. Resolve the versioned name through `Formulary.factory` with the requested provider and drop the tap scan, so only the resolved formula or its unversioned counterpart is installed.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

GPT-6 Astra and Claude Code (Fable 5.1) drafted the implementation and tests; I reviewed the diff, verified the new test fails without the change and passes with it, and ran `brew lgtm --online` plus targeted specs.

-----
