### PR TITLE
advisory-match: skip unverifiable formula history

### DIFF
--- a/Library/Homebrew/dev-cmd/advisory-match.rb
+++ b/Library/Homebrew/dev-cmd/advisory-match.rb
@@ -105,9 +105,21 @@ module Homebrew
                   walk_history &&= emitter.history_required?(record_id) if args.new_history?
                   emitter.record_history_walk if walk_history
                   first_fixed = matcher.first_fixed_version(formula, hit) if walk_history
-                  next if first_fixed == :never_affected
+                  fixed_boundary = T.let(nil, T.nilable(String))
+                  case first_fixed
+                  when String
+                    fixed_boundary = first_fixed
+                  when nil
+                    # No history walk was required.
+                  when :never_affected
+                    next
+                  when :history_unavailable
+                    opoo "#{record_id}: formula history is unavailable; skipping automatic update"
+                    next
+                  else
+                    raise TypeError, "unexpected fixed-history result: #{first_fixed.inspect}"
+                  end
 
-                  fixed_boundary = first_fixed if first_fixed.is_a?(String)
                   if fixed_boundary && !emitter.fixed_boundary_valid?(record_id, fixed_boundary)
                     onoe "#{record_id}: fixed #{fixed_boundary} does not follow its reviewed range"
                     Homebrew.failed = true

--- a/Library/Homebrew/test/dev-cmd/advisory-match_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/advisory-match_spec.rb
@@ -522,6 +522,55 @@ RSpec.describe Homebrew::DevCmd::AdvisoryMatch do
     end
   end
 
+  it "skips a new record when formula history is unavailable" do
+    stub_osv_hit("CVE-2024-1234", fixed: "2.28.1")
+    matcher = Homebrew::Vulns::Match.new
+    expect(matcher).to receive(:first_fixed_version).and_return(:history_unavailable)
+    allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
+
+    Dir.mktmpdir do |dir|
+      expect { cmd_for("requests", "--output", dir, "--new-history").run }
+        .to output(/formula history is unavailable; skipping automatic update/).to_stderr
+      expect(Dir.glob(File.join(dir, "*.json"))).to be_empty
+    end
+  end
+
+  it "leaves an existing open range unchanged when formula history is unavailable" do
+    stub_osv_hit("CVE-2024-1234", fixed: "2.28.1")
+    matcher = Homebrew::Vulns::Match.new
+    expect(matcher).to receive(:first_fixed_version).and_return(:history_unavailable)
+    allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
+
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "BREW-requests-CVE-2024-1234.json")
+      existing = {
+        "id"                => "BREW-requests-CVE-2024-1234",
+        "affected"          => [{
+          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [{ "introduced" => "1.0" }] }],
+        }],
+        "database_specific" => { "source" => "matched" },
+      }
+      File.write(path, JSON.generate(existing))
+
+      expect { cmd_for("requests", "--output", dir, "--new-history").run }
+        .to output(/formula history is unavailable; skipping automatic update/).to_stderr
+      expect([JSON.parse(File.read(path)), Homebrew.failed?]).to eq [existing, false]
+    end
+  end
+
+  it "rejects an unknown fixed-history result" do
+    stub_osv_hit("CVE-2024-1234", fixed: "2.28.1")
+    matcher = Homebrew::Vulns::Match.new
+    expect(matcher).to receive(:first_fixed_version).and_return(:future_result)
+    allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
+
+    Dir.mktmpdir do |dir|
+      expect { cmd_for("requests", "--output", dir, "--new-history").run }
+        .to raise_error(TypeError, /unexpected fixed-history result: :future_result/)
+    end
+  end
+
   it "walks history when an existing matched record has no ranges" do
     stub_osv_hit("CVE-2024-1234", fixed: "2.28.1")
     matcher = Homebrew::Vulns::Match.new

--- a/Library/Homebrew/test/vulns/match_spec.rb
+++ b/Library/Homebrew/test/vulns/match_spec.rb
@@ -823,7 +823,7 @@ RSpec.describe Homebrew::Vulns::Match do
       expect([
         matcher.first_fixed_version(current, git_hit.call("1.1")),
         matcher.first_reintroduced_version(current, git_hit.call("3.0")),
-      ]).to eq ["2.0", :not_reintroduced]
+      ]).to eq [:history_unavailable, :not_reintroduced]
     end
 
     it "returns :never_affected when a fixed resource was absent from earlier formula revisions" do
@@ -866,6 +866,32 @@ RSpec.describe Homebrew::Vulns::Match do
       )
 
       expect(matcher.first_fixed_version(current, hit)).to eq "2.0"
