### PR TITLE
style: root the RuboCop project index at the tap

### DIFF
--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -236,6 +236,15 @@ module Homebrew
         args << "--config" << (HOMEBREW_REPOSITORY/"docs/docs_rubocop_style.yml")
       elsif files.any? { |f| f.to_s.start_with? HOMEBREW_LIBRARY_PATH }
         base_dir = HOMEBREW_LIBRARY_PATH
+      elsif (tap = single_tap(files))
+        # RuboCop roots its project index at the working directory for this
+        # config (see `tap_rubocop_style.yml`). A tap has to be indexed on its
+        # own: rooted at `Library`, the index spans every installed tap and the
+        # cross-file cops pair one tap's constants and methods with another's as
+        # reassignments and duplicates. The paths stay as given, so the shared
+        # config's `Taps/...` exclusions keep matching a symlinked tap.
+        args << "--config" << (HOMEBREW_LIBRARY/"tap_rubocop_style.yml")
+        base_dir = tap.path
       else
         args << "--config" << (HOMEBREW_LIBRARY/".rubocop.yml")
         base_dir = HOMEBREW_LIBRARY if files.any? { |f| f.to_s.start_with? HOMEBREW_LIBRARY }
@@ -280,6 +289,15 @@ module Homebrew
           file["path"] = File.absolute_path(file["path"], base_dir)
         end
       end
+    end
+
+    sig { params(files: T::Array[Pathname]).returns(T.nilable(Tap)) }
+    def self.single_tap(files)
+      taps = files.filter_map { |file| Tap.from_path(file) }
+      return if taps.empty? || taps.length != files.length
+      return unless taps.map(&:name).uniq.one?
+
+      taps.first
     end
 
     sig {

--- a/Library/Homebrew/test/style_spec.rb
+++ b/Library/Homebrew/test/style_spec.rb
@@ -256,5 +256,37 @@ RSpec.describe Homebrew::Style do
 
       described_class.run_rubocop([ruby_file], :json, fix: true, todo: true)
     end
+
+    it "roots RuboCop at the tap when every file is in one tap" do
+      tap_path = HOMEBREW_TAP_DIRECTORY/"homebrew/homebrew-foo"
+      script = tap_path/"cmd/foo.rb"
+      script.dirname.mkpath
+      script.write "# frozen_string_literal: true\n"
+      result = double(status: double(exitstatus: 0), stdout: '{"files":[]}')
+
+      expect(described_class).to receive(:system_command).with(
+        anything,
+        hash_including(args: include("--config", HOMEBREW_LIBRARY/"tap_rubocop_style.yml", script), chdir: tap_path),
+      ).and_return(result)
+
+      described_class.run_rubocop([script], :json)
+    end
+
+    it "uses the shared config when files span multiple taps" do
+      scripts = %w[foo bar].map do |name|
+        script = HOMEBREW_TAP_DIRECTORY/"homebrew/homebrew-#{name}/cmd/#{name}.rb"
+        script.dirname.mkpath
+        script.write "# frozen_string_literal: true\n"
+        script
+      end
+      result = double(status: double(exitstatus: 0), stdout: '{"files":[]}')
+
+      expect(described_class).to receive(:system_command).with(
+        anything,
+        hash_including(args: include("--config", HOMEBREW_LIBRARY/".rubocop.yml"), chdir: HOMEBREW_LIBRARY),
+      ).and_return(result)
+
+      described_class.run_rubocop(scripts, :json)
+    end
   end
 end

--- a/Library/tap_rubocop_style.yml
+++ b/Library/tap_rubocop_style.yml
@@ -1,0 +1,7 @@
+---
+# `brew style` passes this file as `--config` when every target is inside one
+# tap. RuboCop roots its project index at the directory of a `.rubocop*` config
+# file and at the working directory for any other name, so this file lets
+# `brew style` root the index at the tap it is checking instead of at every
+# tap under `Library/Taps`.
+inherit_from: .rubocop.yml


### PR DESCRIPTION
`brew style` on a tap reports `Lint/DuplicateMethods` and `Lint/ConstantReassignment` offenses that pair the tap's methods and constants with identically named ones in a *different* installed tap. Taps are never loaded together, so these are false positives, and they make `brew style` fail on a tap whose Ruby happens to share names with any other tap on the machine.

The cause is where RuboCop roots its project index. RuboCop roots it at the directory of a `.rubocop*` config file and at the working directory for any other config name. `brew style` forces `Library/.rubocop.yml` for tap targets, so the index is rooted at `Library` and spans every installed tap, and the cross-file cops compare across all of them. The shared config excludes only a tap's top-level `*.rb` from those cops, so anything under `cmd/`, `scripts/`, `test/` and similar collides.

This change checks a tap from its own directory through `Library/tap_rubocop_style.yml`, a config that only inherits the shared one. Because its name does not start with `.rubocop`, RuboCop roots the index at the working directory, which is the tap, so the index covers that tap alone. Cross-file detection inside the tap still works. Files spanning several taps, Homebrew's own code, and docs keep their current handling. Paths are passed as given rather than realpathed so the shared config's `Taps/...` exclusions keep matching a tap that is a symlink into a checkout elsewhere.

To reproduce on `main`, install two copies of a tap that has Ruby below its top level, then style either of them:

```
brew tap starhaven-io/tap
git clone https://github.com/starhaven-io/homebrew-tap "$(brew --repository)/Library/Taps/starhaven-review/homebrew-tap"
brew style starhaven-review/tap
```

On `main` this reports 127 offenses, every one naming a file in the other copy. With this change both copies are clean, a duplicate added inside one copy's `scripts/` is still reported, and a duplicate hidden in a file that was not passed to `brew style` is still reported from a single-file run, which shows the index is rooted at the tap rather than absent.

Two specs cover the dispatch: a single-tap target gets the tap config and the tap as working directory; files spanning two taps fall back to the shared config.

-----

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

AI/LLM disclosure: Claude Fable 5.1 drafted the change, the config file and the specs under my direction, and I reviewed all of it. Verified with `brew lgtm`, `brew tests --only=style`, `brew typecheck`, and by reproducing the false positive and each of the three behaviours above against two installed copies of a tap.
