### PR TITLE
Show red ⊘ for packages that can't be installed

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -268,6 +268,16 @@ module Cask
       !depends_on.requires_linux?
     end
 
+    # True if this cask can be installed on this platform.
+    sig { returns(T::Boolean) }
+    def valid_platform?
+      if Homebrew::SimulateSystem.simulating_or_running_on_macos?
+        supports_macos?
+      else
+        supports_linux?
+      end
+    end
+
     sig { returns(T::Boolean) }
     def uninstall_flight_blocks?
       artifacts.any? do |artifact|

--- a/Library/Homebrew/cask/info.rb
+++ b/Library/Homebrew/cask/info.rb
@@ -54,10 +54,11 @@ module Cask
       name_with_status = pretty_install_status(
         cask.token,
         installed:,
-        outdated:   installed && cask.outdated?,
-        deprecated: cask.deprecated?,
-        disabled:   cask.disabled?,
-        bold:       true,
+        outdated:    installed && cask.outdated?,
+        deprecated:  cask.deprecated?,
+        disabled:    cask.disabled?,
+        can_install: cask.valid_platform? && !cask.disabled?,
+        bold:        true,
       )
       title = oh1_title(name_with_status).to_s
       title += " (#{cask.name.join(", ")})" unless cask.name.empty?

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -458,12 +458,13 @@ module Homebrew
         end
         name_with_status = pretty_install_status(
           title_name,
-          warning:    missing_libraries.present?,
+          warning:     missing_libraries.present?,
           installed:,
           outdated:,
-          deprecated: formula.deprecated?,
-          disabled:   formula.disabled?,
-          bold:       true,
+          deprecated:  formula.deprecated?,
+          disabled:    formula.disabled?,
+          can_install: formula.valid_platform? && !formula.disabled?,
+          bold:        true,
         )
 
         puts "#{oh1_title(name_with_status)}: #{specs * ", "}#{" [#{attrs * ", "}]" unless attrs.empty?}"
@@ -873,11 +874,11 @@ module Homebrew
         end.join(", ")
       end
 
-      sig { params(requirements: T::Array[Requirement], mark_uninstalled: T::Boolean).returns(String) }
-      def decorate_requirements(requirements, mark_uninstalled: true)
+      sig { params(requirements: T::Array[Requirement]).returns(String) }
+      def decorate_requirements(requirements)
         req_status = requirements.map do |req|
           req_s = req.display_s
-          pretty_install_status(req_s, installed: req.satisfied?, mark_uninstalled:, bold: true)
+          pretty_install_status(req_s, installed: req.satisfied?, mark_uninstalled: true, bold: true)
         end
         req_status.join(", ")
       end

--- a/Library/Homebrew/cmd/tap-info.rb
+++ b/Library/Homebrew/cmd/tap-info.rb
@@ -128,6 +128,7 @@ module Homebrew
           outdated:         installed && formula.outdated?,
           deprecated:       formula.deprecated?,
           disabled:         formula.disabled?,
+          can_install:      formula.valid_platform? && !formula.disabled?,
           mark_uninstalled: false,
         )
       rescue
@@ -143,6 +144,7 @@ module Homebrew
           outdated:         installed && cask.outdated?,
           deprecated:       cask.deprecated?,
           disabled:         cask.disabled?,
+          can_install:      cask.valid_platform? && !cask.disabled?,
           mark_uninstalled: false,
         )
       rescue

--- a/Library/Homebrew/test/cask/info_spec.rb
+++ b/Library/Homebrew/test/cask/info_spec.rb
@@ -12,7 +12,11 @@ RSpec.describe Cask::Info, :cask do
   include Utils::Output::Mixin
 
   def uninstalled(string)
-    "#{Tty.bold}#{string} #{Formatter.error("✘")}#{Tty.reset}"
+    "#{Tty.bold}#{string}#{Tty.reset}"
+  end
+
+  def cannot_install(string)
+    "#{Tty.bold}#{string} #{Formatter.error("⊘")}#{Tty.reset}"
   end
 
   def installed(string)
