### PR TITLE
vulns: keep unknown subjects unresolved

### DIFF
--- a/Library/Homebrew/test/vulns/match_spec.rb
+++ b/Library/Homebrew/test/vulns/match_spec.rb
@@ -153,6 +153,18 @@ RSpec.describe Homebrew::Vulns::Match do
   end
 
   describe "#range_status" do
+    it "keeps an unknown resource range unresolved when the primary package is fixed" do
+      v = vuln("id" => "CVE-1", "affected" => [
+        { "package" => { "ecosystem" => "PyPI", "name" => "requests" },
+          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [{ "introduced" => "0" }, { "fixed" => "2.0" }] }] },
+      ])
+      hit = make_hit(v,
+                     ev(:registry, ecosystem: "PyPI", name: "requests", subject_version: "3.0"),
+                     ev(:registry, ecosystem: "PyPI", name: "certifi", subject_version: nil, resource: "certifi"))
+
+      expect(matcher.range_status(hit)).to be_nil
+    end
+
     it "returns the registry-entry status when GIT ranges are uncomparable" do
       v = vuln("id" => "CVE-1", "affected" => [
         { "package" => { "ecosystem" => "GIT", "name" => "https://github.com/jqlang/jq" },

--- a/Library/Homebrew/vulns/match.rb
+++ b/Library/Homebrew/vulns/match.rb
@@ -459,7 +459,8 @@ module Homebrew
       # Evaluate `hit` against every evidence's subject, each against the
       # record that evidence was matched against, and aggregate: `:affected` if
       # any subject is affected (a fixed primary must not hide an affected
-      # resource, or vice versa), else `:fixed` if any is fixed, else
+      # resource, or vice versa), else unknown if any subject is unresolved,
+      # else `:fixed` if any is fixed, else
       # `:not_applicable` only when every comparable subject says so. Returns
       # `[status, evidence]` where `evidence` is the one whose result was
       # chosen (used by {#first_fixed_version} and for the emitted record's
@@ -470,13 +471,17 @@ module Homebrew
           .returns(T.nilable([Vulnerability::RangeStatus, Evidence]))
       }
       def range_status(hit, formula_name: nil)
-        results = hit.evidence.filter_map do |ev|
-          status = evidence_range_status(ev, ev.subject_version)
-          [status, ev] if status
+        subjects = hit.evidence.reject { |ev| ev.strategy == :distro && ev.subject_version.nil? }
+                      .group_by(&:resource).map do |_, evidence|
+          results = evidence.filter_map do |ev|
+            status = evidence_range_status(ev, ev.subject_version)
+            [status, ev] if status
+          end
+          results.find { |s, _| s.affected? } || results.find { |s, _| s.fixed? } || results.first
         end
-        selected = results.find { |s, _| s.affected? } ||
-                   results.find { |s, _| s.fixed? } ||
-                   results.first
+        results = subjects.compact
+        selected = results.find { |s, _| s.affected? }
+        selected ||= results.find { |s, _| s.fixed? } || results.first unless subjects.include?(nil)
         override = @overrides&.advisory_override(formula_name, hit.identifiers) if formula_name
         return selected unless override
 


### PR DESCRIPTION
`brew vulns` combined range evidence across subjects before checking each subject, so a fixed result for one subject could mark an advisory fixed while another shipped subject had no comparable range at all. Evaluate evidence within each subject first and only fall back to fixed or first results when every subject resolved, so an unresolved subject keeps the advisory unresolved instead of reporting it as fixed.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

GPT-6 Astra and Claude Code (Fable 5.1) drafted the implementation and tests; I reviewed the diff, verified the new test fails without the change and passes with it, and ran `brew lgtm --online` plus targeted specs.

-----
