### PR TITLE
services: default to canonical Linux service labels

### DIFF
--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -225,7 +225,7 @@ class Keg
 
   sig { params(file: Pathname).returns(T::Boolean) }
   def homebrew_created_file?(file)
-    return false unless file.basename.to_s.start_with?("homebrew.")
+    return false unless file.basename.to_s.start_with?("homebrew.", "sh.brew.")
 
     %w[.plist .service .timer].include?(file.extname)
   end

--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -106,7 +106,7 @@ module Homebrew
 
     sig { returns(String) }
     def default_service_name
-      legacy_service_name
+      canonical_service_name
     end
 
     sig { returns(String) }

--- a/Library/Homebrew/services/cli.rb
+++ b/Library/Homebrew/services/cli.rb
@@ -63,7 +63,7 @@ module Homebrew
         end
 
         if loaded_name.present? && loaded_name != service.service_name
-          if System.launchctl? && service.service_file_generated? && service.service_names.include?(loaded_name)
+          if service.service_file_generated? && service.service_names.include?(loaded_name)
             puts "Service `#{service.name}` is already loaded as `#{loaded_name}`; " \
                  "a service label migration is pending. Use `#{bin} restart #{service.name}` " \
                  "to migrate to `#{service.service_name}`."

--- a/Library/Homebrew/services/formula_wrapper.rb
+++ b/Library/Homebrew/services/formula_wrapper.rb
@@ -113,7 +113,7 @@ module Homebrew
       end
 
       # service_name delegates with formula.plist_name or formula.service_name
-      # for systemd (e.g., `homebrew.<formula>`).
+      # for systemd (e.g., `sh.brew.<formula>`).
       sig { returns(String) }
       def service_name
         @service_name ||= T.let(
@@ -443,7 +443,7 @@ module Homebrew
             success = ($CHILD_STATUS&.success? || false) && output.present?
             odebug [System::Systemctl.executable, System::Systemctl.scope, *cmd].join(" "), output
             candidate = StatusOutputSuccessType.new(output, success, :systemctl, name)
-            result ||= candidate
+            result ||= candidate if output.present?
             if status_pid(candidate)&.positive?
               result = candidate
               break

--- a/Library/Homebrew/test/bundle/brew_services_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_services_spec.rb
@@ -140,8 +140,8 @@ RSpec.describe Homebrew::Bundle::Brew::Services do
         rack:          HOMEBREW_CELLAR/"fooformula",
         plist_name:    "sh.brew.fooformula",
         plist_names:   ["sh.brew.fooformula", "homebrew.mxcl.fooformula"],
-        service_name:  "homebrew.fooformula",
-        service_names: ["homebrew.fooformula", "sh.brew.fooformula"],
+        service_name:  "sh.brew.fooformula",
+        service_names: ["sh.brew.fooformula", "homebrew.fooformula"],
       )
     end
 
@@ -197,7 +197,7 @@ RSpec.describe Homebrew::Bundle::Brew::Services do
 
         prefix = foo.rack/foo.version
         prefix.mkpath
-        service_file = prefix/"sh.brew.fooformula.service"
+        service_file = prefix/"homebrew.fooformula.service"
         service_file.write("service")
 
         expect(described_class.versioned_service_file(foo.name)).to eq(service_file)

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -1683,9 +1683,10 @@ RSpec.describe FormulaInstaller do
 
       expect([
         launchd_service_path.basename.to_s,
+        service_path.basename.to_s,
         launchd_service_path.exist?,
         service_path.exist?,
-      ]).to eq(["sh.brew.testball.plist", true, true])
+      ]).to eq(["sh.brew.testball.plist", "sh.brew.testball.service", true, true])
     end
 
     it "works if timed service is set" do
@@ -1713,9 +1714,13 @@ RSpec.describe FormulaInstaller do
         installer.install_service
       end.not_to output(/Error: Failed to install service files/).to_stderr
 
-      expect(launchd_service_path).to exist
-      expect(service_path).to exist
-      expect(timer_path).to exist
+      expect([
+        service_path.basename.to_s,
+        timer_path.basename.to_s,
+        launchd_service_path.exist?,
+        service_path.exist?,
+        timer_path.exist?,
+      ]).to eq(["sh.brew.testball.service", "sh.brew.testball.timer", true, true, true])
     end
 
     it "returns without definition" do

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1675,22 +1675,22 @@ RSpec.describe Formula do
 
       expect(f.plist_name).to eq("sh.brew.formula_name")
       expect(f.plist_names).to eq(["sh.brew.formula_name", "homebrew.mxcl.formula_name"])
-      expect(f.service_name).to eq("homebrew.formula_name")
-      expect(f.service_names).to eq(["homebrew.formula_name", "sh.brew.formula_name"])
+      expect(f.service_name).to eq("sh.brew.formula_name")
+      expect(f.service_names).to eq(["sh.brew.formula_name", "homebrew.formula_name"])
       expect(f.launchd_service_path).to eq(HOMEBREW_PREFIX/"opt/formula_name/sh.brew.formula_name.plist")
       expect(f.launchd_service_paths).to eq([
         HOMEBREW_PREFIX/"opt/formula_name/sh.brew.formula_name.plist",
         HOMEBREW_PREFIX/"opt/formula_name/homebrew.mxcl.formula_name.plist",
       ])