@@ -88,7 +92,7 @@ RSpec.describe Cask::Info, :cask do
     expect do
       described_class.info(Cask::CaskLoader.load(cask_path("livecheck/livecheck-disabled")), args:)
     end.to output(
-      /#{Regexp.escape(uninstalled("livecheck-disabled"))} #{Regexp.escape(Formatter.error("(disabled)"))}/,
+      /#{Regexp.escape(cannot_install("livecheck-disabled"))} #{Regexp.escape(Formatter.error("(disabled)"))}/,
     ).to_stdout
   end
 

--- a/Library/Homebrew/test/cmd/tap-info_spec.rb
+++ b/Library/Homebrew/test/cmd/tap-info_spec.rb
@@ -111,31 +111,68 @@ RSpec.describe Homebrew::Cmd::TapInfo do
     end
 
     it "marks an installed formula as satisfied" do
-      formula = instance_double(Formula, outdated?: false, deprecated?: false, disabled?: false)
+      formula = instance_double(
+        Formula,
+        outdated?:       false,
+        deprecated?:     false,
+        disabled?:       false,
+        valid_platform?: true,
+      )
       allow(Formulary).to receive(:factory).with("homebrew/foo/installed").and_return(formula)
 
       expect(tap_info.decorate_formula(tap, "installed", installed: true)).to match(/installed.*✔/)
     end
 
     it "marks an outdated installed formula as upgradable" do
-      formula = instance_double(Formula, outdated?: true, deprecated?: false, disabled?: false)
+      formula = instance_double(
+        Formula,
+        outdated?:       true,
+        deprecated?:     false,
+        disabled?:       false,
+        valid_platform?: true,
+      )
       allow(Formulary).to receive(:factory).with("homebrew/foo/outdated").and_return(formula)
 
       expect(tap_info.decorate_formula(tap, "outdated", installed: true)).to match(/outdated.*↑/)
     end
 
     it "marks a deprecated formula with `(deprecated)`" do
-      formula = instance_double(Formula, outdated?: false, deprecated?: true, disabled?: false)
+      formula = instance_double(
+        Formula,
+        outdated?:       false,
+        deprecated?:     true,
+        disabled?:       false,
+        valid_platform?: true,
+      )
       allow(Formulary).to receive(:factory).with("homebrew/foo/old").and_return(formula)
 
       expect(tap_info.decorate_formula(tap, "old", installed: false)).to match(/old.*\(deprecated\)/)
     end
 
-    it "marks a disabled formula with `(disabled)`" do
-      formula = instance_double(Formula, outdated?: false, deprecated?: false, disabled?: true)
+    it "marks a disabled formula with `(disabled)` and ⊘" do
+      formula = instance_double(
+        Formula,
+        outdated?:       false,
+        deprecated?:     false,
+        disabled?:       true,
+        valid_platform?: true,
+      )
       allow(Formulary).to receive(:factory).with("homebrew/foo/gone").and_return(formula)
 
-      expect(tap_info.decorate_formula(tap, "gone", installed: false)).to match(/gone.*\(disabled\)/)
+      expect(tap_info.decorate_formula(tap, "gone", installed: false)).to match(/gone.*⊘.*\(disabled\)/)
+    end
+
+    it "marks a formula that cannot be installed on this platform with ⊘" do
+      formula = instance_double(
+        Formula,
+        outdated?:       false,
+        deprecated?:     false,
+        disabled?:       false,
+        valid_platform?: false,
+      )
+      allow(Formulary).to receive(:factory).with("homebrew/foo/incompatible").and_return(formula)
+
+      expect(tap_info.decorate_formula(tap, "incompatible", installed: false)).to match(/incompatible.*⊘/)
     end
   end
 
@@ -153,31 +190,68 @@ RSpec.describe Homebrew::Cmd::TapInfo do
     end
 
     it "marks an installed cask as satisfied" do
-      cask = instance_double(Cask::Cask, outdated?: false, deprecated?: false, disabled?: false)
+      cask = instance_double(
+        Cask::Cask,
+        outdated?:       false,
+        deprecated?:     false,
+        disabled?:       false,
+        valid_platform?: true,
+      )
       allow(Cask::CaskLoader).to receive(:load).with("homebrew/foo/installed").and_return(cask)
 
       expect(tap_info.decorate_cask(tap, "installed", installed: true)).to match(/installed.*✔/)
     end
 
     it "marks an outdated installed cask as upgradable" do
