### PR TITLE
bump: handle partially disabled packages

### DIFF
--- a/Library/Homebrew/deprecate_disable.rb
+++ b/Library/Homebrew/deprecate_disable.rb
@@ -36,6 +36,17 @@ module DeprecateDisable
   REMOVE_DISABLED_TIME_WINDOW = 12
   REMOVE_DISABLED_BEFORE = T.let((Date.today << REMOVE_DISABLED_TIME_WINDOW).freeze, Date)
 
+  # Whether a formula or cask is disabled on every OS/architecture combination.
+  sig { params(formula_or_cask: T.any(Formula, Cask::Cask)).returns(T::Boolean) }
+  def disabled_on_all_platforms?(formula_or_cask)
+    return false unless formula_or_cask.disabled?
+    return true unless formula_or_cask.on_system_blocks_exist?
+
+    formula_or_cask.to_hash_with_variations.fetch("variations").each_value.all? do |variation|
+      variation.fetch("disabled", true)
+    end
+  end
+
   sig { params(formula_or_cask: T.any(Formula, Cask::Cask)).returns(T.nilable(Symbol)) }
   def type(formula_or_cask)
     return :deprecated if formula_or_cask.deprecated?

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -119,7 +119,7 @@ module Homebrew
           formula = args.named.to_formulae.first
           raise FormulaUnspecifiedError if formula.blank?
 
-          raise ArgumentError, "This formula is disabled!" if formula.disabled?
+          raise ArgumentError, "This formula is disabled!" if DeprecateDisable.disabled_on_all_platforms?(formula)
           if formula.deprecation_reason == :does_not_build
             raise ArgumentError, "This formula is deprecated and does not build!"
           end

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -186,14 +186,15 @@ module Homebrew
         params(formula_or_cask: T.any(Formula, Cask::Cask)).returns(T::Boolean)
       }
       def skip_ineligible_package!(formula_or_cask)
+        disabled = DeprecateDisable.disabled_on_all_platforms?(formula_or_cask)
         if formula_or_cask.is_a?(Formula)
-          skip = formula_or_cask.disabled? || formula_or_cask.head_only?
+          skip = disabled || formula_or_cask.head_only?
           name = formula_or_cask.name
-          text = "Formula is #{formula_or_cask.disabled? ? "disabled" : "HEAD-only"} so not accepting updates.\n"
+          text = "Formula is #{disabled ? "disabled" : "HEAD-only"} so not accepting updates.\n"
         else
-          skip = formula_or_cask.disabled? || formula_or_cask.version.latest?
+          skip = disabled || formula_or_cask.version.latest?
           name = formula_or_cask.token
-          text = if formula_or_cask.disabled?
+          text = if disabled
             "Cask is disabled so not accepting updates.\n"
           else
             "Cask uses `version :latest` so `brew bump` cannot check it.\n"

--- a/Library/Homebrew/livecheck/skip_conditions.rb
+++ b/Library/Homebrew/livecheck/skip_conditions.rb
@@ -91,7 +91,7 @@ module Homebrew
         ).returns(T::Hash[Symbol, T.untyped])
       }
       private_class_method def self.formula_disabled(formula, livecheck_defined, full_name: false, verbose: false)
-        return {} if !formula.disabled? || livecheck_defined
+        return {} if livecheck_defined || !DeprecateDisable.disabled_on_all_platforms?(formula)
 
         Livecheck.status_hash(formula, "disabled", full_name:, verbose:)
       end
@@ -134,7 +134,7 @@ module Homebrew
         ).returns(T::Hash[Symbol, T.untyped])
       }
       private_class_method def self.cask_disabled(cask, livecheck_defined, full_name: false, verbose: false)
-        return {} if !cask.disabled? || livecheck_defined
+        return {} if livecheck_defined || !DeprecateDisable.disabled_on_all_platforms?(cask)
 
         Livecheck.status_hash(cask, "disabled", full_name:, verbose:)
       end

--- a/Library/Homebrew/test/deprecate_disable_spec.rb
+++ b/Library/Homebrew/test/deprecate_disable_spec.rb
@@ -84,6 +84,63 @@ RSpec.describe DeprecateDisable do
     end
   end
 