-      expect(f.systemd_service_path).to eq(HOMEBREW_PREFIX/"opt/formula_name/homebrew.formula_name.service")
+      expect(f.systemd_service_path).to eq(HOMEBREW_PREFIX/"opt/formula_name/sh.brew.formula_name.service")
       expect(f.systemd_service_paths).to eq([
-        HOMEBREW_PREFIX/"opt/formula_name/homebrew.formula_name.service",
         HOMEBREW_PREFIX/"opt/formula_name/sh.brew.formula_name.service",
+        HOMEBREW_PREFIX/"opt/formula_name/homebrew.formula_name.service",
       ])
-      expect(f.systemd_timer_path).to eq(HOMEBREW_PREFIX/"opt/formula_name/homebrew.formula_name.timer")
+      expect(f.systemd_timer_path).to eq(HOMEBREW_PREFIX/"opt/formula_name/sh.brew.formula_name.timer")
       expect(f.systemd_timer_paths).to eq([
-        HOMEBREW_PREFIX/"opt/formula_name/homebrew.formula_name.timer",
         HOMEBREW_PREFIX/"opt/formula_name/sh.brew.formula_name.timer",
+        HOMEBREW_PREFIX/"opt/formula_name/homebrew.formula_name.timer",
       ])
     end
   end

--- a/Library/Homebrew/test/keg_spec.rb
+++ b/Library/Homebrew/test/keg_spec.rb
@@ -553,6 +553,12 @@ RSpec.describe Keg do
       expect(keg.homebrew_created_file?(regular_file)).to be false
       expect(keg.homebrew_created_file?(non_homebrew_plist)).to be false
     end
+
+    it "identifies canonical Homebrew service files" do
+      service_files = %w[sh.brew.foo.plist sh.brew.foo.service sh.brew.foo.timer].map { |file| Pathname(file) }
+
+      expect(service_files.map { |file| keg.homebrew_created_file?(file) }).to all(be(true))
+    end
   end
 
   specify "#link and #unlink" do

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -1256,7 +1256,7 @@ RSpec.describe Homebrew::Service do
         WantedBy=timers.target
 
         [Timer]
-        Unit=homebrew.formula_name.service
+        Unit=sh.brew.formula_name.service
         OnUnitActiveSec=5
       SYSTEMD
       expect(unit).to eq(unit_expect)
@@ -1280,7 +1280,7 @@ RSpec.describe Homebrew::Service do
         WantedBy=timers.target
 
         [Timer]
-        Unit=homebrew.formula_name.service
+        Unit=sh.brew.formula_name.service
 
       SYSTEMD
       expect(unit).to eq(unit_expect)
@@ -1331,7 +1331,7 @@ RSpec.describe Homebrew::Service do
           WantedBy=timers.target
 
           [Timer]
-          Unit=homebrew.formula_name.service
+          Unit=sh.brew.formula_name.service
           Persistent=true
           OnCalendar=#{calendar}
         SYSTEMD

--- a/Library/Homebrew/test/services/cli_spec.rb
+++ b/Library/Homebrew/test/services/cli_spec.rb
@@ -37,12 +37,13 @@ RSpec.describe Homebrew::Services::Cli do
     it "systemD - returns the currently running services" do
       allow(Homebrew::Services::System).to receive(:launchctl?).and_return(false)
       allow(Homebrew::Services::System::Systemctl).to receive(:popen_read).and_return <<~EOS
-        homebrew.php.service     loaded active running Homebrew PHP service
+        sh.brew.php.service      loaded active running Homebrew PHP service
+        homebrew.redis.service   loaded active running Homebrew Redis service
         systemd-udevd.service    loaded active running Rule-based Manager for Device Events and Files
         udisks2.service          loaded active running Disk Manager
         user@1000.service        loaded active running User Manager for UID 1000
       EOS
-      expect(services_cli.running).to eq(["homebrew.php"])
+      expect(services_cli.running).to eq(["sh.brew.php", "homebrew.redis"])
     end
   end
 