-      cask = instance_double(Cask::Cask, outdated?: true, deprecated?: false, disabled?: false)
+      cask = instance_double(
+        Cask::Cask,
+        outdated?:       true,
+        deprecated?:     false,
+        disabled?:       false,
+        valid_platform?: true,
+      )
       allow(Cask::CaskLoader).to receive(:load).with("homebrew/foo/outdated").and_return(cask)
 
       expect(tap_info.decorate_cask(tap, "outdated", installed: true)).to match(/outdated.*↑/)
     end
 
     it "marks a deprecated cask with `(deprecated)`" do
-      cask = instance_double(Cask::Cask, outdated?: false, deprecated?: true, disabled?: false)
+      cask = instance_double(
+        Cask::Cask,
+        outdated?:       false,
+        deprecated?:     true,
+        disabled?:       false,
+        valid_platform?: true,
+      )
       allow(Cask::CaskLoader).to receive(:load).with("homebrew/foo/old").and_return(cask)
 
       expect(tap_info.decorate_cask(tap, "old", installed: false)).to match(/old.*\(deprecated\)/)
     end
 
-    it "marks a disabled cask with `(disabled)`" do
-      cask = instance_double(Cask::Cask, outdated?: false, deprecated?: false, disabled?: true)
+    it "marks a disabled cask with `(disabled)` and ⊘" do
+      cask = instance_double(
+        Cask::Cask,
+        outdated?:       false,
+        deprecated?:     false,
+        disabled?:       true,
+        valid_platform?: true,
+      )
       allow(Cask::CaskLoader).to receive(:load).with("homebrew/foo/gone").and_return(cask)
 
-      expect(tap_info.decorate_cask(tap, "gone", installed: false)).to match(/gone.*\(disabled\)/)
+      expect(tap_info.decorate_cask(tap, "gone", installed: false)).to match(/gone.*⊘.*\(disabled\)/)
+    end
+
+    it "marks a cask that cannot be installed on this platform with ⊘" do
+      cask = instance_double(
+        Cask::Cask,
+        outdated?:       false,
+        deprecated?:     false,
+        disabled?:       false,
+        valid_platform?: false,
+      )
+      allow(Cask::CaskLoader).to receive(:load).with("homebrew/foo/incompatible").and_return(cask)
+
+      expect(tap_info.decorate_cask(tap, "incompatible", installed: false)).to match(/incompatible.*⊘/)
     end
   end
 
@@ -203,22 +277,24 @@ RSpec.describe Homebrew::Cmd::TapInfo do
       before do
         allow(Formula).to receive(:installed_formula_names).and_return(["foo"])
         allow(Cask::Caskroom).to receive(:tokens).and_return(["bar"])
-        allow(Formulary).to receive(:factory).with("homebrew/foo/foo")
-                                             .and_return(instance_double(Formula, outdated?:   false,
-                                                                                  deprecated?: false,
-                                                                                  disabled?:   false))
-        allow(Formulary).to receive(:factory).with("homebrew/foo/uninstalled-formula")
-                                             .and_return(instance_double(Formula, outdated?:   false,
-                                                                                  deprecated?: false,
-                                                                                  disabled?:   false))
-        allow(Cask::CaskLoader).to receive(:load).with("homebrew/foo/bar")
-                                                 .and_return(instance_double(Cask::Cask, outdated?:   false,
-                                                                                         deprecated?: false,
-                                                                                         disabled?:   false))
-        allow(Cask::CaskLoader).to receive(:load).with("homebrew/foo/uninstalled-cask")
-                                                 .and_return(instance_double(Cask::Cask, outdated?:   false,
-                                                                                         deprecated?: false,
-                                                                                         disabled?:   false))
+        formula = instance_double(
+          Formula,
+          outdated?:       false,
+          deprecated?:     false,
+          disabled?:       false,
+          valid_platform?: true,
+        )
+        cask = instance_double(
+          Cask::Cask,
+          outdated?:       false,
+          deprecated?:     false,
+          disabled?:       false,
+          valid_platform?: true,
+        )
+        allow(Formulary).to receive(:factory).with("homebrew/foo/foo").and_return(formula)
+        allow(Formulary).to receive(:factory).with("homebrew/foo/uninstalled-formula").and_return(formula)
+        allow(Cask::CaskLoader).to receive(:load).with("homebrew/foo/bar").and_return(cask)
+        allow(Cask::CaskLoader).to receive(:load).with("homebrew/foo/uninstalled-cask").and_return(cask)
       end
 
       it "lists every formula and cask, marking only the installed ones" do
