### PR TITLE
Load legacy bottles from formula history

### DIFF
--- a/Library/Homebrew/bottle_specification.rb
+++ b/Library/Homebrew/bottle_specification.rb
@@ -6,6 +6,28 @@ require "utils/output"
 class BottleSpecification
   include Utils::Output::Mixin
 
+  LEGACY_SYNTAX_KEY = :homebrew_legacy_bottle_syntax
+  private_constant :LEGACY_SYNTAX_KEY
+
+  sig {
+    type_parameters(:U)
+      .params(_block: T.proc.returns(T.type_parameter(:U)))
+      .returns(T.type_parameter(:U))
+  }
+  def self.with_legacy_syntax(&_block)
+    thread = Thread.current
+    previous = thread.thread_variable_get(LEGACY_SYNTAX_KEY)
+    thread.thread_variable_set(LEGACY_SYNTAX_KEY, true)
+    yield
+  ensure
+    thread&.thread_variable_set(LEGACY_SYNTAX_KEY, previous)
+  end
+
+  sig { returns(T::Boolean) }
+  def self.legacy_syntax?
+    Thread.current.thread_variable_get(LEGACY_SYNTAX_KEY) == true
+  end
+
   # Relocatable cellar using placeholders, e.g. `@@HOMEBREW_PREFIX@@`.
   # Requires relocating text files and binaries.
   ANY_CELLAR = :any
@@ -35,6 +57,7 @@ class BottleSpecification
     @collector = T.let(Utils::Bottles::Collector.new, Utils::Bottles::Collector)
     @root_url_specs = T.let({}, T::Hash[Symbol, T.untyped])
     @root_url = T.let(nil, T.nilable(String))
+    @legacy_cellar = T.let(nil, T.nilable(T.any(Symbol, String)))
   end
 
   sig { params(val: T.nilable(Integer)).returns(Integer) }
@@ -133,22 +156,36 @@ class BottleSpecification
   def sha256(hash)
     sha256_regex = /^[a-f0-9]{64}$/i
 
-    # find new `sha256 big_sur: "69489ae397e4645..."` format
-    tag, digest = hash.find do |key, value|
-      # Don't use `odie` in this case. We want to be able to catch this exception
-      # in runtime when getting committed version info in formula auditor
-      raise LegacyDSLError.new(:sha256, hash) if key.is_a?(String) && key.match?(sha256_regex) && value.is_a?(Symbol)
+    legacy = hash.find do |key, value|
+      key.is_a?(String) && key.match?(sha256_regex) && value.is_a?(Symbol)
+    end
+    if legacy
+      # Historical formula loading needs to cross the 2021 bottle syntax wall,
+      # while current formulae must continue to reject the removed DSL.
+      raise LegacyDSLError.new(:sha256, hash) unless self.class.legacy_syntax?
 
-      key.is_a?(Symbol) && value.is_a?(String) && value.match?(sha256_regex)
+      digest, tag = legacy
+    else
+      # find new `sha256 big_sur: "69489ae397e4645..."` format
+      tag, digest = hash.find do |key, value|
+        key.is_a?(Symbol) && value.is_a?(String) && value.match?(sha256_regex)
+      end
     end
 
     odie "Invalid sha256 hash: #{digest}" if !tag || !digest
 
     tag = Utils::Bottles::Tag.from_symbol(T.cast(tag, Symbol))
 
-    cellar = hash[:cellar] || tag.default_cellar
+    cellar = hash[:cellar] || @legacy_cellar || tag.default_cellar
 
     collector.add(tag, checksum: Checksum.new(digest.to_s), cellar:)