+    end
+
+    it "returns :history_unavailable when an older revision after a resource-absence gap cannot be loaded" do
+      stub_history([["3.0", "1.2.0"], ["2.0", nil], nil])
+      current = formula("requests") do
+        T.bind(self, T.class_of(Formula))
+        url "https://files.pythonhosted.org/packages/aa/bb/cc/requests-3.0.tar.gz"
+        resource("certifi") do
+          url "https://files.pythonhosted.org/packages/11/22/33/certifi-1.2.0.tar.gz"
+        end
+      end
+      hit = make_hit(
+        vuln("id" => "CVE-1", "affected" => [
+          { "package" => { "ecosystem" => "PyPI", "name" => "certifi" },
+            "ranges"  => [{ "type"   => "ECOSYSTEM",
+                            "events" => [{ "introduced" => "0" }, { "fixed" => "1.0.8" }] }] },
+        ]),
+        ev(:registry, ecosystem: "PyPI", name: "certifi", subject_version: "1.2.0", resource: "certifi"),
+      )
+
+      expect(matcher.first_fixed_version(current, hit)).to eq :history_unavailable
+    end
+
+    it "returns a verified boundary before reaching an older unloadable revision" do
+      stub_history(["2.31.0", "2.28.1", "2.28.0", nil])
+      expect(matcher.first_fixed_version(requests, hit_fixed_at("2.28.1"))).to eq "2.28.1"
     end
 
     it "follows a resource package across historical resource-label changes" do
@@ -939,9 +965,9 @@ RSpec.describe Homebrew::Vulns::Match do
       expect(matcher.first_fixed_version(current, hit)).to eq "3.0"
     end
 
-    it "stops at an unloadable revision and returns the last known fixed pkg_version" do
+    it "returns :history_unavailable when a revision cannot be loaded" do
       stub_history(["2.31.0", "2.30.0", nil, "2.28.0"])
-      expect(matcher.first_fixed_version(requests, hit_fixed_at("2.28.1"))).to eq "2.30.0"
+      expect(matcher.first_fixed_version(requests, hit_fixed_at("2.28.1"))).to eq :history_unavailable
     end
 
     it "returns nil when the current version is still affected" do
@@ -1038,7 +1064,7 @@ RSpec.describe Homebrew::Vulns::Match do
       allow(FormulaVersions).to receive(:new).and_return(fv)
 
       expect(matcher.first_reintroduced_version(requests, hit_fixed_at("2.32.0"))).to eq :not_reintroduced
-      expect(matcher.first_fixed_version(requests, hit_fixed_at("2.28.1"))).to eq "2.31.0"
+      expect(matcher.first_fixed_version(requests, hit_fixed_at("2.28.1"))).to eq :history_unavailable
     end
 
     it "does not let fixed evidence mask another uncheckable historical subject" do

--- a/Library/Homebrew/vulns/match.rb
+++ b/Library/Homebrew/vulns/match.rb
@@ -624,9 +624,9 @@ module Homebrew
       #   i.e. Homebrew jumped from a version below `introduced` straight past
       #   `fixed` and never shipped an affected build. The caller drops the
       #   candidate rather than emitting `{introduced: "0", fixed: <first>}`.
-      # - a `pkg_version` String when the walk hits `:affected`, or when it
-      #   stops at an unloadable revision (best-effort boundary; the reviewer
-      #   can tighten).
+      # - `:history_unavailable` when a revision cannot be loaded or compared,
+      #   so the caller can skip the candidate rather than inventing a boundary.
+      # - a `pkg_version` String when the walk hits `:affected`.
       #
       # The rev-list and per-revision loads are cached per formula.
       sig { params(formula: Formula, hit: Hit).returns(T.nilable(T.any(String, Symbol))) }
@@ -642,14 +642,21 @@ module Homebrew
           state = fv.formula_at_revision(rev, entry) do |old|
             [aggregate_state_at(old, hit), old.pkg_version.to_s]
           end
-          # `nil` means the revision failed to load; can't verify further.
-          return last_fixed if state.nil?
+          return :history_unavailable if state.nil?
 
           aggregate, pkg_version = state
-          return :never_affected if aggregate == :not_applicable
-          return last_fixed if aggregate != :fixed
-
-          last_fixed = pkg_version
+          case aggregate
+          when :fixed
+            last_fixed = pkg_version
+          when :affected
+            return last_fixed
+          when :not_applicable
+            return :never_affected
+          when nil
+            return :history_unavailable
+          else
+            raise TypeError, "unexpected historical aggregate: #{aggregate.inspect}"
+          end
         end
         :never_affected
       end


### PR DESCRIPTION
`brew advisory-match` walks homebrew-core history to find the first Homebrew version that shipped an upstream fix. When `FormulaVersions#formula_at_revision` could not load an old revision, `first_fixed_version` returned the last verified-fixed version as the boundary. For openstackclient, an obsolete `cellar :any` bottle declaration makes every revision before February 2021 unloadable, so the walk emitted `fixed: 5.4.0_3` for four advisories whose affected resources were first added at already-fixed versions in 10.3.0 (Homebrew/advisory-database#270).

`first_fixed_version` now returns `:history_unavailable` when a revision cannot be loaded or its subjects cannot be compared, and the command warns and skips that candidate instead of inventing a boundary. Existing open records are left unchanged, and an unrecognized walk result raises rather than falling back to the current `pkg_version`.

Every bottled formula's pre-2021 revisions hit the same legacy bottle DSL wall, so measuring warning volume across the corpus and tolerating that DSL in the history loader are follow-ups.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Fable 5.1) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the fix and pass with it, and ran `brew lgtm --online` plus targeted specs.

-----