@@ -246,10 +322,14 @@ RSpec.describe Homebrew::Cmd::TapInfo do
       before do
         allow(Formula).to receive(:installed_formula_names).and_return(["formula7"])
         allow(Cask::Caskroom).to receive(:tokens).and_return([])
-        allow(Formulary).to receive(:factory).with("homebrew/foo/formula7")
-                                             .and_return(instance_double(Formula, outdated?:   false,
-                                                                                  deprecated?: false,
-                                                                                  disabled?:   false))
+        formula7 = instance_double(
+          Formula,
+          outdated?:       false,
+          deprecated?:     false,
+          disabled?:       false,
+          valid_platform?: true,
+        )
+        allow(Formulary).to receive(:factory).with("homebrew/foo/formula7").and_return(formula7)
       end
 
       it "warns about truncation and shows only installed entries under the standard header" do

--- a/Library/Homebrew/test/search_spec.rb
+++ b/Library/Homebrew/test/search_spec.rb
@@ -92,6 +92,11 @@ RSpec.describe Homebrew::Search do
       expect(described_class.search_formulae(/testball/)).to contain_exactly(include("(disabled)"))
     end
 
+    it "does not show a red cross for disabled formulae" do
+      allow(formula).to receive(:disabled?).and_return(true)
+      expect(described_class.search_formulae(/testball/).join(" ")).not_to include("#{Tty.red}✘")
+    end
+
     it "does not annotate normal formulae" do
       expect(described_class.search_formulae(/testball/)).to eq(["testball"])
     end
@@ -127,6 +132,11 @@ RSpec.describe Homebrew::Search do
     it "annotates disabled casks", :needs_macos do
       allow(cask).to receive(:disabled?).and_return(true)
       expect(described_class.search_casks(/testball/)).to contain_exactly(include("(disabled)"))
+    end
+
+    it "does not show a red cross for disabled casks", :needs_macos do
+      allow(cask).to receive(:disabled?).and_return(true)
+      expect(described_class.search_casks(/testball/).join(" ")).not_to include("#{Tty.red}✘")
     end
 
     it "does not annotate normal casks", :needs_macos do

--- a/Library/Homebrew/test/utils/output_spec.rb
+++ b/Library/Homebrew/test/utils/output_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Utils::Output do
       before { allow($stdout).to receive(:tty?).and_return(true) }
 
       context "with HOMEBREW_NO_EMOJI unset" do