+  end
+
+  sig { params(value: T.any(Symbol, String)).returns(T.any(Symbol, String)) }
+  def cellar(value)
+    raise LegacyDSLError.new(:cellar, value) unless self.class.legacy_syntax?
+
+    @legacy_cellar = value
   end
 
   sig {

--- a/Library/Homebrew/formula_versions.rb
+++ b/Library/Homebrew/formula_versions.rb
@@ -55,7 +55,9 @@ class FormulaVersions
 
     yield @formula_at_revision[revision] ||= begin
       contents = file_contents_at_revision(revision, formula_relative_path)
-      nostdout { Formulary.from_contents(name, path, contents, ignore_errors: true) }
+      BottleSpecification.with_legacy_syntax do
+        nostdout { Formulary.from_contents(name, path, contents, ignore_errors: true) }
+      end
     end
   rescue *IGNORED_EXCEPTIONS => e
     require "utils/backtrace"

--- a/Library/Homebrew/test/bottle_specification_spec.rb
+++ b/Library/Homebrew/test/bottle_specification_spec.rb
@@ -39,6 +39,33 @@ RSpec.describe BottleSpecification do
         expect(checksum[:cellar]).to eq(tag_spec.cellar)
       end
     end
+
+    it "rejects legacy syntax outside historical formula loading" do
+      expect { bottle_spec.sha256(("deadbeef" * 8) => :big_sur) }
+        .to raise_error(LegacyDSLError)
+    end
+
+    it "rejects a legacy cellar outside historical formula loading" do
+      expect { bottle_spec.cellar(:any) }.to raise_error(LegacyDSLError)
+    end
+
+    it "restores legacy syntax rejection after the compatibility scope" do
+      digest = "deadbeef" * 8
+      described_class.with_legacy_syntax do
+        bottle_spec.cellar(:any)
+        bottle_spec.sha256(digest => :big_sur)
+      end
+
+      expect { described_class.new.sha256(digest => :big_sur) }
+        .to raise_error(LegacyDSLError)
+    end
+
+    it "restores legacy syntax rejection when the compatibility scope raises" do
+      expect { described_class.with_legacy_syntax { raise "boom" } }.to raise_error(RuntimeError, "boom")
+
+      expect { described_class.new.sha256(("deadbeef" * 8) => :big_sur) }
+        .to raise_error(LegacyDSLError)
+    end
   end
 
   describe "#compatible_locations?" do

--- a/Library/Homebrew/test/formula_versions_spec.rb
+++ b/Library/Homebrew/test/formula_versions_spec.rb
@@ -1,0 +1,34 @@
+# typed: true
+# frozen_string_literal: true
+
+require "formula_versions"
+
+RSpec.describe FormulaVersions do
+  it "loads historical formulae that use legacy bottle syntax" do
+    current = formula("legacy-bottle") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/legacy-bottle-2.0.tar.gz"
+    end
+    versions = described_class.new(current)
+    digest = "a" * 64
+    contents = <<~RUBY
+      class LegacyBottle < Formula
+        url "https://brew.sh/legacy-bottle-1.0.tar.gz"
+
+        bottle do
+          cellar :any_skip_relocation
+          sha256 "#{digest}" => :big_sur
+        end
+      end
+    RUBY
+    allow(versions).to receive(:file_contents_at_revision).and_return(contents)
+
+    result = versions.formula_at_revision("abc123") do |historical|
+      tag = Utils::Bottles::Tag.from_symbol(:big_sur)
+      tag_spec = historical.bottle_specification.tag_specification_for(tag)
+      [historical.pkg_version.to_s, tag_spec&.checksum&.hexdigest, tag_spec&.cellar]
+    end
+
+    expect(result).to eq ["1.0", digest, :any_skip_relocation]
+  end
+end


### PR DESCRIPTION
`FormulaVersions` loads historical formula revisions with the current DSL, so every bottled homebrew-core revision before the February 2021 bottle syntax change (`cellar :any` and `sha256 "..." => :tag`) raises and is skipped. The `brew advisory-match` history walks stop at that wall and skip candidates as history unavailable even when the fix landed years earlier; on the local core clone only 103 of 184 httpie revisions, 43 of 181 wget and 201 of 398 curl revisions load.

`BottleSpecification` now parses the legacy checksum and `cellar` DSL only inside `BottleSpecification.with_legacy_syntax`, which `FormulaVersions#formula_at_revision` wraps around `Formulary.from_contents`. The flag is a thread variable so it is visible inside the `Ignorable` fiber that evaluates the formula and is restored on exit, including on exceptions; normal formula loading keeps rejecting the removed syntax with `LegacyDSLError`. With this, 165 of 184 httpie, 116 of 181 wget and 356 of 398 curl revisions load; the remaining unreadable revisions use `devel do`, `revision` inside `bottle do` or `prefix` and still fail closed.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Fable 5.1) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the change and pass with it, and ran `brew lgtm` plus targeted specs and a load census over the local homebrew-core history.

-----
