### PR TITLE
cmd/cache: print cask cache paths for Linux platforms

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -722,14 +722,15 @@ module Cask
       end
     end
 
-    private
-
-    sig { params(bottle_tag: ::Utils::Bottles::Tag).returns(T::Boolean) }
-    def platform_supported?(bottle_tag)
-      return false if bottle_tag.linux? && !supports_linux?
-      return false if bottle_tag.macos? && !supports_macos?
+    sig { params(bottle_tag: ::Utils::Bottles::Tag, installable: T::Boolean).returns(T::Boolean) }
+    def platform_supported?(bottle_tag, installable: true)
+      if bottle_tag.linux?
+        return false unless supports_linux?
+      else
+        return false unless supports_macos?
+      end
       return false if version.blank? || sha256.blank? || url.blank?
-      return false unless installable_artifact?
+      return false if installable && !installable_artifact?
 
       arch_supported = depends_on.arch&.any? do |arch|
         required_arch = ::Utils::Bottles::Tag.new(system: bottle_tag.system, arch: arch[:type]).standardized_arch
@@ -743,6 +744,8 @@ module Cask
         requirement.allows?(bottle_tag.to_macos_version)
       end
     end
+
+    private
 
     # Returns caveats text for API serialization, excluding conditional
     # built-in caveats that depend on the current machine's state.

--- a/Library/Homebrew/cmd/--cache.rb
+++ b/Library/Homebrew/cmd/--cache.rb
@@ -70,11 +70,23 @@ module Homebrew
               end
             end
           when Cask::Cask
-            os_arch_combinations.each do |os, arch|
-              next if os == :linux
-
-              SimulateSystem.with(os:, arch:) do
-                print_cask_cache(Cask::CaskLoader.load(ref))
+            combinations = os_arch_combinations
+            host = [SimulateSystem.current_os, SimulateSystem.current_arch]
+            if formula_or_cask.loaded_from_api? && combinations != [host]
+              opoo "Cask #{formula_or_cask} was loaded from the API; only showing the cache file for the " \
+                   "current platform. Set `HOMEBREW_NO_INSTALL_FROM_API=1` to show others."
+              combinations &= [host]
+            end
+            combinations.each do |os, arch|
+              tag = Utils::Bottles::Tag.new(system: os, arch:)
+              # Source loads may lack an installable artifact, e.g. naked containers.
+              supported = formula_or_cask.refresh_for_tag(tag) do
+                formula_or_cask.platform_supported?(tag, installable: formula_or_cask.loaded_from_api?)
+              end
+              if supported
+                print_cask_cache(formula_or_cask)
+              else
+                opoo "Cask #{formula_or_cask} is not supported on os #{os} and arch #{arch}"
               end
             end
           end

--- a/Library/Homebrew/test/cmd/--cache_spec.rb
+++ b/Library/Homebrew/test/cmd/--cache_spec.rb
@@ -13,13 +13,65 @@ RSpec.describe Homebrew::Cmd::Cache do
       .and not_to_output.to_stderr
   end
 
-  it "prints the cache files for a given Cask", :cask do
+  it "prints the cache files for a given Cask" do
     expect { described_class.new(["--cask", cask_path("local-caffeine").to_s]).run }
       .to output(%r{#{HOMEBREW_CACHE}/downloads/[\da-f]{64}--caffeine\.zip}o).to_stdout
       .and not_to_output.to_stderr
   end
 
-  it "prints the cache files for a given Formula and Cask", :integration_test, :needs_macos do
+  it "prints the cache file for a source Cask without an installable artifact" do
+    expect { described_class.new(["--cask", cask_path("naked-executable").to_s]).run }
+      .to output(%r{#{HOMEBREW_CACHE}/downloads/[\da-f]{64}--naked_executable\n}o).to_stdout
+      .and not_to_output.to_stderr
+  end
+
+  it "prints the cache file for a given Cask on the given operating system" do
+    expect { described_class.new(["--cask", "--os=linux", cask_path("on-linux-blocks").to_s]).run }
+      .to output(%r{#{HOMEBREW_CACHE}/downloads/[\da-f]{64}--caffeine-linux\.zip}o).to_stdout
+      .and not_to_output.to_stderr
+  end
+
+  it "warns for a given Cask that does not support the given operating system" do
+    expect do
+      described_class.new(["--cask", "--os=linux", "--arch=arm", cask_path("with-depends-on-macos-bare").to_s]).run
+    end
+      .to output("Warning: Cask with-depends-on-macos-bare is not supported on os linux and arch arm\n").to_stderr
+      .and not_to_output.to_stdout
+  end
+
+  it "warns for a given Cask that does not support the given architecture" do
+    expect { described_class.new(["--cask", "--arch=intel", cask_path("depends-on-arch-arm64").to_s]).run }
+      .to output(/is not supported on os \w+ and arch intel\n/).to_stderr
+      .and not_to_output.to_stdout
+  end
+
+  it "warns for a Linux-only Cask with `--os=macos`" do
+    expect do
+      described_class.new(["--cask", "--os=macos", "--arch=arm", cask_path("with-depends-on-linux-bare").to_s]).run
+    end
+      .to output(/is not supported on os macos and arch arm\n/).to_stderr
+      .and not_to_output.to_stdout
+  end
+
+  it "only shows the current platform for a Cask loaded from the API" do
+    api_cask = Cask::Cask.new("api-cask", loaded_from_api: true) do
+      version "1.2.3"
+      sha256 "67cdb8a4a4d0e4f5f8c1f0b3b7f1c4d8e2a6b9c0d1e2f3a4b5c6d7e8f9a0b1c2"
+      url "https://brew.sh/api-cask-1.2.3.zip"
+      app "Api.app"
+    end
+    allow(Cask::CaskLoader).to receive(:load).and_return(api_cask)
+
+    expect do
+      Homebrew::SimulateSystem.with(os: :sequoia, arch: :arm) do
+        described_class.new(["--cask", "--os=all", "api-cask"]).run
+      end
+    end
+      .to output(%r{\A#{HOMEBREW_CACHE}/downloads/[\da-f]{64}--api-cask-1\.2\.3\.zip\n\z}o).to_stdout
+      .and output(/\AWarning: Cask api-cask was loaded from the API; only showing .*\n\z/).to_stderr
+  end
+
+  it "prints the cache files for a given Formula and Cask", :integration_test do
     expect { brew "--cache", testball, cask_path("local-caffeine") }
       .to output(
         %r{


### PR DESCRIPTION
- `brew --cache` skipped every Linux combination for casks, so `--os=linux` printed nothing and `--os=all` never showed Linux paths even for casks with an `on_linux` block or an AppImage.
- Evaluate each OS and arch with `refresh_for_tag` and decide with `platform_supported?`, which already covers `depends_on macos:`, `depends_on arch:` and blank `url`/`sha256`, so `--cache` and `fetch` agree on what a cask supports.
- Warn with the same wording as `brew fetch` for Formulas
- Make `Cask#platform_supported?` public


Reproduce on `main`:

`brew --cache --cask --os=linux actual` => prints nothing, exit 0

With this change it prints the `Actual-linux-arm64.AppImage` cache path.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Claude Code (Fable 5.1) drafted the change and the spec. I reviewed the diff, ran `brew lgtm` on macOS and exercised the command on a Fedora 44 container against `HEAD`.