### PR TITLE
Strategy: deprecate user_agent fallback

### DIFF
--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -241,7 +241,7 @@ module Homebrew
           [:default, :browser]
         end
 
-        user_agents.each do |user_agent|
+        user_agents.each_with_index do |user_agent, i|
           begin
             parsed_output = curl_headers(
               *curl_post_args,
@@ -259,8 +259,17 @@ module Homebrew
             next
           end
 
-          parsed_output[:responses].each { |response| headers << response[:headers] }
-          break if headers.present?
+          parsed_output[:responses]&.each { |response| headers << response[:headers] }
+          next unless headers.present?
+
+          if i.positive?
+            Utils::Output.odeprecated(
+              "the user agent fallback in `page_headers`",
+              "the `user_agent:` option in a `livecheck` block",
+            )
+          end
+
+          break
         end
 
         headers
@@ -296,7 +305,7 @@ module Homebrew
         end
 
         stderr = T.let(nil, T.nilable(String))
-        user_agents.each do |user_agent|
+        user_agents.each_with_index do |user_agent, i|
           stdout, stderr, status = curl_output(
             *curl_post_args,
             *args,
@@ -311,6 +320,13 @@ module Homebrew
             user_agent:,
           )
           next unless status.success?
+
+          if i.positive?
+            Utils::Output.odeprecated(
+              "the user agent fallback in `page_content`",
+              "the `user_agent:` option in a `livecheck` block",
+            )
+          end
 
           # stdout contains the header information followed by the page content.
           # We use #scrub here to avoid "invalid byte sequence in UTF-8" errors.

--- a/Library/Homebrew/test/livecheck/strategy_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy_spec.rb
@@ -286,13 +286,68 @@ RSpec.describe Homebrew::Livecheck::Strategy do
     it "returns an empty array if `curl_headers` only raises an `ErrorDuringExecution` error" do
       allow(strategy).to receive(:curl_headers).and_raise(ErrorDuringExecution.new([], status: 1))
 
+      # TODO: Remove this line when removing the user agent fallback logic
+      expect(Utils::Output).not_to receive(:odeprecated)
+
       expect(strategy.page_headers(url)).to eq([])
+    end
+
+    it "returns an empty array if `curl_headers` returns a hash without responses" do
+      allow(strategy).to receive(:curl_headers).and_return({})
+
+      # TODO: Remove this line when removing the user agent fallback logic
+      expect(Utils::Output).not_to receive(:odeprecated)
+
+      expect(strategy.page_headers(url)).to eq([])
+    end
+
+    # TODO: Remove this block when removing the user agent fallback logic
+    context "when the `:default` user agent request fails" do
+      before do
+        allow(strategy).to receive(:curl_headers) do |*_args, user_agent:, **|
+          raise ErrorDuringExecution.new([], status: 1) if user_agent == :default
+
+          { responses:, body: }
+        end
+      end
+
+      it "deprecates the user agent fallback if the `:browser` user agent request succeeds" do
+        expect(Utils::Output).to receive(:odeprecated).with(
+          "the user agent fallback in `page_headers`",
+          "the `user_agent:` option in a `livecheck` block",
+        )
+
+        strategy.page_headers(url)
+      end
+
+      it "returns headers from the `:browser` user agent request" do
+        allow(Utils::Output).to receive(:odeprecated)
+
+        expect(strategy.page_headers(url)).to eq([responses.first[:headers]])
+      end
+    end
+
+    # TODO: Remove this block when removing the user agent fallback logic
+    it "deprecates the user agent fallback if `:default` doesn't return headers but `:browser` succeeds" do
+      allow(strategy).to receive(:curl_headers) do |*_args, user_agent:, **|
+        next { responses: [], body: } if user_agent == :default
+
+        { responses:, body: }
+      end
+
+      expect(Utils::Output).to receive(:odeprecated).with(
+        "the user agent fallback in `page_headers`",
+        "the `user_agent:` option in a `livecheck` block",
+      )
+
+      strategy.page_headers(url)
     end
   end
 
   describe "::page_content" do
     let(:curl_version) { Version.new("8.7.1") }
     let(:success_status) { instance_double(Process::Status, success?: true, exitstatus: 0) }
+    let(:failure_status) { instance_double(Process::Status, success?: false, exitstatus: 1) }
 
     it "returns hash including fetched content" do
       allow_any_instance_of(Utils::Curl).to receive(:curl_version).and_return(curl_version)
@@ -447,11 +502,10 @@ RSpec.describe Homebrew::Livecheck::Strategy do
 
     it "returns default error `messages` in the return hash on failure when `stderr` is `nil`" do
       allow_any_instance_of(Utils::Curl).to receive(:curl_version).and_return(curl_version)
-      allow(strategy).to receive(:curl_output).and_return([
-        nil,
-        nil,
-        instance_double(Process::Status, success?: false, exitstatus: 1),
-      ])
+      allow(strategy).to receive(:curl_output).and_return([nil, nil, failure_status])
+
+      # TODO: Remove this line when removing the user agent fallback logic
+      expect(Utils::Output).not_to receive(:odeprecated)
 
       expect(strategy.page_content(url)).to eq({ messages: ["cURL failed without a detectable error"] })
     end
@@ -461,6 +515,33 @@ RSpec.describe Homebrew::Livecheck::Strategy do
       allow(strategy).to receive(:curl_output).and_return([response_text[:redirection_to_ok], nil, success_status])
 
       expect(strategy.page_content(url)).to eq({ content: body, final_url: redirection_url })
+    end
+
+    # TODO: Remove this block when removing the user agent fallback logic
+    context "when the `:default` user agent request fails" do
+      before do
+        allow_any_instance_of(Utils::Curl).to receive(:curl_version).and_return(curl_version)
+        allow(strategy).to receive(:curl_output) do |*_args, user_agent:, **|
+          next [nil, nil, failure_status] if user_agent == :default
+
+          [response_text[:ok], nil, success_status]
+        end
+      end
+
+      it "deprecates the user agent fallback if the `:browser` user agent request succeeds" do
+        expect(Utils::Output).to receive(:odeprecated).with(
+          "the user agent fallback in `page_content`",
+          "the `user_agent:` option in a `livecheck` block",
+        )
+
+        strategy.page_content(url)
+      end
+
+      it "returns hash including content from the `:browser` user agent request" do
+        allow(Utils::Output).to receive(:odeprecated)
+
+        expect(strategy.page_content(url)).to eq({ content: body })
+      end
     end
   end
 


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

I used Claude Code (Opus 5, high) to review these changes and to implement tests. I went through a couple of rounds, where I reviewed the generated tests and made changes, reworked logic in `page_headers` to address flagged issues, etc.

-----

The `Strategy::page_headers` and `::page_content` methods contain logic to first try a request with the `:default` user agent and to retry it using the `:browser` user agent if it fails. This was originally introduced as a temporary workaround for some failing checks but I made it clear at the time that I would be adding an explicit `user_agent` option and removing this logic when that's available. That option was introduced in the 5.0.7 brew release (on 2025-12-21) and I've added an explicit `user_agent` option to the packages in homebrew/core and homebrew/cask that are currently relying on the fallback.

I have accounted for all the checks in core or cask that are using the fallback, so this deprecates the user agent fallback logic. If a check falls back to the `:browser` user agent and the request is successful, then these `odeprecated` calls will output a message like, "Calling user agent fallback in `page_content` is deprecated! Use the `user_agent:` option in a `livecheck` block instead." This will make affected users aware of the situation, so they can implement fixes before this logic is removed and the checks fail without providing any guidance.

-----

Looking at open PRs, I see that https://github.com/Homebrew/brew/pull/23783 also includes a similar deprecation (with a somewhat similar approach) but I would prefer to handle this as a separate PR, as there are pending fixes that need to be merged before this deprecation can be merged (and merging this prematurely would cause failures):

* https://github.com/Homebrew/brew/pull/23832
* https://github.com/Homebrew/homebrew-cask/pull/285479
* https://github.com/Homebrew/homebrew-core/pull/302614

The notable difference here is that the deprecation is only triggered if the response using the fallback user agent is successful. The deprecation advises the user to add a `user_agent:` option in a `livecheck` block and we only want to mention that if it would make a difference. That is to say, we don't want the deprecation to show for a check where the default and fallback user agent both have a failing response (i.e., a check that fails for other reasons).

I've also taken a different approach to the tests, for better or worse. This also includes an additional test to cover the one uncovered line in `Strategy`, so this provides 100% coverage.