+  describe "::disabled_on_all_platforms?" do
+    sig { params(disable_stanzas: String).returns(T::Array[T::Boolean]) }
+    def disable_statuses(disable_stanzas)
+      [:formula, :cask].product([:sonoma, :linux], [:arm, :intel]).map do |type, os, arch|
+        Homebrew::SimulateSystem.with(os:, arch:) do
+          path = mktmpdir/"test.rb"
+          path.write <<~RUBY
+            #{(type == :formula) ? "class Test < Formula" : 'cask "test" do'}
+              version "1.2.3"
+              url "https://brew.sh/test-1.2.3.tgz"
+              #{disable_stanzas}
+            end
+          RUBY
+          package = (type == :formula) ? Formulary.factory(path) : Cask::CaskLoader.load(path)
+          described_class.disabled_on_all_platforms?(package)
+        end
+      end
+    end
+
+    it "returns false for enabled packages" do
+      expect(disable_statuses("")).to all(be(false))
+    end
+
+    it "returns true for unconditional disables with unrelated system blocks" do
+      expect(disable_statuses(<<~RUBY)).to all(be(true))
+        disable! date: "2020-01-01", because: :unmaintained
+        on_arm do
+          url "https://brew.sh/test-arm-1.2.3.tgz"
+        end
+      RUBY
+    end
+
+    it "returns true when disabled on both operating systems" do
+      expect(disable_statuses(<<~RUBY)).to all(be(true))
+        on_macos do
+          disable! date: "2020-01-01", because: :unmaintained
+        end
+        on_linux do
+          disable! date: "2020-01-01", because: :unmaintained
+        end
+      RUBY
+    end
+
+    test_each([
+      %w[on_macos], %w[on_linux], %w[on_arm], %w[on_intel],
+      ["on_sonoma :or_older"], %w[on_macos on_arm]
+    ]) do |conditions|
+      it "returns false when disabled in #{conditions.join(" and ")}" do
+        expect(disable_statuses(<<~RUBY)).to all(be(false))
+          #{conditions.join(" do\n")} do
+            disable! date: "2020-01-01", because: :unmaintained
+          #{conditions.map { "end" }.join("\n")}
+        RUBY
+      end
+    end
+  end
+
   describe "::type" do
     it "returns :deprecated if the formula is deprecated" do
       expect(described_class.type(deprecated_formula)).to eq :deprecated

--- a/Library/Homebrew/test/dev-cmd/bump-formula-pr_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-formula-pr_spec.rb
@@ -33,6 +33,38 @@ RSpec.describe Homebrew::DevCmd::BumpFormulaPr do
   end
 
   describe "#run" do
+    it "updates a formula disabled only on the current OS" do
+      formula_path = CoreTap.instance.new_formula_path("test")
+      formula_path.dirname.mkpath
+      formula_path.write <<~RUBY
+        class Test < Formula
+          url "https://brew.sh/test-1.2.3.tgz"
+          sha256 "#{"a" * 64}"
+
+          on_#{OS.mac? ? "macos" : "linux"} do
+            disable! date: "2020-01-01", because: :unmaintained
+          end
+        end
+      RUBY
+      formula = Formulary.factory(formula_path)
+      command = described_class.new([
+        "--write-only", "--no-audit", "--url=https://brew.sh/test-1.2.4.tgz", "--sha256=#{"b" * 64}", "test"
+      ])
+
+      allow(Utils::GemSetup).to receive(:install_bundler_gems!)
+      allow(CoreTap.instance).to receive_messages(allow_bump?: true, git?: true,
+                                                  remote_repository: "Homebrew/homebrew-core", install: nil)
+      allow(command).to receive_messages(check_new_version: nil, run_audit: false,
+                                         update_matching_version_resources!: {})
+      allow(PyPI).to receive(:update_python_resources!)
+      allow(command.args.named).to receive(:to_formulae).and_return([formula])
+      allow(Formula).to receive(:[]).with("test").and_return(formula)
+
+      command.run
+
+      expect(formula_path.read).to include('url "https://brew.sh/test-1.2.4.tgz"')
+    end
+
     it "adds updated mirrors as string literals" do
       formula_path = CoreTap.instance.new_formula_path("couchdb")
       formula_path.dirname.mkpath

--- a/Library/Homebrew/test/dev-cmd/bump_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump_spec.rb
@@ -94,6 +94,21 @@ RSpec.describe Homebrew::DevCmd::Bump do
   end
 
   describe "::skip_ineligible_package!" do
+    it "does not skip a cask disabled only on the current OS" do
+      cask = Cask::CaskLoader.load(<<~RUBY)
+        cask "partially-disabled" do
+          version "1.2.3"
+          url "https://brew.sh/test-1.2.3.tgz"
+
+          on_#{OS.mac? ? "macos" : "linux"} do
+            disable! date: "2020-01-01", because: :unmaintained
+          end
+        end
+      RUBY
+
+      expect(bump.skip_ineligible_package!(cask)).to be(false)
+    end
+
     it "prints a message for disabled formulae" do
       expect { expect(bump.skip_ineligible_package!(f_disabled)).to be(true) }
         .to output(/Formula is disabled so not accepting updates\./).to_stdout

--- a/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
+++ b/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
@@ -352,6 +352,21 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
   end
 
   describe "::skip_information" do
+    it "does not skip a cask disabled only on the current OS" do
+      cask = Cask::CaskLoader.load(<<~RUBY)
+        cask "partially-disabled" do
+          version "1.2.3"
+          url "https://brew.sh/test-1.2.3.tgz"
+
+          on_#{OS.mac? ? "macos" : "linux"} do
+            disable! date: "2020-01-01", because: :unmaintained
+          end
+        end
+      RUBY
+
+      expect(skip_conditions.skip_information(cask)).to eq({})
+    end
+
     context "when a formula without a `livecheck` block is deprecated" do
       it "skips" do
         expect(skip_conditions.skip_information(formulae[:deprecated]))


### PR DESCRIPTION
- Check OS and architecture variants before skipping disabled packages so `bump` and `livecheck` work independently of the host platform.
- Use the same check in `bump-formula-pr` to allow formula updates.

Fixes #23846

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Codex with GPT 6 Astra at Extra High effort, with local review and testing.

-----