### PR TITLE
Mark unsatisfied requirements in `brew info`

### DIFF
--- a/Library/Homebrew/cask/info.rb
+++ b/Library/Homebrew/cask/info.rb
@@ -29,7 +29,7 @@ module Cask
       output << "#{repo}\n" if repo
       deps = deps_info(cask, mark_uninstalled: installed)
       output << deps if deps
-      requirements = requirements_info(cask, mark_uninstalled: installed)
+      requirements = requirements_info(cask)
       output << requirements if requirements
       language = language_info(cask)
       output << language if language

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -596,7 +596,7 @@ module Homebrew
             reqs = formula.requirements.select(&:"#{type}?")
             next if reqs.to_a.empty?
 
-            puts "#{type.capitalize}: #{decorate_requirements(reqs, mark_uninstalled: kegs.any?)}"
+            puts "#{type.capitalize}: #{decorate_requirements(reqs)}"
           end
         end
 

--- a/Library/Homebrew/test/cask/info_spec.rb
+++ b/Library/Homebrew/test/cask/info_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe Cask::Info, :cask do
     "#{Tty.bold}#{string} #{Formatter.success("✔")}#{Tty.reset}"
   end
 
+  def unsatisfied_requirement(string)
+    "#{string} #{Formatter.error("✘")}#{Tty.reset}"
+  end
+
   def requirements_section(string)
     <<~EOS.chomp
       #{ohai_title "Requirements"}
@@ -134,9 +138,9 @@ RSpec.describe Cask::Info, :cask do
   it "prints cask and formulas dependencies if the Cask has both" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
     arch_requirements = if Hardware::CPU.arm?
-      "x86_64 architecture, #{installed("arm64 architecture")}"
+      "#{unsatisfied_requirement("x86_64 architecture")}, #{installed("arm64 architecture")}"
     else
-      "#{installed("x86_64 architecture")}, arm64 architecture"
+      "#{installed("x86_64 architecture")}, #{unsatisfied_requirement("arm64 architecture")}"
     end
 
     expect do
@@ -153,6 +157,14 @@ RSpec.describe Cask::Info, :cask do
       #{ohai_title "Artifacts"}
       Caffeine.app (App)
     EOS
+  end
+
+  it "marks an unsatisfied requirement on an uninstalled cask" do
+    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+    unsatisfied_arch = Hardware::CPU.arm? ? "x86_64" : "arm64"
+
+    expect { described_class.info(Cask::CaskLoader.load("with-depends-on-everything"), args:) }
+      .to output(/Required: .*#{unsatisfied_arch} architecture.*✘/).to_stdout
   end
 
   it "prints auto_updates if the Cask has `auto_updates true`" do

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -1032,6 +1032,75 @@ RSpec.describe Homebrew::Cmd::Info do
       .and not_to_output.to_stderr
   end
 
+  it "marks an unsatisfied architecture requirement on an uninstalled formula" do
+    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+    info = described_class.new([])
+    formula = formula("testball") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/testball-0.1.tar.gz"
+      homepage "https://brew.sh/testball"
+      desc "Some test"
+    end
+    requirement = ArchRequirement.new([:arm64])
+    allow(requirement).to receive(:satisfied?).and_return(false)
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+    allow(formula).to receive_messages(
+      core_formula?: false,
+      requirements:  Requirements.new(requirement),
+    )
+
+    expect { info.info_formula(formula) }
+      .to output(/Required: .*arm64 architecture.*✘/).to_stdout
+      .and not_to_output.to_stderr
+  end
+
+  it "marks an unsatisfied OS requirement on an uninstalled formula" do
+    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+    info = described_class.new([])
+    formula = formula("testball") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/testball-0.1.tar.gz"
+      homepage "https://brew.sh/testball"
+      desc "Some test"
+    end
+    other_os_requirement = OS.mac? ? LinuxRequirement.new : MacOSRequirement.new
+    other_os = OS.mac? ? "Linux" : "macOS"
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+    allow(formula).to receive_messages(
+      core_formula?: false,
+      requirements:  Requirements.new(other_os_requirement),
+    )
+
+    expect { info.info_formula(formula) }
+      .to output(/Required: .*#{other_os}.*✘/).to_stdout
+      .and not_to_output.to_stderr
+  end
+
+  it "keeps a satisfied requirement marked on an uninstalled formula" do
+    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+    info = described_class.new([])
+    formula = formula("testball") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/testball-0.1.tar.gz"
+      homepage "https://brew.sh/testball"
+      desc "Some test"
+    end
+    requirement = ArchRequirement.new([:arm64])
+    allow(requirement).to receive(:satisfied?).and_return(true)
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+    allow(formula).to receive_messages(
+      core_formula?: false,
+      requirements:  Requirements.new(requirement),
+    )
+
+    expect { info.info_formula(formula) }
+      .to output(/Required: .*arm64 architecture.*✔/).to_stdout
+      .and not_to_output.to_stderr
+  end
+
   it "hides source install metadata for formulae that only run on another OS" do
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
 


### PR DESCRIPTION
`brew info <pkg>` prints a `✔`/`✘` satisfaction mark next to entries in its Requirements and Dependencies sections. For requirements (e.g. platform, macOS version, CPU architecture) the mark is currently dropped when the requirement is unsatisfied *and* the package isn't installed, so a host that cannot satisfy the requirement shows a bare, unmarked entry rather than a clear `✘`. For example, on Linux `brew info discord` (a macOS-only cask, not installed) prints `Required: macOS` with no mark, even though the tool already knows the host can't satisfy it.

A requirement describes the host, not the installation, so its satisfaction is knowable regardless of whether the package is installed — the mark should reflect that, on both casks and formulae. This PR makes requirements marking stop being conditional on package install state, so an unsatisfied requirement always renders `✘`:

```
# before
Required: macOS

# after
Required: macOS ✘
```

Satisfaction marks for dependencies are intentionally left conditional on install state, retaining the intent from #22342, which added that condition. Indeed, missing dependencies for a not-yet-installed package should not be flagged loudly with `✘`, since dependencies get pulled in at install time anyway. Requirements, on the other hand, cannot be satisfied by installing, so an unmet one is a real blocker for installation. (This PR also follows the spirit of #21909, which made cask requirements explicit and consistent across platforms.)

The change applies symmetrically to both requirement types (`MacOSRequirement`, `LinuxRequirement`) and to an unsatisfiable `ArchRequirement` (e.g. `arm64` on an `x86_64` host), on casks and formulae alike; satisfied requirements still render `✔`. New test specs cover both the cask and formula paths on macOS and Linux.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

I used Claude Opus 4.8 to help implement and test this change; I co-designed the change and reviewed all output.