### PR TITLE
svn: read externals from the pinned checkout

### DIFF
--- a/Library/Homebrew/download_strategy/subversion_download_strategy.rb
+++ b/Library/Homebrew/download_strategy/subversion_download_strategy.rb
@@ -62,7 +62,7 @@ class SubversionDownloadStrategy < VCSDownloadStrategy
 
   sig { params(_block: T.proc.params(arg0: String, arg1: String).void).void }
   def externals(&_block)
-    out = silent_command("svn", args: ["propget", "svn:externals", @url]).stdout
+    out = silent_command("svn", args: ["propget", "svn:externals", cached_location]).stdout
     out.chomp.split("\n").each do |line|
       name, url = line.split(/\s+/)
       raise "Invalid svn:externals definition: #{line.inspect}" if name.nil? || url.nil?

--- a/Library/Homebrew/test/download_strategies/subversion_spec.rb
+++ b/Library/Homebrew/test/download_strategies/subversion_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe SubversionDownloadStrategy do
         external_url = "-example"
 
         allow(strategy).to receive(:silent_command)
-          .with("svn", args: ["propget", "svn:externals", url])
+          .with("svn", args: ["propget", "svn:externals", strategy.cached_location])
           .and_return(instance_double(SystemCommand::Result, stdout: "external #{external_url}\n"))
 
         expect(strategy).to receive(:system_command!)


### PR DESCRIPTION
The Subversion download strategy read `svn:externals` from the remote URL, so a pinned revision still picked up whatever externals mapping the repository's current head declared. Read the property from the pinned checkout instead, so externals follow the revision the formula pinned. The spec now expects the checkout path.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

GPT-6 Astra and Claude Code (Fable 5.1) drafted the implementation and tests; I reviewed the diff, verified the updated spec fails without the change and passes with it, and ran `brew lgtm --online` plus targeted specs.

-----
