### PR TITLE
Preserve resource evidence for overrides

### DIFF
--- a/Library/Homebrew/test/vulns/match_spec.rb
+++ b/Library/Homebrew/test/vulns/match_spec.rb
@@ -165,6 +165,32 @@ RSpec.describe Homebrew::Vulns::Match do
       expect(matcher.range_status(hit)).to be_nil
     end
 
+    it "uses resolved resource evidence for a fixed override of an unknown aggregate" do
+      overrides = Homebrew::Vulns::AdvisoryOverrides.new({
+        "requests" => { "advisories" => {
+          "CVE-1" => { "range_state" => "fixed" },
+        } },
+      })
+      overridden = described_class.new(repology:, cpan_sec:, overrides:)
+      v = vuln("id" => "CVE-1", "affected" => [
+        { "package" => { "ecosystem" => "GIT", "name" => "https://github.com/psf/requests" },
+          "ranges"  => [{ "type" => "GIT", "events" => [{ "fixed" => "e47e56d" }] }] },
+        { "package" => { "ecosystem" => "PyPI", "name" => "certifi" },
+          "ranges"  => [{ "type"   => "ECOSYSTEM",
+                          "events" => [{ "introduced" => "0" }, { "fixed" => "2024.1.0" }] }] },
+      ])
+      hit = make_hit(v,
+                     ev(:git, ecosystem: "GIT", name: "https://github.com/psf/requests",
+                              subject_version: "2.31.0", key: "https://github.com/psf/requests"),
+                     ev(:registry, ecosystem: "PyPI", name: "certifi", subject_version: "2024.2.2",
+                                   key: "pkg:pypi/certifi@2024.2.2", resource: "certifi"))
+
+      status, evidence = overridden.range_status(hit, formula_name: "requests") ||
+                         raise("expected the reviewed override to resolve the range")
+      expect([status.state, status.fixed_in, evidence.resource, evidence.key])
+        .to eq [:fixed, "2024.1.0", "certifi", "pkg:pypi/certifi@2024.2.2"]
+    end
+
     it "returns the registry-entry status when GIT ranges are uncomparable" do
       v = vuln("id" => "CVE-1", "affected" => [
         { "package" => { "ecosystem" => "GIT", "name" => "https://github.com/jqlang/jq" },

--- a/Library/Homebrew/vulns/match.rb
+++ b/Library/Homebrew/vulns/match.rb
@@ -485,7 +485,9 @@ module Homebrew
         override = @overrides&.advisory_override(formula_name, hit.identifiers) if formula_name
         return selected unless override
 
-        status, evidence = selected || [nil, hit.primary_evidence]
+        status, evidence = selected ||
+                           (results.find { |candidate, _| candidate.state == override.state } if override.state) ||
+                           [nil, hit.primary_evidence]
         state = override.state || status&.state
         return selected unless state
 


### PR DESCRIPTION
After Homebrew/brew#23830 kept unknown subjects unresolved, [the next Ingest run](https://github.com/Homebrew/advisory-database/actions/runs/34045558545) failed because 33 tracked ansible and node records became uncomparable: each has a fixed `ansible-core` or `npm` resource beside a subject that cannot be compared, the Git repository for `ansible` and `node` or the PyPI `ansible` identity added during distro resolution for `ansible@9` through `ansible@13`. A reviewed `range_state: fixed` override resolves that ambiguity, but `range_status` attached it to the primary evidence, so the record lost its `resource`, `resource_purl` and the inherited upstream fix version.

When an override names a state and the aggregate is unresolved, pick the evidence whose own result already has that state before falling back to primary evidence. A fixed override on an unknown aggregate therefore keeps the fixed resource, its purl and its upstream fix, while an override with no supporting evidence still attaches to primary evidence as before. Overrides without a `range_state` are unchanged. The advisory-database overrides land after this.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Fable 5.1) drafted the implementation and tests; I reviewed the diff, verified the new test fails without the change and passes with it, and ran `brew lgtm --online` plus a live `brew advisory-match` run for the six affected formulae.

-----