-        it "returns a string with a colored checkmark" do
+        it "returns a string with a red cross" do
           expect(pretty_uninstalled_output)
             .to match(/#{esc 1}foo #{esc 31}✘#{esc 0}/)
         end
@@ -91,6 +91,38 @@ RSpec.describe Utils::Output do
 
       it "returns plain text" do
         expect(pretty_uninstalled_output).to eq("foo")
+      end
+    end
+  end
+
+  describe "#pretty_cannot_install" do
+    subject(:pretty_cannot_install_output) { described_class.pretty_cannot_install("foo") }
+
+    context "when $stdout is a TTY" do
+      before { allow($stdout).to receive(:tty?).and_return(true) }
+
+      context "with HOMEBREW_NO_EMOJI unset" do
+        it "returns a string with a red ⊘ symbol" do
+          expect(pretty_cannot_install_output)
+            .to match(/#{esc 1}foo #{esc 31}⊘#{esc 0}/)
+        end
+      end
+
+      context "with HOMEBREW_NO_EMOJI set" do
+        before { ENV["HOMEBREW_NO_EMOJI"] = "1" }
+
+        it "returns a string with colored info" do
+          expect(pretty_cannot_install_output)
+            .to match(/#{esc 1}foo \(can't be installed\)#{esc 0}/)
+        end
+      end
+    end
+
+    context "when $stdout is not a TTY" do
+      before { allow($stdout).to receive(:tty?).and_return(false) }
+
+      it "returns plain text" do
+        expect(pretty_cannot_install_output).to eq("foo")
       end
     end
   end
@@ -133,6 +165,36 @@ RSpec.describe Utils::Output do
     it "omits the bold escape on every entry when bold is false" do
       expect(described_class.pretty_install_status("foo", installed: true, outdated: true, bold: false))
         .to match(/\Afoo #{esc 32}↑#{esc 0}/)
+    end
+
+    it "marks an uninstalled entry expected to be installed with a red cross" do
+      expect(described_class.pretty_install_status("foo", installed: false, mark_uninstalled: true))
+        .to match(/\Afoo #{esc 31}✘#{esc 0}\z/)
+    end
+
+    it "annotates an uninstalled disabled entry with `(disabled)`" do
+      expect(described_class.pretty_install_status("foo", installed: false, disabled: true, mark_uninstalled: false))
+        .to match(/\Afoo #{esc 31}\(disabled\)#{esc 0}\z/)
+    end
+
+    it "marks an uninstalled entry that cannot be installed with a red ⊘" do
+      expect(described_class.pretty_install_status("foo", installed: false, can_install: false))
+        .to match(/\Afoo #{esc 31}⊘#{esc 0}\z/)
+    end
+
+    it "marks a disabled uninstalled entry that cannot be installed with ⊘ and (disabled)" do
+      status = described_class.pretty_install_status(
+        "foo",
+        installed:   false,
+        disabled:    true,
+        can_install: false,
+      )
+      expect(status).to match(/\Afoo #{esc 31}⊘#{esc 0} #{esc 31}\(disabled\)#{esc 0}\z/)
+    end
+
+    it "keeps a disabled installed entry marked as installed" do
+      expect(described_class.pretty_install_status("foo", installed: true, disabled: true))
+        .to match(/foo #{esc 32}✔#{esc 0} #{esc 31}\(disabled\)#{esc 0}\z/)
     end
   end
 

--- a/Library/Homebrew/utils/output.rb
+++ b/Library/Homebrew/utils/output.rb
@@ -288,6 +288,18 @@ module Utils
         end
       end
 
+      sig { params(string: String, bold: T::Boolean).returns(String) }
+      def pretty_cannot_install(string, bold: true)
+        weight = bold ? Tty.bold.to_s : ""
+        if !$stdout.tty?
+          string
+        elsif Homebrew::EnvConfig.no_emoji?
+          Formatter.error("#{weight}#{string} (can't be installed)#{Tty.reset}")
+        else
+          "#{weight}#{string} #{Formatter.error("⊘")}#{Tty.reset}"
+        end
+      end
+
       # Keep status labels, colours and emoji in sync with
       # `pretty_uninstalled` in Library/Homebrew/utils.sh.
       sig { params(string: String, bold: T::Boolean).returns(String) }
@@ -325,11 +337,12 @@ module Utils
 
       sig {
         params(string: String, installed: T::Boolean, warning: T::Boolean, outdated: T::Boolean,
-               deprecated: T::Boolean, disabled: T::Boolean, mark_uninstalled: T::Boolean,
-               bold: T.nilable(T::Boolean)).returns(String)
+               deprecated: T::Boolean, disabled: T::Boolean, can_install: T::Boolean,
+               mark_uninstalled: T::Boolean, bold: T.nilable(T::Boolean)).returns(String)
       }
       def pretty_install_status(string, installed:, warning: false, outdated: false, deprecated: false,
-                                disabled: false, mark_uninstalled: true, bold: nil)
+                                disabled: false, can_install: true, mark_uninstalled: false,
+                                bold: nil)
         bold = installed if bold.nil?
         status = if warning
           pretty_warning(string, bold:)
@@ -337,6 +350,8 @@ module Utils
           pretty_upgradable(string, bold:)
         elsif installed
           pretty_installed(string)
+        elsif !can_install
+          pretty_cannot_install(string, bold:)
         elsif mark_uninstalled
           pretty_uninstalled(string, bold:)
         else


### PR DESCRIPTION
- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Cline (Claude) was used to implement and test these changes, I iterated on changes and checked output.

-----

## What do these changes do?

They split the ✘ shown for uninstalled packages into two cases:

- White ✘ (rather than red) for packages that are simply not currently installed.
- Red ✘ for packages that can't be installed, i.e. disabled packages and packages with a macOS/Linux platform mismatch. A package that is already installed keeps ✔ even if it is now disabled.

## Why are these changes needed?

It is useful to distinguish "I don't have this installed" from "I cannot install this", e.g. when browsing `brew tap-info` listings or inspecting a disabled formula or a cask that does not support the current platform.