### PR TITLE
formula: improve typing conflicts_with

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -4816,7 +4816,7 @@ class Formula
     # @api public
     # @param names formulae that conflict
     # @param because reason for conflict
-    # @param cask token of cask that conflicts. Not implemented.
+    # @param cask token of cask that conflicts. Accepted but currently ignored.
     sig { params(names: String, because: T.nilable(String), cask: T.nilable(String)).void }
     def conflicts_with(*names, because: nil, cask: nil)
       raise ArgumentError, "`conflicts_with` needs at least one formula or cask" if names.empty? && cask.nil?

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -107,7 +107,10 @@ class Formula
   abstract!
 
   # Used to track formulae that cannot be installed at the same time.
-  FormulaConflict = Struct.new(:name, :reason)
+  class FormulaConflict < T::Struct
+    const :name, String
+    const :reason, T.nilable(String)
+  end
 
   SUPPORTED_NETWORK_ACCESS_PHASES = [:build, :test, :postinstall].freeze
   private_constant :SUPPORTED_NETWORK_ACCESS_PHASES
@@ -4811,10 +4814,14 @@ class Formula
     # ```
     #
     # @api public
-    sig { params(names: T.untyped).void }
-    def conflicts_with(*names)
-      opts = T.let(names.last.is_a?(Hash) ? names.pop : {}, T::Hash[Symbol, T.untyped])
-      names.each { |name| conflicts << FormulaConflict.new(name, opts[:because]) }
+    # @param names formulae that conflict
+    # @param because reason for conflict
+    # @param cask token of cask that conflicts. Not implemented.
+    sig { params(names: String, because: T.nilable(String), cask: T.nilable(String)).void }
+    def conflicts_with(*names, because: nil, cask: nil)
+      raise ArgumentError, "`conflicts_with` needs at least one formula or cask" if names.empty? && cask.nil?
+
+      names.each { |name| conflicts << FormulaConflict.new(name:, reason: because) }
     end
 
     # Skip cleaning paths in a formula.

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -3330,6 +3330,31 @@ RSpec.describe Formula do
     end
   end
 
+  describe "#conflicts_with" do
+    it "can be given multiple formulae" do
+      klass = Class.new(Formula) do
+        conflicts_with "foo", "bar", "baz", because: "some reason"
+      end
+      expect(klass.conflicts.map(&:name)).to eq %w[foo bar baz]
+      expect(klass.conflicts.map(&:reason)).to eq(["some reason"] * 3)
+    end
+
+    it "can be given a cask and ignores it" do
+      klass = Class.new(Formula) do
+        conflicts_with cask: "foo"
+      end
+      expect(klass.conflicts).to be_empty
+    end
+
+    it "raises an error when not given a formula or cask" do
+      expect do
+        Class.new(Formula) do
+          conflicts_with because: "some reason"
+        end
+      end.to raise_error(ArgumentError, /needs at least one formula or cask/)
+    end
+  end
+
   describe "#preserve_rpath" do
     it "defaults to false" do
       f = formula do

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -3335,8 +3335,7 @@ RSpec.describe Formula do
       klass = Class.new(Formula) do
         conflicts_with "foo", "bar", "baz", because: "some reason"
       end
-      expect(klass.conflicts.map(&:name)).to eq %w[foo bar baz]
-      expect(klass.conflicts.map(&:reason)).to eq(["some reason"] * 3)
+      expect(klass.conflicts.map { |c| [c.name, c.reason] }).to eq(%w[foo bar baz].zip(["some reason"] * 3))
     end
 
     it "can be given a cask and ignores it" do


### PR DESCRIPTION
Sorbet is able to track types better using T::Struct and by replacing T.untyped splat with explicit typed parameters.

Also clarify that `conflicts_with cask:` is allowed DSL but has no functional impact. Historic, unimplemented pair to partly removed Cask `conflicts_with formula:`.

On Cask side, we ended up replacing above with automatically skipping link so could consider this on Formula side too.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

n/a

-----
