### PR TITLE
Crate: add default strategy user agent

### DIFF
--- a/Library/Homebrew/livecheck/strategy/crate.rb
+++ b/Library/Homebrew/livecheck/strategy/crate.rb
@@ -95,6 +95,7 @@ module Homebrew
           match_data[:url] = generated[:url]
 
           unless match_data[:cached]
+            options = options.merge(user_agent: :browser) unless options.user_agent
             match_data.merge!(Strategy.page_content(match_data[:url], options:))
             content = match_data[:content]
           end

--- a/Library/Homebrew/test/livecheck/strategy/crate_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/crate_spec.rb
@@ -85,9 +85,23 @@ RSpec.describe Homebrew::Livecheck::Strategy::Crate do
     it "finds versions in fetched content" do
       allow(Homebrew::Livecheck::Strategy).to receive(:page_content).and_return({ content: })
 
+      expect(Homebrew::Livecheck::Strategy).to receive(:page_content)
+        .at_least(:once)
+        .with(generated[:url], options: Homebrew::Livecheck::Options.new(user_agent: :browser))
       expect(crate.find_versions(url: crate_url, regex:))
         .to eq(match_data[:fetched].merge({ regex: }))
       expect(crate.find_versions(url: crate_url)).to eq(match_data[:fetched])
+    end
+
+    it "finds versions in fetched content using explicit user_agent" do
+      allow(Homebrew::Livecheck::Strategy).to receive(:page_content).and_return({ content: })
+
+      options = Homebrew::Livecheck::Options.new(user_agent: :curl)
+      expect(Homebrew::Livecheck::Strategy).to receive(:page_content)
+        .at_least(:once)
+        .with(generated[:url], options:)
+      expect(crate.find_versions(url: crate_url, options:))
+        .to eq(match_data[:fetched])
     end
 
     it "finds versions in provided content" do


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

The crates.io API now returns a 403 (Forbidden) response for all requests seemingly unless they use a browser user agent (i.e., `:default` and `:curl` fail). Checks using livecheck's `Crate` strategy have continued to work because the user agent fallback logic in `Strategy::page_content` tries the URL again using the `:browser` user agent (after failing with `:default`) and that works. However, this fallback logic will be deprecated in the near future and these checks will error instead (not to mention we don't need to be trying with a user agent we know will fail before using one that will work).

This issue affects all of the `Crate` strategy checks, so this adds logic to the `Crates::find_versions` method to set a `:browser` user agent if one isn't set in the `livecheck` block. For the sake of simplicity, I haven't included this in the `match_data` return value as something that would be surfaced in debug and verbose JSON output. It's technically possible (and I prototyped it) but it requires some changes to the JSON structure and I wasn't convinced it was worth it. I may revisit it in the future but for now I'm treating it as an implementation detail.