### PR TITLE
bundle: run go inventory with argument arrays

### DIFF
--- a/Library/Homebrew/bundle/extensions/go.rb
+++ b/Library/Homebrew/bundle/extensions/go.rb
@@ -35,8 +35,8 @@ module Homebrew
           @packages = if (go = package_manager_executable)
             ENV["GOBIN"] = ENV.fetch("HOMEBREW_GOBIN", nil)
             ENV["GOPATH"] = ENV.fetch("HOMEBREW_GOPATH", nil)
-            gobin = `#{go} env GOBIN`.chomp
-            gopath = `#{go} env GOPATH`.chomp
+            gobin = Utils.popen_read(go, "env", "GOBIN", err: :err).chomp
+            gopath = Utils.popen_read(go, "env", "GOPATH", err: :err).chomp
             bin_dir = gobin.empty? ? "#{gopath}/bin" : gobin
             if File.directory?(bin_dir)
               binaries = Dir.glob("#{bin_dir}/*").select do |file|
@@ -44,7 +44,7 @@ module Homebrew
               end
 
               binaries.filter_map do |binary|
-                output = `#{go} version -m "#{binary}" 2>/dev/null`
+                output = Utils.popen_read(go, "version", "-m", binary, err: File::NULL)
                 next if output.empty?
 
                 lines = output.split("\n")
@@ -100,8 +100,8 @@ module Homebrew
           go = package_manager_executable
           return if go.nil?
 
-          gobin = `#{go} env GOBIN`.chomp
-          gopath = `#{go} env GOPATH`.chomp
+          gobin = Utils.popen_read(go, "env", "GOBIN", err: :err).chomp
+          gopath = Utils.popen_read(go, "env", "GOPATH", err: :err).chomp
           bin_dir = gobin.empty? ? "#{gopath}/bin" : gobin
           return unless File.directory?(bin_dir)
 
@@ -109,7 +109,7 @@ module Homebrew
           Dir.glob("#{bin_dir}/*").each do |binary|
             next if !File.executable?(binary) || File.directory?(binary) || File.symlink?(binary)
 
-            output = `#{go} version -m "#{binary}" 2>/dev/null`
+            output = Utils.popen_read(go, "version", "-m", binary, err: File::NULL)
             next if output.empty?
 
             path_line = output.split("\n").find { |line| line.strip.start_with?("path\t") }

--- a/Library/Homebrew/test/bundle/go_spec.rb
+++ b/Library/Homebrew/test/bundle/go_spec.rb
@@ -28,14 +28,17 @@ RSpec.describe Homebrew::Bundle::Go do
       end
 
       it "returns package list" do
-        allow(described_class).to receive(:`).with("go env GOBIN").and_return("")
-        allow(described_class).to receive(:`).with("go env GOPATH").and_return("/Users/test/go")
+        allow(described_class).to receive(:`).and_raise("Shell execution is not permitted")
+        allow(Utils).to receive(:popen_read).with(Pathname("go"), "env", "GOBIN", err: :err).and_return("")
+        allow(Utils).to receive(:popen_read).with(Pathname("go"), "env", "GOPATH",
+                                                  err: :err).and_return("/Users/test/go")
         allow(File).to receive(:directory?).with("/Users/test/go/bin").and_return(true)
         allow(Dir).to receive(:glob).with("/Users/test/go/bin/*").and_return(["/Users/test/go/bin/crush"])
         allow(File).to receive(:executable?).with("/Users/test/go/bin/crush").and_return(true)
         allow(File).to receive(:directory?).with("/Users/test/go/bin/crush").and_return(false)
-        allow(described_class).to receive(:`).with("go version -m \"/Users/test/go/bin/crush\" 2>/dev/null")
-                                             .and_return("\tpath\tgithub.com/charmbracelet/crush\n")
+        allow(Utils).to receive(:popen_read)
+          .with(Pathname("go"), "version", "-m", "/Users/test/go/bin/crush", err: File::NULL)
+          .and_return("\tpath\tgithub.com/charmbracelet/crush\n")
         expect(dumper.packages).to eql(["github.com/charmbracelet/crush"])
       end
 
@@ -129,6 +132,25 @@ RSpec.describe Homebrew::Bundle::Go do
       entries = [Homebrew::Bundle::Dsl::Entry.new(:go, "github.com/charmbracelet/crush")]
       expect(described_class.cleanup_items(entries))
         .to eql(%w[github.com/golangci/golangci-lint/v2/cmd/golangci-lint])
+    end
+
+    it "removes binaries by their literal names" do
+      binary = "/Users/test/go/bin/cr;ush $(touch pwned)"
+      allow(described_class).to receive(:`).and_raise("Shell execution is not permitted")
+      allow(described_class).to receive(:puts)
+      allow(Utils).to receive(:popen_read).with(Pathname("go"), "env", "GOBIN", err: :err).and_return("")
+      allow(Utils).to receive(:popen_read).with(Pathname("go"), "env", "GOPATH", err: :err)
+                                          .and_return("/Users/test/go")
+      allow(File).to receive(:directory?).with("/Users/test/go/bin").and_return(true)
+      allow(Dir).to receive(:glob).with("/Users/test/go/bin/*").and_return([binary])
+      allow(File).to receive(:executable?).with(binary).and_return(true)
+      allow(File).to receive(:directory?).with(binary).and_return(false)
+      allow(Utils).to receive(:popen_read).with(Pathname("go"), "version", "-m", binary, err: File::NULL)
+                                          .and_return("\tpath\tgithub.com/charmbracelet/crush\n")
+
+      expect(FileUtils).to receive(:rm_f).with(binary)
+
+      described_class.cleanup!(["github.com/charmbracelet/crush"])
     end
 
     it "returns frozen empty array when go is not installed" do


### PR DESCRIPTION
The Go inventory in `brew bundle` built shell command strings from the `go` path and the binary names found in `GOBIN`, so a binary name containing shell metacharacters was interpreted by the shell. Run `go env` and `go version -m` through `Utils.popen_read` with argument arrays so every name is passed literally. `go env` keeps inheriting stderr so its failures stay visible, while `go version -m` stays quiet as before. The specs expect the argument arrays for both inventory and cleanup.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

GPT-6 Astra and Claude Code (Fable 5.1) drafted the implementation and tests; I reviewed the diff, verified the updated spec fails without the change and passes with it, and ran `brew lgtm --online` plus targeted specs.

-----
