### PR TITLE
tap: check provenance for migration oldnames

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -147,7 +147,7 @@ module Cask
     def old_tokens
       @old_tokens ||= T.let(
         if (t = tap)
-          Tap.tap_migration_oldnames(t, token) +
+          Tap.tap_migration_oldnames(t, token, cask: true) +
             t.cask_reverse_renames.fetch(token, [])
         else
           []

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -1293,14 +1293,30 @@ class Tap
   end
 
   # The old names a formula or cask had before getting migrated to the current tap.
-  sig { params(current_tap: Tap, name_or_token: String).returns(T::Array[String]) }
-  def self.tap_migration_oldnames(current_tap, name_or_token)
+  sig { params(current_tap: Tap, name_or_token: String, cask: T::Boolean).returns(T::Array[String]) }
+  def self.tap_migration_oldnames(current_tap, name_or_token, cask: false)
+    require "tab"
+
     key = "#{current_tap}/#{name_or_token}"
 
     Tap.each_with_object([]) do |tap, array|
       next unless (renames = tap.reverse_tap_migrations_renames[key])
 
-      array.concat(renames)
+      array.concat(renames.select do |oldname|
+        next false if [".", ".."].include?(oldname) || !Utils.safe_filename?(oldname)
+
+        if cask
+          old_cask = Cask::Cask.new(oldname)
+          next true unless old_cask.caskroom_path.directory?
+
+          old_cask.tab.tap == tap
+        else
+          old_rack = HOMEBREW_CELLAR/oldname
+          next true unless old_rack.directory?
+
+          old_rack.subdirs.all? { |keg| Tab.for_keg(keg).tap == tap }
+        end
+      end)
     end
   end
 

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -1249,6 +1249,16 @@ RSpec.describe Tap do
         let(:cask_tap) { CoreCaskTap.instance }
         let(:core_tap) { CoreTap.instance }
 
+        it "checks an installed formula's provider before accepting a migration" do
+          rack = HOMEBREW_CELLAR/"schismtracker/1.0"
+          rack.mkpath
+          tab = Tab.empty
+          tab.source["tap"] = "homebrew/unrelated"
+          allow(Tab).to receive(:for_keg).with(rack).and_return(tab)
+
+          expect(described_class.tap_migration_oldnames(cask_tap, "schism-tracker")).to be_empty
+        end
+
         it "returns expected renames", :no_api do
           [
             [cask_tap, "gimp", []],


### PR DESCRIPTION
`Tap.tap_migration_oldnames` returned every old name that any installed tap's `tap_migrations.json` mapped to a formula or cask, so an installed but unrelated tap could claim a package another provider installed and have it treated as an old name during upgrades and renames. Keep an old name only when nothing is installed under it or when the installed kegs or Caskroom entry record the declaring tap in their receipts, and reject names that are not safe single path components.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

GPT-6 Astra and Claude Code (Fable 5.1) drafted the implementation and tests; I reviewed the diff, verified the new test fails without the change and passes with it, and ran `brew lgtm --online` plus targeted specs.

-----
