### PR TITLE
services: keep active systemd timers on cleanup

### DIFF
--- a/Library/Homebrew/services/cli.rb
+++ b/Library/Homebrew/services/cli.rb
@@ -111,6 +111,8 @@ module Homebrew
           label = FormulaWrapper.service_file_label(file) if file.extname.casecmp?(".plist")
           service_name = label || File.basename(file).sub(/\.(?:plist|service|timer)$/i, "")
           next if running_services.include?(service_name)
+          next if System.systemctl? && !file.extname.casecmp?(".plist") &&
+                  System::Systemctl.quiet_run("status", "#{service_name}.timer")
           next if label && System.launchctl? && System.launchctl_service_running?(label)
 
           puts "Removing unused service file: #{file}"

--- a/Library/Homebrew/test/services/cli_spec.rb
+++ b/Library/Homebrew/test/services/cli_spec.rb
@@ -110,6 +110,21 @@ RSpec.describe Homebrew::Services::Cli do
       expect(stale_timer).not_to exist
     end
 
+    it "keeps systemd service files for an active timer" do
+      path = mktmpdir
+      service_file = path/"homebrew.name.service"
+      timer_file = path/"homebrew.name.timer"
+      service_file.write("service")
+      timer_file.write("timer")
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: false, path:, systemctl?: true)
+      allow(Homebrew::Services::System::Systemctl).to receive(:quiet_run)
+        .with("status", "homebrew.name.timer").and_return(true)
+      allow(services_cli).to receive(:running).and_return([])
+
+      expect([services_cli.remove_unused_service_files, service_file.exist?, timer_file.exist?])
+        .to eq([[], true, true])
+    end
+
     it "removes unused canonical macOS service files" do
       path = mktmpdir
       active_service = path/"sh.brew.name.plist"


### PR DESCRIPTION
`brew services cleanup` on systemd removed the unit files of a scheduled timer whenever its service was idle between runs: `running` only lists running service units, so neither the `.timer` nor the `.service` file counted as in use. Cleanup now keeps both while the timer unit is active. Found while reviewing #23837; the bug predates the label migration.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Fable 5.1) drafted the implementation and tests; I reviewed the diff, verified the new test fails without the change and passes with it, and ran `brew lgtm`.

-----