@@ -74,8 +75,8 @@ RSpec.describe Homebrew::Services::Cli do
       service = instance_double(
         service_string,
         name:                 "example_service",
-        service_name:         "homebrew.example_service",
-        active_service_name:  "homebrew.example_service",
+        service_name:         "sh.brew.example_service",
+        active_service_name:  "sh.brew.example_service",
         pid?:                 true,
         dest:                 Pathname("this_path_does_not_exist"),
         keep_alive?:          false,
@@ -84,7 +85,7 @@ RSpec.describe Homebrew::Services::Cli do
       allow(service).to receive(:reset_cache!)
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
       expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
-        .with("stop", "homebrew.example_service")
+        .with("stop", "sh.brew.example_service")
       allow(Homebrew::Services::FormulaWrapper).to receive(:from).and_return(service)
       allow(services_cli).to receive(:running).and_return(["example_service"])
       expect do
@@ -96,12 +97,12 @@ RSpec.describe Homebrew::Services::Cli do
   describe "#remove_unused_service_files" do
     it "removes unused timer files" do
       path = mktmpdir
-      active_timer = path/"homebrew.name.timer"
-      stale_timer = path/"homebrew.stale.timer"
+      active_timer = path/"sh.brew.name.timer"
+      stale_timer = path/"sh.brew.stale.timer"
       active_timer.write("timer")
       stale_timer.write("timer")
       allow(Homebrew::Services::System).to receive(:path).and_return(path)
-      allow(services_cli).to receive(:running).and_return(["homebrew.name"])
+      allow(services_cli).to receive(:running).and_return(["sh.brew.name"])
 
       expect do
         expect(services_cli.remove_unused_service_files).to eq([stale_timer.to_s])
@@ -190,8 +191,8 @@ RSpec.describe Homebrew::Services::Cli do
       service = instance_double(
         service_string,
         name:                "example_service",
-        service_name:        "homebrew.example_service",
-        active_service_name: "homebrew.example_service",
+        service_name:        "sh.brew.example_service",
+        active_service_name: "sh.brew.example_service",
         pid?:                true,
       )
       expect do
@@ -217,21 +218,41 @@ RSpec.describe Homebrew::Services::Cli do
       end.to output(/already loaded as `homebrew.mxcl.name`/).to_stdout
     end
 
-    it "does not run a service already loaded with the compatible systemd label" do
+    it "reports a pending migration for a generated service loaded with the legacy systemd label" do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
       service = instance_double(
         service_string,
-        name:                 "name",
-        service_name:         "homebrew.name",
-        active_service_name:  "sh.brew.name",
-        loaded_service_names: ["sh.brew.name"],
-        pid?:                 true,
+        name:                    "name",
+        service_name:            "sh.brew.name",
+        service_file_generated?: true,
+        service_names:           ["sh.brew.name", "homebrew.name"],
+        active_service_name:     "homebrew.name",
+        loaded_service_names:    ["homebrew.name"],
+        pid?:                    true,
       )
       expect(services_cli).not_to receive(:service_load)
 
       expect do
         services_cli.run([service])
-      end.to output(/already running \(label: sh\.brew\.name\)/).to_stdout
+      end.to output(/already loaded as `homebrew\.name`.*migration is pending/).to_stdout
+    end
+
+    it "reports a pending migration for a stopped legacy systemd service" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+      service = instance_double(
+        service_string,
+        name:                    "name",
+        service_name:            "sh.brew.name",
+        service_file_generated?: true,
+        service_names:           ["sh.brew.name", "homebrew.name"],
+        loaded_service_names:    ["homebrew.name"],
+        pid?:                    false,
+      )
+      expect(services_cli).not_to receive(:service_load)
+
+      expect do
+        services_cli.run([service])
+      end.to output(/already loaded as `homebrew\.name`.*migration is pending/).to_stdout
     end
   end
 
@@ -256,8 +277,8 @@ RSpec.describe Homebrew::Services::Cli do
       service = instance_double(
         service_string,
         name:                "example_service",
-        service_name:        "homebrew.example_service",
-        active_service_name: "homebrew.example_service",
+        service_name:        "sh.brew.example_service",
+        active_service_name: "sh.brew.example_service",
         pid?:                true,
       )
       expect do
@@ -359,19 +380,19 @@ RSpec.describe Homebrew::Services::Cli do
     it "stops compatible systemd timers before services when kept" do
       allow(Homebrew::Services::System).to receive(:systemctl?).and_return(true)
       expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
-        .with("stop", "sh.brew.name.timer")
+        .with("stop", "homebrew.name.timer")
         .ordered
         .and_return(true)
       expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
-        .with("stop", "sh.brew.name")
+        .with("stop", "homebrew.name")
         .ordered
         .and_return(true)
       service = instance_double(
         Homebrew::Services::FormulaWrapper,
         name:                 "name",
-        service_name:         "homebrew.name",
-        service_names:        ["homebrew.name", "sh.brew.name"],
-        loaded_service_names: ["sh.brew.name"],
+        service_name:         "sh.brew.name",
+        service_names:        ["sh.brew.name", "homebrew.name"],
+        loaded_service_names: ["homebrew.name"],
         timed?:               true,
         pid?:                 false,
       )
@@ -386,24 +407,24 @@ RSpec.describe Homebrew::Services::Cli do
     it "stops and removes timed systemd timer files" do
       allow(Homebrew::Services::System).to receive(:systemctl?).and_return(true)
       expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
-        .with("disable", "--now", "homebrew.name.timer")
+        .with("disable", "--now", "sh.brew.name.timer")
         .and_return(true)
       expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
-        .with("disable", "--now", "homebrew.name")
+        .with("disable", "--now", "sh.brew.name")
         .and_return(true)
       expect(Homebrew::Services::System::Systemctl).to receive(:run).with("daemon-reload")
 
       dest_dir = mktmpdir
-      service_dest = dest_dir/"homebrew.name.service"
-      timer_dest = dest_dir/"homebrew.name.timer"
+      service_dest = dest_dir/"sh.brew.name.service"
+      timer_dest = dest_dir/"sh.brew.name.timer"
       service_dest.write("service")
       timer_dest.write("timer")
       service = instance_double(
         Homebrew::Services::FormulaWrapper,
         name:                 "name",
-        service_name:         "homebrew.name",
-        service_names:        ["homebrew.name", "sh.brew.name"],
-        loaded_service_names: ["homebrew.name"],
+        service_name:         "sh.brew.name",
+        service_names:        ["sh.brew.name", "homebrew.name"],
+        loaded_service_names: ["sh.brew.name"],
         destinations:         [service_dest],
         timed?:               true,
         timer_destinations:   [timer_dest],
@@ -421,20 +442,20 @@ RSpec.describe Homebrew::Services::Cli do
     it "stops and removes the compatible systemd service label" do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
       expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
-        .with("disable", "--now", "sh.brew.name").and_return(true)
+        .with("disable", "--now", "homebrew.name").and_return(true)
       expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
-        .with("disable", "homebrew.name.service").and_return(true)
+        .with("disable", "sh.brew.name.service").and_return(true)
       expect(Homebrew::Services::System::Systemctl).to receive(:run).with("daemon-reload")
 
       dest_dir = mktmpdir
-      destinations = [dest_dir/"homebrew.name.service", dest_dir/"sh.brew.name.service"]
+      destinations = [dest_dir/"sh.brew.name.service", dest_dir/"homebrew.name.service"]
       destinations.each { |destination| destination.write("service") }
       service = instance_double(
         Homebrew::Services::FormulaWrapper,
         name:                 "name",
-        service_name:         "homebrew.name",
-        service_names:        ["homebrew.name", "sh.brew.name"],
-        loaded_service_names: ["sh.brew.name"],
+        service_name:         "sh.brew.name",
+        service_names:        ["sh.brew.name", "homebrew.name"],
+        loaded_service_names: ["homebrew.name"],
         destinations:,
         timed?:               false,
         pid?:                 false,
@@ -444,24 +465,24 @@ RSpec.describe Homebrew::Services::Cli do
 
       expect do
         services_cli.stop([service])
-      end.to output(/Successfully stopped `name` \(label: sh\.brew\.name\)/).to_stdout
+      end.to output(/Successfully stopped `name` \(label: homebrew\.name\)/).to_stdout
       expect(destinations).not_to include(an_object_satisfying(&:exist?))
     end
 
     it "preserves a compatible systemd service file when stopping fails" do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
       expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
-        .with("disable", "--now", "sh.brew.name").and_return(false)
+        .with("disable", "--now", "homebrew.name").and_return(false)
       expect(Homebrew::Services::System::Systemctl).not_to receive(:run)
 
-      destination = mktmpdir/"sh.brew.name.service"
+      destination = mktmpdir/"homebrew.name.service"
       destination.write("service")
       service = instance_double(
         Homebrew::Services::FormulaWrapper,
         name:                 "name",
-        service_name:         "homebrew.name",
-        service_names:        ["homebrew.name", "sh.brew.name"],
-        loaded_service_names: ["sh.brew.name"],
+        service_name:         "sh.brew.name",
+        service_names:        ["sh.brew.name", "homebrew.name"],
+        loaded_service_names: ["homebrew.name"],
         destinations:         [destination],
         timed?:               false,
         pid?:                 false,
@@ -471,24 +492,24 @@ RSpec.describe Homebrew::Services::Cli do
 
       expect do
         services_cli.stop([service])
-      end.to output(/Unable to stop `name` \(label: sh\.brew\.name\)/).to_stderr
+      end.to output(/Unable to stop `name` \(label: homebrew\.name\)/).to_stderr
       expect(destination).to exist
     end
 
     it "cleans up after an accepted asynchronous systemd stop" do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
       expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
-        .with("--no-block", "disable", "--now", "sh.brew.name").and_return(true)
+        .with("--no-block", "disable", "--now", "homebrew.name").and_return(true)
       expect(Homebrew::Services::System::Systemctl).to receive(:run).with("--no-block", "daemon-reload")
 
-      destination = mktmpdir/"sh.brew.name.service"
+      destination = mktmpdir/"homebrew.name.service"
       destination.write("service")
       service = instance_double(
         Homebrew::Services::FormulaWrapper,
         name:                 "name",
-        service_name:         "homebrew.name",
-        service_names:        ["homebrew.name", "sh.brew.name"],
-        loaded_service_names: ["sh.brew.name"],
+        service_name:         "sh.brew.name",
+        service_names:        ["sh.brew.name", "homebrew.name"],
+        loaded_service_names: ["homebrew.name"],
         destinations:         [destination],
         timed?:               false,
         pid?:                 true,
@@ -498,22 +519,22 @@ RSpec.describe Homebrew::Services::Cli do
 
       expect do
         services_cli.stop([service], no_wait: true)
-      end.to output(/Successfully stopped `name` \(label: sh\.brew\.name\)/).to_stdout
+      end.to output(/Successfully stopped `name` \(label: homebrew\.name\)/).to_stdout
       expect(destination).not_to exist
     end
 
     it "stops a compatible systemd service whose timer is inactive" do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
       expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
-        .with("stop", "sh.brew.name.timer").ordered.and_return(true)
+        .with("stop", "homebrew.name.timer").ordered.and_return(true)
       expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
-        .with("stop", "sh.brew.name").ordered.and_return(true)
+        .with("stop", "homebrew.name").ordered.and_return(true)
       service = instance_double(
         Homebrew::Services::FormulaWrapper,
         name:                  "name",
-        service_name:          "homebrew.name",
-        service_names:         ["homebrew.name", "sh.brew.name"],
-        active_service_name:   "sh.brew.name",
+        service_name:          "sh.brew.name",
+        service_names:         ["sh.brew.name", "homebrew.name"],
+        active_service_name:   "homebrew.name",
         loaded_service_names:  [],
         service_file_present?: false,
         timed?:                true,
@@ -524,7 +545,7 @@ RSpec.describe Homebrew::Services::Cli do
 
       expect do
         services_cli.stop([service], keep: true)
-      end.to output(/Successfully stopped `name` \(label: sh\.brew\.name\)/).to_stdout
+      end.to output(/Successfully stopped `name` \(label: homebrew\.name\)/).to_stdout
     end
 
     it "stops and removes both compatible macOS service labels" do
@@ -645,27 +666,27 @@ RSpec.describe Homebrew::Services::Cli do
       service = instance_double(
         service_string,
         name:                 "name",
-        service_name:         "homebrew.name",
+        service_name:         "sh.brew.name",
         keep_alive?:          false,
-        loaded_service_names: ["sh.brew.name"],
+        loaded_service_names: ["homebrew.name"],
       )
       allow(service).to receive(:pid?).and_return(true, false)
       allow(service).to receive(:reset_cache!)
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
       expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
-        .with("stop", "sh.brew.name").and_return(true)
+        .with("stop", "homebrew.name").and_return(true)
 
       expect do
         services_cli.kill([service])
-      end.to output(/Successfully killed `name` \(label: sh\.brew\.name\)/).to_stdout
+      end.to output(/Successfully killed `name` \(label: homebrew\.name\)/).to_stdout
     end
 
     it "kills a compatible systemd service whose timer is inactive" do
       service = instance_double(
         service_string,
         name:                 "name",
-        service_name:         "homebrew.name",
-        active_service_name:  "sh.brew.name",
+        service_name:         "sh.brew.name",
+        active_service_name:  "homebrew.name",
         keep_alive?:          false,
         loaded_service_names: [],
       )
@@ -673,11 +694,11 @@ RSpec.describe Homebrew::Services::Cli do
       allow(service).to receive(:reset_cache!)
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
       expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
-        .with("stop", "sh.brew.name").and_return(true)
+        .with("stop", "homebrew.name").and_return(true)
 
       expect do
         services_cli.kill([service])
-      end.to output(/Successfully killed `name` \(label: sh\.brew\.name\)/).to_stdout
+      end.to output(/Successfully killed `name` \(label: homebrew\.name\)/).to_stdout
     end
   end
 
@@ -752,21 +773,21 @@ RSpec.describe Homebrew::Services::Cli do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
       allow(Homebrew::Services::System::Systemctl).to receive(:quiet_run).and_return(true)
       expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
-        .with("disable", "sh.brew.name.service")
+        .with("disable", "homebrew.name.service")
       allow(Homebrew::Services::System::Systemctl).to receive(:run).with("daemon-reload")
 
       source_dir = mktmpdir
       dest_dir = mktmpdir
       service_file = source_dir/"homebrew.name.service"
-      primary_dest = dest_dir/"homebrew.name.service"
-      compatible_dest = dest_dir/"sh.brew.name.service"
+      primary_dest = dest_dir/"sh.brew.name.service"
+      compatible_dest = dest_dir/"homebrew.name.service"
       service_file.write("service")
       primary_dest.write("old service")
       compatible_dest.write("compatible service")
       service = instance_double(
         Homebrew::Services::FormulaWrapper,
         name:                "name",
-        service_name:        "homebrew.name",
+        service_name:        "sh.brew.name",
         installed?:          true,
         source_service_file: service_file,
         service_contents:    "service",
@@ -784,21 +805,21 @@ RSpec.describe Homebrew::Services::Cli do
     it "installs timed systemd timer files" do
       allow(Homebrew::Services::System).to receive(:systemctl?).and_return(true)
       expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
-        .with("disable", "sh.brew.name.timer").and_return(true)
+        .with("disable", "homebrew.name.timer").and_return(true)
       allow(Homebrew::Services::System::Systemctl).to receive(:run).with("daemon-reload")
 
       source_dir = mktmpdir
       dest_dir = mktmpdir
-      service_file = source_dir/"homebrew.name.service"
-      timer_file = source_dir/"homebrew.name.timer"
-      compatible_timer_dest = dest_dir/"sh.brew.name.timer"
+      service_file = source_dir/"sh.brew.name.service"
+      timer_file = source_dir/"sh.brew.name.timer"
+      compatible_timer_dest = dest_dir/"homebrew.name.timer"
       service_file.write("service")
       timer_file.write("legacy timer")
       compatible_timer_dest.write("old timer")
       service = instance_double(
         Homebrew::Services::FormulaWrapper,
         name:                "name",
-        service_name:        "homebrew.name",
+        service_name:        "sh.brew.name",
         installed?:          true,
         service_file:,
         source_service_file: service_file,

--- a/Library/Homebrew/test/services/formula_wrapper_spec.rb
+++ b/Library/Homebrew/test/services/formula_wrapper_spec.rb
@@ -13,16 +13,16 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
                     name:                   "mysql",
                     plist_name:             "sh.brew.mysql",
                     plist_names:            ["sh.brew.mysql"],
-                    service_name:           "homebrew.mysql",
-                    service_names:          ["homebrew.mysql", "sh.brew.mysql"],
+                    service_name:           "sh.brew.mysql",
+                    service_names:          ["sh.brew.mysql", "homebrew.mysql"],
                     launchd_service_path:   Pathname.new("/usr/local/opt/mysql/sh.brew.mysql.plist"),
                     launchd_service_paths:  [Pathname.new("/usr/local/opt/mysql/sh.brew.mysql.plist")],
-                    systemd_service_path:   Pathname.new("/usr/local/opt/mysql/homebrew.mysql.service"),
-                    systemd_service_paths:  [Pathname.new("/usr/local/opt/mysql/homebrew.mysql.service"),
-                                             Pathname.new("/usr/local/opt/mysql/sh.brew.mysql.service")],
-                    systemd_timer_path:     Pathname.new("/usr/local/opt/mysql/homebrew.mysql.timer"),
-                    systemd_timer_paths:    [Pathname.new("/usr/local/opt/mysql/homebrew.mysql.timer"),
-                                             Pathname.new("/usr/local/opt/mysql/sh.brew.mysql.timer")],
+                    systemd_service_path:   Pathname.new("/usr/local/opt/mysql/sh.brew.mysql.service"),
+                    systemd_service_paths:  [Pathname.new("/usr/local/opt/mysql/sh.brew.mysql.service"),
+                                             Pathname.new("/usr/local/opt/mysql/homebrew.mysql.service")],
+                    systemd_timer_path:     Pathname.new("/usr/local/opt/mysql/sh.brew.mysql.timer"),
+                    systemd_timer_paths:    [Pathname.new("/usr/local/opt/mysql/sh.brew.mysql.timer"),
+                                             Pathname.new("/usr/local/opt/mysql/homebrew.mysql.timer")],
                     opt_prefix:             Pathname.new("/usr/local/opt/mysql"),
                     any_version_installed?: true,
                     service?:               false)
@@ -74,7 +74,7 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
 
     it "systemD - outputs the full service file path" do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
-      expect(service.service_file.to_s).to eq("/usr/local/opt/mysql/homebrew.mysql.service")
+      expect(service.service_file.to_s).to eq("/usr/local/opt/mysql/sh.brew.mysql.service")
     end
 
     it "Other - raises an error" do
@@ -110,7 +110,7 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
     end
 
     it "uses the compatible systemd service file when it is the only one present" do
-      service_files = [mktmpdir/"homebrew.mysql.service", mktmpdir/"sh.brew.mysql.service"]
+      service_files = [mktmpdir/"sh.brew.mysql.service", mktmpdir/"homebrew.mysql.service"]
       service_files.last.write("service")
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
       allow(formula).to receive(:systemd_service_paths).and_return(service_files)
@@ -121,12 +121,12 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
 
   describe "#timer_file" do
     it "uses the compatible systemd timer file when it is the only one present" do
-      timer_files = [mktmpdir/"homebrew.mysql.timer", mktmpdir/"sh.brew.mysql.timer"]
+      timer_files = [mktmpdir/"sh.brew.mysql.timer", mktmpdir/"homebrew.mysql.timer"]
       timer_files.last.write("timer")
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
       allow(formula).to receive(:systemd_timer_paths).and_return(timer_files)
 
-      expect([service.timer_file, service.timer_name]).to eq([timer_files.last, "homebrew.mysql.timer"])
+      expect([service.timer_file, service.timer_name]).to eq([timer_files.last, "sh.brew.mysql.timer"])
     end
   end
 
@@ -217,7 +217,7 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
 
     it "systemD - outputs the service name" do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
-      expect(service.service_name).to eq("homebrew.mysql")
+      expect(service.service_name).to eq("sh.brew.mysql")
     end
 
     it "Other - raises an error" do
@@ -240,7 +240,7 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
     it "includes both compatible default systemd labels" do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
 
-      expect(service.service_names).to eq(["homebrew.mysql", "sh.brew.mysql"])
+      expect(service.service_names).to eq(["sh.brew.mysql", "homebrew.mysql"])
     end
   end
 
@@ -285,15 +285,15 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
 
     it "systemD - outputs the destination for the service file" do
       allow(Homebrew::Services::System).to receive(:systemctl?).and_return(true)
-      expect(service.dest.to_s).to eq("/tmp_home/.config/systemd/user/homebrew.mysql.service")
+      expect(service.dest.to_s).to eq("/tmp_home/.config/systemd/user/sh.brew.mysql.service")
     end
 
     it "systemD - includes both compatible destinations" do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
 
       expect(service.destinations.map(&:to_s)).to eq([
-        "/tmp_home/.config/systemd/user/homebrew.mysql.service",
         "/tmp_home/.config/systemd/user/sh.brew.mysql.service",
+        "/tmp_home/.config/systemd/user/homebrew.mysql.service",
       ])
     end
   end
@@ -303,8 +303,8 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
 
       expect(service.timer_destinations.map(&:to_s)).to eq([
-        "/tmp_home/.config/systemd/user/homebrew.mysql.timer",
         "/tmp_home/.config/systemd/user/sh.brew.mysql.timer",
+        "/tmp_home/.config/systemd/user/homebrew.mysql.timer",
       ])
     end
   end
@@ -393,13 +393,13 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
       allow(service).to receive(:timed?).and_return(true)
       expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
-        .with("status", "homebrew.mysql.timer")
+        .with("status", "sh.brew.mysql.timer")
         .and_return(true)
       expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
-        .with("status", "sh.brew.mysql.timer")
+        .with("status", "homebrew.mysql.timer")
         .and_return(false)
       expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
-        .with("status", "sh.brew.mysql.service")
+        .with("status", "homebrew.mysql.service")
         .and_return(false)
 
       expect(service.loaded?).to be(true)
@@ -410,53 +410,74 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
       allow(service).to receive(:timed?).and_return(true)
       allow(Homebrew::Services::System::Systemctl).to receive(:quiet_run).and_return(false)
       expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
-        .with("status", "sh.brew.mysql.service").and_return(true)
+        .with("status", "homebrew.mysql.service").and_return(true)
 
-      expect(service.loaded_service_names).to eq(["sh.brew.mysql"])
+      expect(service.loaded_service_names).to eq(["homebrew.mysql"])
     end
 
     it "finds a service loaded with the compatible systemd label" do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
       expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
-        .with("status", "homebrew.mysql.service").and_return(false)
+        .with("status", "sh.brew.mysql.service").and_return(false)
       expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
-        .with("status", "sh.brew.mysql.service").and_return(true)
+        .with("status", "homebrew.mysql.service").and_return(true)
 
-      expect(service.loaded_service_names).to eq(["sh.brew.mysql"])
+      expect(service.loaded_service_names).to eq(["homebrew.mysql"])
     end
 
     it "caches compatible systemd loaded-name probes" do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
       expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
-        .with("status", "homebrew.mysql.service").once.and_return(false)
+        .with("status", "sh.brew.mysql.service").once.and_return(false)
       expect(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
-        .with("status", "sh.brew.mysql.service").once.and_return(true)
+        .with("status", "homebrew.mysql.service").once.and_return(true)
 
       expect([
         service.loaded?,
         service.loaded?(cached: true),
         service.loaded_service_names,
-      ]).to eq([true, true, ["sh.brew.mysql"]])
+      ]).to eq([true, true, ["homebrew.mysql"]])
     end
 
     it "reports the active compatible systemd label" do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
       allow(Homebrew::Services::System::Systemctl).to receive(:popen_read)
-        .with("status", "sh.brew.mysql.service").and_return("Main PID: 123 (mysqld)")
-      allow(service).to receive(:loaded_service_names).and_return(["sh.brew.mysql"])
+        .with("status", "homebrew.mysql.service").and_return("Main PID: 123 (mysqld)")
+      allow(service).to receive(:loaded_service_names).and_return(["homebrew.mysql"])
 
-      expect(service.active_service_name).to eq("sh.brew.mysql")
+      expect(service.active_service_name).to eq("homebrew.mysql")
     end
 
     it "finds a running compatible systemd service when its timer is inactive" do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
       allow(service).to receive_messages(timed?: true, loaded_service_names: [])
       allow(Homebrew::Services::System::Systemctl).to receive(:popen_read)
-        .with("status", "homebrew.mysql.service").and_return("Active: inactive (dead)")
+        .with("status", "sh.brew.mysql.service").and_return("Active: inactive (dead)")
       allow(Homebrew::Services::System::Systemctl).to receive(:popen_read)
-        .with("status", "sh.brew.mysql.service").and_return("Main PID: 123 (mysqld)")
+        .with("status", "homebrew.mysql.service").and_return("Main PID: 123 (mysqld)")
 
-      expect(service.active_service_name).to eq("sh.brew.mysql")
+      expect(service.active_service_name).to eq("homebrew.mysql")
+    end
+
+    it "reports a failed legacy systemd service when the canonical unit is absent" do
+      output = <<~EOS
+        ● homebrew.mysql.service - Homebrew MySQL service
+             Loaded: loaded (/tmp/homebrew.mysql.service; enabled)
+             Active: failed (Result: exit-code)
+            Process: 123 ExecStart=/bin/false (code=exited, status=1)
+      EOS
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
+      allow(service).to receive(:loaded_service_names).and_return([])
+      expect(Homebrew::Services::System::Systemctl).to receive(:popen_read)
+        .with("status", "sh.brew.mysql.service").and_return("")
+      expect(Homebrew::Services::System::Systemctl).to receive(:popen_read)
+        .with("status", "homebrew.mysql.service").and_return(output)
+
+      expect([
+        service.active_service_name,
+        service.exit_code,
+        service.loaded_file,
+      ]).to eq(["homebrew.mysql", 1, "/tmp/homebrew.mysql.service"])
     end
 
     it "Other - raises an error" do
@@ -578,10 +599,10 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
 
     it "prefers the systemd service file matching the active compatible label" do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, root?: false, systemctl?: true)
-      allow(service).to receive_messages(active_service_name: "sh.brew.mysql", dest_dir: mktmpdir)
+      allow(service).to receive_messages(active_service_name: "homebrew.mysql", dest_dir: mktmpdir)
       service.destinations.each { |destination| destination.write("service") }
 
-      expect(service.registered_destination.basename.to_s).to eq("sh.brew.mysql.service")
+      expect(service.registered_destination.basename.to_s).to eq("homebrew.mysql.service")
     end
   end
 
@@ -630,10 +651,10 @@ RSpec.describe Homebrew::Services::FormulaWrapper, :needs_daemon_manager do
       allow(Homebrew::Services::System).to receive_messages(launchctl?: false, systemctl?: true)
       allow(Formulary).to receive(:factory).with("mysql").and_return(formula)
 
-      discovered_service = described_class.from("/tmp/sh.brew.mysql.service")
+      discovered_service = described_class.from("/tmp/homebrew.mysql.service")
       raise "Expected service to be discovered" unless discovered_service
 
-      expect(discovered_service.service_names).to eq(["sh.brew.mysql"])
+      expect(discovered_service.service_names).to eq(["homebrew.mysql"])
     end
   end
 

--- a/Library/Homebrew/test/utils/service_spec.rb
+++ b/Library/Homebrew/test/utils/service_spec.rb
@@ -60,9 +60,9 @@ RSpec.describe Utils::Service do
       systemctl = Pathname("/bin/systemctl")
       allow(described_class).to receive_messages(launchctl: nil, systemctl?: true, systemctl:)
       expect(SystemCommand).to receive(:quiet_system)
-        .with(systemctl, "is-active", "--quiet", "homebrew.formula_name").and_return(false)
+        .with(systemctl, "is-active", "--quiet", "sh.brew.formula_name").and_return(false)
       expect(SystemCommand).to receive(:quiet_system)
-        .with(systemctl, "is-active", "--quiet", "sh.brew.formula_name").and_return(true)
+        .with(systemctl, "is-active", "--quiet", "homebrew.formula_name").and_return(true)
 
       expect(described_class.running?(f)).to be true
     end


### PR DESCRIPTION
Phase two of moving the default Linux service label from `homebrew.<formula>` to `sh.brew.<formula>`, following #23792 and matching the macOS change in #23750. Generated systemd services and timers now use the canonical label for the unit filenames and the timer's `Unit=` target. Legacy `homebrew.<formula>` units stay discoverable and controllable, explicit `name linux:` labels and unrelated package-provided timer targets are unchanged, and macOS behavior is unchanged.

Migration is restart-only, as on macOS: `start` and `run` report a pending migration for a generated service loaded under the legacy label and point at `brew services restart`, which stops and disables the legacy units, removes their files and installs the canonical ones. Bundle keeps finding the legacy service file in existing kegs.

Two fixes found in review: systemd status discovery no longer lets an absent canonical unit mask a registered legacy unit that has stopped or failed, so `brew services info` keeps reporting its label, exit code and loaded file; and `Keg#homebrew_created_file?` now recognizes the `sh.brew.` prefix so canonical service files keep full-prefix relocation on `/usr/local`.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Fable 5.1) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the change and pass with it, and ran `brew lgtm --online`.

-----
