### PR TITLE
Require `utils/analytics` in `cmd/info`

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -14,6 +14,7 @@ require "tab"
 require "json"
 require "cask/cask_loader"
 require "utils/spdx"
+require "utils/analytics"
 require "deprecate_disable"
 require "api"
 


### PR DESCRIPTION
Add the missing `utils/analytics` dependency to [`cmd/info.rb`](https://github.com/Homebrew/brew/blob/main/Library/Homebrew/cmd/info.rb), which needs it due to calls to `Utils::Analytics.output`, `Utils::Analytics.formula_output` and `Utils::Analytics.cask_output` — primarily in [`print_analytics`](https://github.com/Homebrew/brew/blob/6.0.22/Library/Homebrew/cmd/info.rb#L643-L663).

The missing dependency does not cause issues at runtime because `brew.rb` [requires `utils/analytics` before invoking commands](https://github.com/Homebrew/brew/blob/6.0.22/Library/Homebrew/brew.rb#L139-L143), so the constant is always loaded. In the test suite, it is only defined if another spec requires it before the [`cmd/info_spec.rb`](https://github.com/Homebrew/brew/blob/main/Library/Homebrew/test/cmd/info_spec.rb) runs. Running the `cmd/info` tests in isolation (`brew tests --only=cmd/info`) raises `uninitialized constant Utils::Analytics`:

```
NameError: uninitialized constant Utils::Analytics
# ./cmd/info.rb:630:in 'Homebrew::Cmd::Info#info_formula'
```

To reproduce (before this change):

```
brew tests --only=cmd/info
```

The fix is to `require "utils/analytics"` in `cmd/info.rb` directly, so the command loads its own dependency regardless of load order.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

I used Claude Opus 4.8 to help diagnose and fix this; I reviewed all output and confirmed the reproduction above failed before this change and passed after.