### PR TITLE
Reject path components in internal command names

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -478,6 +478,12 @@ case "${HOMEBREW_COMMAND}" in
   tc) HOMEBREW_COMMAND="typecheck" ;;
   x) HOMEBREW_COMMAND="exec" ;;
 esac
+
+# Keep in sync with `Commands.internal_cmd_name?` in `commands.rb`.
+if [[ "${HOMEBREW_COMMAND}" == */* || "${HOMEBREW_COMMAND}" == "." || "${HOMEBREW_COMMAND}" == ".." ]]
+then
+  odie "Unknown command: brew ${HOMEBREW_COMMAND}"
+fi
 # `update.sh` assumes normal repositories, so fail before it mutates a worktree.
 if [[ "${HOMEBREW_COMMAND}" == "update" && -z "${HOMEBREW_HELP}" && -f "${HOMEBREW_REPOSITORY}/.git" ]]
 then

--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -42,14 +42,20 @@ module Commands
   # middle due to dots in URLs or paths.
   DESCRIPTION_SPLITTING_PATTERN = /\.(?>\s|$)/
 
+  # Keep in sync with the command name check in `brew.sh`.
+  sig { params(cmd: String).returns(T::Boolean) }
+  def self.internal_cmd_name?(cmd)
+    cmd.exclude?("/") && %w[. ..].exclude?(cmd)
+  end
+
   sig { params(cmd: String).returns(T::Boolean) }
   def self.valid_internal_cmd?(cmd)
-    Utils::Ruby.require?(HOMEBREW_CMD_PATH/cmd)
+    internal_cmd_name?(cmd) && Utils::Ruby.require?(HOMEBREW_CMD_PATH/cmd)
   end
 
   sig { params(cmd: String).returns(T::Boolean) }
   def self.valid_internal_dev_cmd?(cmd)
-    Utils::Ruby.require?(HOMEBREW_DEV_CMD_PATH/cmd)
+    internal_cmd_name?(cmd) && Utils::Ruby.require?(HOMEBREW_DEV_CMD_PATH/cmd)
   end
 
   sig { params(cmd: String).returns(T::Boolean) }
@@ -75,6 +81,8 @@ module Commands
 
   sig { params(cmd: String).returns(T.nilable(Pathname)) }
   def self.internal_cmd_path(cmd)
+    return unless internal_cmd_name?(cmd)
+
     [
       HOMEBREW_CMD_PATH/"#{cmd}.rb",
       HOMEBREW_CMD_PATH/"#{cmd}.sh",
@@ -83,6 +91,8 @@ module Commands
 
   sig { params(cmd: String).returns(T.nilable(Pathname)) }
   def self.internal_dev_cmd_path(cmd)
+    return unless internal_cmd_name?(cmd)
+
     [
       HOMEBREW_DEV_CMD_PATH/"#{cmd}.rb",
       HOMEBREW_DEV_CMD_PATH/"#{cmd}.sh",

--- a/Library/Homebrew/test/commands_spec.rb
+++ b/Library/Homebrew/test/commands_spec.rb
@@ -41,6 +41,24 @@ end
 RSpec.describe Commands do
   include_context "custom internal commands"
 
+  test_each(["../other", ".", ".."]) do |cmd|
+    it "rejects #{cmd.inspect} before attempting to load an internal command" do
+      allow(Utils::Ruby).to receive(:require?).and_raise("Loading is not permitted")
+
+      expect(described_class.valid_internal_cmd?(cmd)).to be(false)
+    end
+
+    it "rejects #{cmd.inspect} before attempting to load an internal developer command" do
+      allow(Utils::Ruby).to receive(:require?).and_raise("Loading is not permitted")
+
+      expect(described_class.valid_internal_dev_cmd?(cmd)).to be(false)
+    end
+  end
+
+  it "does not resolve a path component as an internal command path" do
+    expect(described_class.path("../brew")).to be_nil
+  end
+
   specify "::internal_commands" do
     cmds = described_class.internal_commands
     expect(cmds).to include("rbcmd"), "Ruby commands files should be recognized"


### PR DESCRIPTION
Both `brew.sh` and `Commands.valid_internal_cmd?` resolved internal command names by joining them onto the `cmd` and `dev-cmd` directories, so a name containing path components could select a file outside those directories before any tap trust check ran. Reject names containing `/`, `.` or `..` in `brew.sh` as soon as the command name is known, before the developer-command classification, and in one Ruby check behind `valid_internal_cmd?`, `valid_internal_dev_cmd?` and `Commands.path`, with two-way comments keeping both in sync.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

GPT-6 Astra and Claude Code (Fable 5.1) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the change and pass with it, and ran `brew lgtm --online` plus targeted specs.

-----
