### PR TITLE
info: mark disabled/deprecated casks in title

### DIFF
--- a/Library/Homebrew/cask/info.rb
+++ b/Library/Homebrew/cask/info.rb
@@ -51,11 +51,14 @@ module Cask
 
     sig { params(cask: Cask, installed: T::Boolean).returns(String) }
     def self.title_info(cask, installed:)
-      name_with_status = if installed
-        pretty_install_status(cask.token, installed: true, outdated: cask.outdated?, bold: true)
-      else
-        pretty_uninstalled(cask.token)
-      end
+      name_with_status = pretty_install_status(
+        cask.token,
+        installed:,
+        outdated:   installed && cask.outdated?,
+        deprecated: cask.deprecated?,
+        disabled:   cask.disabled?,
+        bold:       true,
+      )
       title = oh1_title(name_with_status).to_s
       title += " (#{cask.name.join(", ")})" unless cask.name.empty?
 

--- a/Library/Homebrew/test/cask/info_spec.rb
+++ b/Library/Homebrew/test/cask/info_spec.rb
@@ -82,6 +82,26 @@ RSpec.describe Cask::Info, :cask do
     EOS
   end
 
+  it "marks a disabled Cask in the title" do
+    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+    expect do
+      described_class.info(Cask::CaskLoader.load(cask_path("livecheck/livecheck-disabled")), args:)
+    end.to output(
+      /#{Regexp.escape(uninstalled("livecheck-disabled"))} #{Regexp.escape(Formatter.error("(disabled)"))}/,
+    ).to_stdout
+  end
+
+  it "marks a deprecated Cask in the title" do
+    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+    expect do
+      described_class.info(Cask::CaskLoader.load(cask_path("livecheck/livecheck-deprecated")), args:)
+    end.to output(
+      /#{Regexp.escape(uninstalled("livecheck-deprecated"))} #{Regexp.escape(Formatter.warning("(deprecated)"))}/,
+    ).to_stdout
+  end
+
   it "prints inline summary information for casks" do
     cask = Cask::CaskLoader.load("local-transmission")
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)


### PR DESCRIPTION
-----
<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

AI disclosure: drafted with assistance from Cline (Claude, Anthropic). I reviewed and verified all changes and will answer any review comments myself.

-----

**What does this PR do?**

Shows the `⚠ (deprecated)` and `✘ (disabled)` markers for casks in the `brew info` title, matching the existing formula behaviour:

```
$ brew info toptracker
==> toptracker ✘ (disabled): 1.2.3
```

`Cask::Info.title_info` now passes `cask.deprecated?`/`cask.disabled?` through `pretty_install_status`, unifying the previously split installed/uninstalled branches. Two specs cover both markers using the existing `livecheck-deprecated`/`livecheck-disabled` fixture casks.

**Why is this needed?**

#22334 added these markers for formulae, and `brew search`/`brew tap-info` already show them for casks, but the `brew info <cask>` title was missed: disabled casks such as `toptracker` look like regular uninstalled casks there, even though their disabled status is shown in the body text.
