### PR TITLE
Harden advisory history walks

### DIFF
--- a/Library/Homebrew/dev-cmd/advisory-match.rb
+++ b/Library/Homebrew/dev-cmd/advisory-match.rb
@@ -114,6 +114,7 @@ module Homebrew
                   when :never_affected
                     next
                   when :history_unavailable
+                    emitter.record_history_unavailable(formula.name)
                     opoo "#{record_id}: formula history is unavailable; skipping automatic update"
                     next
                   else
@@ -240,6 +241,9 @@ module Homebrew
         sig { void }
         def record_history_walk; end
 
+        sig { params(_formula_name: String).void }
+        def record_history_unavailable(_formula_name); end
+
         sig { params(_record_id: String).returns(T.nilable(Symbol)) }
         def reviewed_range_state(_record_id); end
 
@@ -265,6 +269,7 @@ module Homebrew
           @unchanged = T.let(0, Integer)
           @skipped_generated = T.let(0, Integer)
           @history_walks = T.let(0, Integer)
+          @history_unavailable_by_formula = T.let({}, T::Hash[String, Integer])
           @alias_targets = T.let({}, T::Hash[String, T::Array[String]])
           @protected_aliases = T.let({}, T::Hash[String, T::Boolean])
           @alias_records = T.let({}, T::Hash[String, T.untyped])
@@ -466,6 +471,12 @@ module Homebrew
           puts "  #{@history_walks} history walks" if @verbose && (@history_walks % 100).zero?
         end
 
+        sig { override.params(formula_name: String).void }
+        def record_history_unavailable(formula_name)
+          count = @history_unavailable_by_formula.fetch(formula_name, 0)
+          @history_unavailable_by_formula[formula_name] = count + 1
+        end
+
         sig { params(record_id: String).returns(String) }
         def record_path(record_id)
           File.join(@dir, "#{record_id}.json")
@@ -574,9 +585,14 @@ module Homebrew
 
         sig { override.void }
         def finish
+          history_unavailable = @history_unavailable_by_formula.values.sum
           Utils::Output.ohai "#{@written} records written to #{@dir} " \
                              "(#{@unchanged} unchanged, #{@skipped_generated} generated left as-is, " \
-                             "#{@history_walks} history walks)"
+                             "#{@history_walks} history walks, #{history_unavailable} history-unavailable skips)"
+          return if @history_unavailable_by_formula.empty?
+
+          puts "  Unavailable history by formula:"
+          @history_unavailable_by_formula.sort.each { |formula, count| puts "    #{formula}: #{count}" }
         end
       end
 

--- a/Library/Homebrew/dev-cmd/generate-vulns-advisories.rb
+++ b/Library/Homebrew/dev-cmd/generate-vulns-advisories.rb
@@ -4,7 +4,7 @@
 require "api/env"
 require "abstract_command"
 require "formula"
-require "formula_versions"
+require "vulns/history"
 require "vulns/osv_export"
 
 module Homebrew
@@ -80,12 +80,14 @@ module Homebrew
         (base + variation_patches.flatten(1)).uniq
       end
 
-      # Walk homebrew-core git history (newest first) via {FormulaVersions} and
-      # return the `pkg_version` at the oldest revision where `vuln_id` still
-      # appears in the formula's resolved patch ids: the version at which the
-      # fix first shipped. Revisions that fail to load (older DSL) end the walk
-      # early. Only invoked for records with no existing file, so the cost is
-      # bounded to newly annotated (formula, CVE) pairs.
+      # Walk homebrew-core git history (newest first) via
+      # {Homebrew::Vulns::History} and return the `pkg_version` at the oldest
+      # revision where `vuln_id` still appears in the formula's resolved patch
+      # ids: the version at which the fix first shipped. Untrusted history (a
+      # shallow clone, no git history or a revision that fails to load) returns
+      # `:history_unavailable` so the caller skips the record rather than
+      # inventing a boundary. Only invoked for records with no existing file,
+      # so the cost is bounded to newly annotated (formula, CVE) pairs.
       #
       # Because `resolved_ids` includes CVEs inferred from patch URLs and
       # `apply` file paths, this finds the true fix version when the CVE is
@@ -100,30 +102,28 @@ module Homebrew
       # {FormulaVersions} caches by revision alone, so per-variation historical
       # loading would need separate instances; deferred until a variation-only
       # security annotation actually exists in core.
-      sig { params(formula: Formula, vuln_id: String).returns(T.nilable(String)) }
+      sig { params(formula: Formula, vuln_id: String).returns(T.any(String, Symbol)) }
       def first_fixed_version(formula, vuln_id)
-        # `FormulaVersions#rev_list` shells out to path-filtered `git rev-list`
-        # over the whole homebrew-core history and dominates runtime; cache it
-        # (and the instance, for its per-revision formula memoisation) per
-        # formula so subsequent CVEs for the same formula reuse both.
-        @formula_versions ||= T.let({}, T.nilable(T::Hash[String, FormulaVersions]))
-        @formula_rev_lists ||= T.let({}, T.nilable(T::Hash[String, T::Array[[String, String]]]))
-        fv = @formula_versions[formula.name] ||= FormulaVersions.new(formula)
-        revs = @formula_rev_lists[formula.name] ||=
-          [].tap { |a| fv.rev_list("HEAD") { |rev, entry| a << [rev, entry] } }
+        # The path-filtered `git rev-list` over the whole homebrew-core history
+        # dominates runtime; {Homebrew::Vulns::History} caches it per formula
+        # so subsequent CVEs for the same formula reuse it.
+        @history ||= T.let(Homebrew::Vulns::History.new, T.nilable(Homebrew::Vulns::History))
 
-        last_fixed = T.let(nil, T.nilable(String))
-        revs.each do |rev, entry|
-          resolved_here = fv.formula_at_revision(rev, entry) do |old|
-            Homebrew::Vulns::Scanner.resolved_ids(old.serialized_patches).include?(vuln_id)
-          end
-          # `nil` means the revision failed to load; stop rather than guess.
-          return last_fixed if resolved_here.nil?
-          return last_fixed unless resolved_here
+        last_fixed = T.let(formula.pkg_version.to_s, String)
+        result = @history.walk(formula) do |old|
+          next last_fixed unless Homebrew::Vulns::Scanner.resolved_ids(old.serialized_patches).include?(vuln_id)
 
-          last_fixed = fv.formula_at_revision(rev, entry) { |old| old.pkg_version.to_s }
+          last_fixed = old.pkg_version.to_s
+          nil
         end
-        last_fixed
+        if result == :history_unavailable
+          record_id = Homebrew::Vulns::OsvExport.record_id(formula, vuln_id)
+          opoo "#{record_id}: formula history is unavailable; skipping automatic generation"
+          return :history_unavailable
+        end
+
+        # An exhausted walk means every revision resolved the CVE.
+        result || last_fixed
       end
     end
   end

--- a/Library/Homebrew/test/dev-cmd/advisory-match_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/advisory-match_spec.rb
@@ -529,9 +529,24 @@ RSpec.describe Homebrew::DevCmd::AdvisoryMatch do
     allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
 
     Dir.mktmpdir do |dir|
-      expect { cmd_for("requests", "--output", dir, "--new-history").run }
-        .to output(/formula history is unavailable; skipping automatic update/).to_stderr
+      expect do
+        expect { cmd_for("requests", "--output", dir, "--new-history").run }
+          .to output(/formula history is unavailable; skipping automatic update/).to_stderr
+      end.to output(/1 history-unavailable skips.*Unavailable history by formula:\n    requests: 1/m).to_stdout
       expect(Dir.glob(File.join(dir, "*.json"))).to be_empty
+    end
+  end
+
+  it "summarises unavailable history deterministically by formula" do
+    Dir.mktmpdir do |dir|
+      emitter = Homebrew::DevCmd::AdvisoryMatch::DirEmitter.new(dir, verbose: false, close_open_ranges: false)
+      emitter.record_history_unavailable("requests")
+      emitter.record_history_unavailable("curl")
+      emitter.record_history_unavailable("requests")
+
+      expect { emitter.finish }
+        .to output(/3 history-unavailable skips.*Unavailable history by formula:\n    curl: 1\n    requests: 2/m)
+        .to_stdout
     end
   end
 

--- a/Library/Homebrew/test/dev-cmd/generate-vulns-advisories_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-vulns-advisories_spec.rb
@@ -34,7 +34,10 @@ RSpec.describe Homebrew::DevCmd::GenerateVulnsAdvisories do
     allow(Formulary).to receive(:factory).with("nvi").and_return(nvi)
     allow(Formulary).to receive(:factory).with("plain").and_return(plain)
     allow(Homebrew::Vulns::OSV).to receive(:vulnerability).and_return({})
-    allow(FormulaVersions).to receive(:new).and_return(instance_double(FormulaVersions, rev_list: nil))
+    fv = instance_double(FormulaVersions)
+    allow(fv).to receive(:rev_list).and_yield("r1", "Formula/n/nvi.rb")
+    allow(fv).to receive(:formula_at_revision).and_yield(nvi)
+    allow(FormulaVersions).to receive(:new).and_return(fv)
 
     Dir.mktmpdir do |dir|
       out = "#{dir}/advisories"
@@ -152,24 +155,36 @@ RSpec.describe Homebrew::DevCmd::GenerateVulnsAdvisories do
       expect(cmd.first_fixed_version(current, "CVE-2024-1")).to eq "1.0"
     end
 
-    it "stops at an unloadable revision and returns the last known resolved version" do
+    it "returns :history_unavailable when a revision cannot be loaded" do
       with_history(
         "r3" => old_formula(pkg_version: "1.2", resolves_ids: ["CVE-2024-1"]),
         "r2" => nil,
         "r1" => old_formula(pkg_version: "1.0", resolves_ids: ["CVE-2024-1"]),
       )
 
-      expect(cmd.first_fixed_version(current, "CVE-2024-1")).to eq "1.2"
+      expect(cmd.first_fixed_version(current, "CVE-2024-1")).to eq :history_unavailable
     end
 
-    it "returns nil when the CVE is not resolved at the newest revision" do
+    it "returns the current pkg_version when the CVE is not resolved at the newest revision" do
       with_history(
         "r2" => old_formula(pkg_version: "1.2", resolves_ids: []),
         # Trap: if the walk continued past r2 it would wrongly return 1.0.
         "r1" => old_formula(pkg_version: "1.0", resolves_ids: ["CVE-2024-1"]),
       )
 
-      expect(cmd.first_fixed_version(current, "CVE-2024-1")).to be_nil
+      expect(cmd.first_fixed_version(current, "CVE-2024-1")).to eq "1.2"
+    end
+
+    it "returns :history_unavailable for a shallow tap" do
+      allow(current.tap!).to receive(:shallow?).and_return(true)
+
+      expect(cmd.first_fixed_version(current, "CVE-2024-1")).to eq :history_unavailable
+    end
+
+    it "returns :history_unavailable when the formula has no git history" do
+      with_history({})
+
+      expect(cmd.first_fixed_version(current, "CVE-2024-1")).to eq :history_unavailable
     end
   end
 end

--- a/Library/Homebrew/test/vulns/history_spec.rb
+++ b/Library/Homebrew/test/vulns/history_spec.rb
@@ -1,0 +1,71 @@
+# typed: true
+# frozen_string_literal: true
+
+require "vulns/history"
+
+RSpec.describe Homebrew::Vulns::History do
+  subject(:history) { described_class.new }
+
+  let(:requests) do
+    formula("requests") do
+      T.bind(self, T.class_of(Formula))
+      url "https://files.pythonhosted.org/packages/aa/bb/cc/requests-2.31.0.tar.gz"
+    end
+  end
+  let(:formula_versions) { instance_double(FormulaVersions) }
+
+  before do
+    allow(FormulaVersions).to receive(:new).and_return(formula_versions)
+  end
+
+  it "returns :history_unavailable for a shallow tap" do
+    allow(requests.tap!).to receive(:shallow?).and_return(true)
+
+    expect(history.walk(requests) { :stop }).to eq :history_unavailable
+  end
+
+  it "returns :history_unavailable when the formula has no git history" do
+    allow(formula_versions).to receive(:rev_list)
+
+    expect(history.walk(requests) { :stop }).to eq :history_unavailable
+  end
+
+  it "returns :history_unavailable when a revision cannot be loaded" do
+    allow(formula_versions).to receive(:rev_list).and_yield("r0", "Formula/r/requests.rb")
+    allow(formula_versions).to receive(:formula_at_revision).and_return(nil)
+
+    expect(history.walk(requests) { nil }).to eq :history_unavailable
+  end
+
+  it "stops at the first result the block returns" do
+    allow(formula_versions).to receive(:rev_list)
+      .and_yield("r0", "Formula/r/requests.rb")
+      .and_yield("r1", "Formula/r/requests.rb")
+      .and_yield("r2", "Formula/r/requests.rb")
+    allow(formula_versions).to receive(:formula_at_revision).and_yield(requests)
+    visited = T.let(0, Integer)
+
+    result = history.walk(requests) do |_old|
+      visited += 1
+      "2.31.0" if visited == 2
+    end
+
+    expect([result, visited]).to eq ["2.31.0", 2]
+  end
+
+  it "returns nil after visiting every revision" do
+    allow(formula_versions).to receive(:rev_list)
+      .and_yield("r0", "Formula/r/requests.rb")
+      .and_yield("r1", "Formula/r/requests.rb")
+    allow(formula_versions).to receive(:formula_at_revision).and_yield(requests)
+
+    expect(history.walk(requests) { nil }).to be_nil
+  end
+
+  it "reuses the rev-list for later walks of the same formula" do
+    expect(formula_versions).to receive(:rev_list).once.and_yield("r0", "Formula/r/requests.rb")
+    allow(formula_versions).to receive(:formula_at_revision).and_yield(requests)
+
+    2.times { history.walk(requests) { nil } }
+  end
+end

--- a/Library/Homebrew/test/vulns/match_spec.rb
+++ b/Library/Homebrew/test/vulns/match_spec.rb
@@ -786,6 +786,27 @@ RSpec.describe Homebrew::Vulns::Match do
       expect(matcher.first_fixed_version(requests, hit_fixed_at("2.28.1"))).to eq :never_affected
     end
 
+    it "returns :history_unavailable for a shallow formula repository" do
+      allow(requests.tap!).to receive(:shallow?).and_return(true)
+      stub_history(["2.31.0"])
+
+      expect(matcher.first_fixed_version(requests, hit_fixed_at("2.28.1"))).to eq :history_unavailable
+    end
+
+    it "does not derive a reintroduction from a shallow formula repository" do
+      allow(requests.tap!).to receive(:shallow?).and_return(true)
+      stub_history(["2.31.0", "2.30.0"])
+      allow(matcher).to receive(:aggregate_state_at).and_return(:affected, :fixed)
+
+      expect(matcher.first_reintroduced_version(requests, hit_fixed_at("2.32.0"))).to eq :not_reintroduced
+    end
+
+    it "returns :history_unavailable when the formula has no git history" do
+      stub_history([])
+
+      expect(matcher.first_fixed_version(requests, hit_fixed_at("2.28.1"))).to eq :history_unavailable
+    end
+
     it "keeps Git history uncheckable across repository URL changes" do
       current = formula("requests") do
         T.bind(self, T.class_of(Formula))
@@ -914,6 +935,68 @@ RSpec.describe Homebrew::Vulns::Match do
       )
 
       expect(matcher.first_fixed_version(current, hit)).to eq "2.0"
+    end
+
+    it "does not inherit the formula version when a verified package URL has no version" do
+      current = formula("requests") do
+        T.bind(self, T.class_of(Formula))
+        url "https://files.pythonhosted.org/packages/aa/bb/cc/requests-3.0.tar.gz"
+        resource("certifi") do
+          url "https://files.pythonhosted.org/packages/11/22/33/certifi-2.0.tar.gz"
+        end
+      end
+      historical = formula("requests") do
+        T.bind(self, T.class_of(Formula))
+        url "https://files.pythonhosted.org/packages/aa/bb/cc/requests-2.0.tar.gz"
+        resource("certifi") do
+          url "https://files.pythonhosted.org/packages/11/22/33/certifi-.tar.gz"
+        end
+      end
+      fv = instance_double(FormulaVersions)
+      allow(fv).to receive(:rev_list).and_yield("r0", "Formula/r/requests.rb")
+      allow(fv).to receive(:formula_at_revision).with("r0", anything).and_yield(historical)
+      allow(FormulaVersions).to receive(:new).and_return(fv)
+      hit = make_hit(
+        vuln("id" => "CVE-1", "affected" => [
+          { "package" => { "ecosystem" => "PyPI", "name" => "certifi" },
+            "ranges"  => [{ "type"   => "ECOSYSTEM",
+                            "events" => [{ "introduced" => "0" }, { "fixed" => "1.5" }] }] },
+        ]),
+        ev(:registry, ecosystem: "PyPI", name: "certifi", subject_version: "2.0", resource: "certifi"),
+      )
+
+      expect(matcher.first_fixed_version(current, hit)).to eq :history_unavailable
+    end
+
+    it "does not inherit package identity from a matching resource label" do
+      current = formula("requests") do
+        T.bind(self, T.class_of(Formula))
+        url "https://files.pythonhosted.org/packages/aa/bb/cc/requests-3.0.tar.gz"
+        resource("certifi") do
+          url "https://files.pythonhosted.org/packages/11/22/33/certifi-2.0.tar.gz"
+        end
+      end
+      historical = formula("requests") do
+        T.bind(self, T.class_of(Formula))
+        url "https://files.pythonhosted.org/packages/aa/bb/cc/requests-2.0.tar.gz"
+        resource("certifi") do
+          url "https://example.com/certifi-1.0.tar.gz"
+        end
+      end
+      fv = instance_double(FormulaVersions)
+      allow(fv).to receive(:rev_list).and_yield("r0", "Formula/r/requests.rb")
+      allow(fv).to receive(:formula_at_revision).with("r0", anything).and_yield(historical)
+      allow(FormulaVersions).to receive(:new).and_return(fv)
+      hit = make_hit(
+        vuln("id" => "CVE-1", "affected" => [
+          { "package" => { "ecosystem" => "PyPI", "name" => "certifi" },
+            "ranges"  => [{ "type"   => "ECOSYSTEM",
+                            "events" => [{ "introduced" => "0" }, { "fixed" => "1.5" }] }] },
+        ]),
+        ev(:registry, ecosystem: "PyPI", name: "certifi", subject_version: "2.0", resource: "certifi"),
+      )
+
+      expect(matcher.first_fixed_version(current, hit)).to eq :history_unavailable
     end
 
     it "keeps versionless (distro) evidence uncheckable at historical revisions too" do

--- a/Library/Homebrew/test/vulns/osv_export_spec.rb
+++ b/Library/Homebrew/test/vulns/osv_export_spec.rb
@@ -491,6 +491,32 @@ RSpec.describe Homebrew::Vulns::OsvExport do
       end
     end
 
+    it "skips a new record when formula history is unavailable" do
+      allow(Homebrew::Vulns::OSV).to receive(:vulnerability).and_return({})
+
+      Dir.mktmpdir do |dir|
+        written = described_class.run(
+          [[nvi, nvi.serialized_patches]], dir,
+          first_fixed: ->(_f, _id) { :history_unavailable }, now:
+        )
+
+        expect([written, Dir.children(dir)]).to eq [[], []]
+      end
+    end
+
+    it "rejects an unknown first-fixed result" do
+      allow(Homebrew::Vulns::OSV).to receive(:vulnerability).and_return({})
+
+      Dir.mktmpdir do |dir|
+        expect do
+          described_class.run(
+            [[nvi, nvi.serialized_patches]], dir,
+            first_fixed: ->(_f, _id) { :future_result }, now:
+          )
+        end.to raise_error(TypeError, /unexpected first-fixed result: :future_result/)
+      end
+    end
+
     it "fetches each upstream vuln id once, even when shared across formulae" do
       shared = [{ "url"      => "https://example.com/fix.patch",
                   "resolves" => [{ "type" => "security", "id" => "CVE-2024-9999" }] }]

--- a/Library/Homebrew/vulns/history.rb
+++ b/Library/Homebrew/vulns/history.rb
@@ -1,0 +1,53 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "formula_versions"
+
+module Homebrew
+  module Vulns
+    # Walks a formula's tap history newest first via {FormulaVersions}, caching
+    # the rev-list and the per-revision loads per formula so every advisory for
+    # the same formula reuses them.
+    #
+    # History that cannot be trusted fails closed: a shallow clone, a formula
+    # file with no git history and a revision that cannot be loaded all end the
+    # walk with `:history_unavailable` so callers skip the candidate rather
+    # than inventing a boundary.
+    class History
+      sig { void }
+      def initialize
+        @formula_versions = T.let({}, T::Hash[String, FormulaVersions])
+        @rev_lists = T.let({}, T::Hash[String, T::Array[[String, String]]])
+      end
+
+      # Yield each loadable historical revision of `formula`, newest first,
+      # until the block returns a result. Returns that result,
+      # `:history_unavailable` when the history cannot be trusted or `nil` once
+      # every revision has been visited.
+      sig {
+        params(formula: Formula,
+               _block:  T.proc.params(old: Formula).returns(T.nilable(T.any(String, Symbol))))
+          .returns(T.nilable(T.any(String, Symbol)))
+      }
+      def walk(formula, &_block)
+        return :history_unavailable if formula.tap!.shallow?
+
+        fv = @formula_versions[formula.name] ||= FormulaVersions.new(formula)
+        revs = @rev_lists[formula.name] ||=
+          [].tap { |a| fv.rev_list("HEAD") { |rev, entry| a << [rev, entry] } }
+        return :history_unavailable if revs.empty?
+
+        revs.each do |rev, entry|
+          # Wrap the verdict so keeping the walk going (`nil`) stays
+          # distinguishable from a revision that failed to load.
+          verdict = fv.formula_at_revision(rev, entry) { |old| [yield(old)] }
+          return :history_unavailable if verdict.nil?
+
+          result = verdict.fetch(0)
+          return result unless result.nil?
+        end
+        nil
+      end
+    end
+  end
+end

--- a/Library/Homebrew/vulns/match.rb
+++ b/Library/Homebrew/vulns/match.rb
@@ -6,6 +6,7 @@ require "utils/output"
 require "formula_versions"
 require "vulns/advisory_overrides"
 require "vulns/cpan_sec"
+require "vulns/history"
 require "vulns/identify"
 require "vulns/osv"
 require "vulns/osv_export"
@@ -128,8 +129,7 @@ module Homebrew
         @overrides = overrides
         @bulk = bulk
         @vuln_cache = T.let({}, T::Hash[String, T.nilable(Vulnerability)])
-        @formula_versions = T.let({}, T::Hash[String, FormulaVersions])
-        @formula_rev_lists = T.let({}, T::Hash[String, T::Array[[String, String]]])
+        @history = T.let(History.new, History)
       end
 
       sig { returns(Repology) }
@@ -609,13 +609,13 @@ module Homebrew
         }
       end
 
-      # Walk homebrew-core git history (newest first) via {FormulaVersions} and
-      # return the `pkg_version` at the oldest revision where the aggregate of
-      # every checkable subject is still `:fixed`. Re-running the full
-      # per-evidence range check with each revision's subject versions keeps
-      # `last_affected` and exclusive-bound semantics intact and stops as soon
-      # as any subject (primary or a resource) drops back into `:affected`, so
-      # a primary fixed at 2.0 with a resource fixed at 3.0 yields 3.0.
+      # Walk homebrew-core git history (newest first) via {History} and return
+      # the `pkg_version` at the oldest revision where the aggregate of every
+      # checkable subject is still `:fixed`. Re-running the full per-evidence
+      # range check with each revision's subject versions keeps `last_affected`
+      # and exclusive-bound semantics intact and stops as soon as any subject
+      # (primary or a resource) drops back into `:affected`, so a primary fixed
+      # at 2.0 with a resource fixed at 3.0 yields 3.0.
       #
       # Returns:
       # - `nil` when the current aggregate is not `:fixed`.
@@ -624,41 +624,28 @@ module Homebrew
       #   i.e. Homebrew jumped from a version below `introduced` straight past
       #   `fixed` and never shipped an affected build. The caller drops the
       #   candidate rather than emitting `{introduced: "0", fixed: <first>}`.
-      # - `:history_unavailable` when a revision cannot be loaded or compared,
-      #   so the caller can skip the candidate rather than inventing a boundary.
+      # - `:history_unavailable` when the tap is a shallow clone, the formula
+      #   has no git history or a revision cannot be loaded or compared, so the
+      #   caller can skip the candidate rather than inventing a boundary.
       # - a `pkg_version` String when the walk hits `:affected`.
-      #
-      # The rev-list and per-revision loads are cached per formula.
       sig { params(formula: Formula, hit: Hit).returns(T.nilable(T.any(String, Symbol))) }
       def first_fixed_version(formula, hit)
         return unless range_status(hit, formula_name: formula.name)&.first&.fixed?
 
-        fv = @formula_versions[formula.name] ||= FormulaVersions.new(formula)
-        revs = @formula_rev_lists[formula.name] ||=
-          [].tap { |a| fv.rev_list("HEAD") { |rev, entry| a << [rev, entry] } }
-
         last_fixed = T.let(formula.pkg_version.to_s, String)
-        revs.each do |rev, entry|
-          state = fv.formula_at_revision(rev, entry) do |old|
-            [aggregate_state_at(old, hit), old.pkg_version.to_s]
-          end
-          return :history_unavailable if state.nil?
-
-          aggregate, pkg_version = state
+        result = @history.walk(formula) do |old|
+          aggregate = aggregate_state_at(old, hit)
           case aggregate
           when :fixed
-            last_fixed = pkg_version
-          when :affected
-            return last_fixed
-          when :not_applicable
-            return :never_affected
-          when nil
-            return :history_unavailable
-          else
-            raise TypeError, "unexpected historical aggregate: #{aggregate.inspect}"
+            last_fixed = old.pkg_version.to_s
+            nil
+          when :affected then last_fixed
+          when :not_applicable then :never_affected
+          when nil then :history_unavailable
+          else raise TypeError, "unexpected historical aggregate: #{aggregate.inspect}"
           end
         end
-        :never_affected
+        result || :never_affected
       end
 
       # Return the lowest representable formula `pkg_version` in the newest
@@ -669,43 +656,41 @@ module Homebrew
       # history is checked so the new interval cannot cover a known
       # non-affected formula version.
       # `:not_reintroduced` means no prior non-affected revision was verified,
-      # either because all loadable history remained affected or because a
-      # revision could not be loaded or compared safely.
+      # either because all loadable history remained affected, the tap is a
+      # shallow clone, the formula has no git history or a revision could not
+      # be loaded or compared safely.
       sig { params(formula: Formula, hit: Hit).returns(T.nilable(T.any(String, Symbol))) }
       def first_reintroduced_version(formula, hit)
         return unless range_status(hit, formula_name: formula.name)&.first&.affected?
 
-        fv = @formula_versions[formula.name] ||= FormulaVersions.new(formula)
-        revs = @formula_rev_lists[formula.name] ||=
-          [].tap { |a| fv.rev_list("HEAD") { |rev, entry| a << [rev, entry] } }
-
         first_affected = T.let(formula.pkg_version.to_s, String)
         transition_found = T.let(false, T::Boolean)
-        revs.each do |rev, entry|
-          state = fv.formula_at_revision(rev, entry) do |old|
-            [aggregate_state_at(old, hit), old.pkg_version.to_s]
-          end
-          return :not_reintroduced if state.nil?
+        result = @history.walk(formula) do |old|
+          aggregate = aggregate_state_at(old, hit)
+          next :not_reintroduced if aggregate.nil?
 
-          aggregate, pkg_version = state
-          return :not_reintroduced if aggregate.nil?
-
+          pkg_version = old.pkg_version.to_s
           begin
             historical = PkgVersion.parse(pkg_version)
             boundary = PkgVersion.parse(first_affected)
             if transition_found
-              return :not_reintroduced if aggregate != :affected && historical >= boundary
+              next :not_reintroduced if aggregate != :affected && historical >= boundary
             elsif aggregate == :affected
               first_affected = pkg_version if historical < boundary
             else
-              return :not_reintroduced if historical >= boundary
+              next :not_reintroduced if historical >= boundary
 
               transition_found = true
             end
           rescue ArgumentError
-            return :not_reintroduced
+            next :not_reintroduced
           end
+          nil
         end
+        # Every early result is fail-closed: untrusted history, an uncomparable
+        # revision or a known non-affected version above the boundary.
+        return :not_reintroduced unless result.nil?
+
         transition_found ? first_affected : :not_reintroduced
       end
 
@@ -765,11 +750,17 @@ module Homebrew
         end
 
         exact_resource = formula.resources.find { |resource| resource.name == evidence.resource }
+        exact_identity_unknown = T.let(false, T::Boolean)
         if exact_resource
           exact_package = Identify.registry_package(exact_resource.url)
-          return [true, exact_resource.version&.to_s] unless exact_package
-          return [true, exact_package.version] if exact_package.ecosystem == evidence.ecosystem &&
-                                                  exact_package.name == evidence.name
+          if exact_package.nil?
+            # A reused resource label is not enough to prove package identity.
+            # Search the remaining resources in case the package was renamed,
+            # then leave this revision uncheckable if no identity can be found.
+            exact_identity_unknown = true
+          elsif exact_package.ecosystem == evidence.ecosystem && exact_package.name == evidence.name
+            return [true, exact_package.version]
+          end
         end
 
         formula.resources.each do |resource|
@@ -781,6 +772,8 @@ module Homebrew
 
           return [true, package.version]
         end
+
+        return [true, nil] if exact_identity_unknown
 
         [false, nil]
       end

--- a/Library/Homebrew/vulns/osv_export.rb
+++ b/Library/Homebrew/vulns/osv_export.rb
@@ -46,12 +46,14 @@ module Homebrew
       #
       # `first_fixed`, when given, is called `(formula, vuln_id) -> String?` for
       # records with no existing file to derive an accurate `fixed` boundary
-      # (e.g. via {FormulaVersions} git history); existing records preserve
-      # their on-disk `ranges` regardless.
+      # (e.g. via {FormulaVersions} git history). It may return
+      # `:history_unavailable` to skip a new record when no boundary can be
+      # verified; existing records preserve their on-disk `ranges` regardless.
       sig {
         params(annotated:   T::Array[[Formula, T::Array[T::Hash[String, T.untyped]]]],
                dir:         T.any(String, Pathname),
-               first_fixed: T.nilable(T.proc.params(formula: Formula, vuln_id: String).returns(T.nilable(String))),
+               first_fixed: T.nilable(T.proc.params(formula: Formula, vuln_id: String)
+                                         .returns(T.nilable(T.any(String, Symbol)))),
                now:         Time)
           .returns(T::Array[String])
       }
@@ -69,7 +71,18 @@ module Homebrew
             # from an existing enriched record; leave it untouched instead.
             next if upstream == :failed && existing
 
-            fixed = (first_fixed&.call(formula, vuln_id) unless existing) || formula.pkg_version.to_s
+            fixed_result = T.let(nil, T.nilable(T.any(String, Symbol)))
+            fixed_result = first_fixed.call(formula, vuln_id) if first_fixed && !existing
+            fixed = case fixed_result
+            when String
+              fixed_result
+            when nil
+              formula.pkg_version.to_s
+            when :history_unavailable
+              next
+            else
+              raise TypeError, "unexpected first-fixed result: #{fixed_result.inspect}"
+            end
             record = record_for(formula, vuln_id, patches:, fixed:,
                                 upstream: upstream.is_a?(Hash) ? upstream : nil, now:)
             merged = merge_existing(path, record)


### PR DESCRIPTION
`brew advisory-match` and `brew generate-vulns-advisories` walk homebrew-core history to find the version that first shipped a fix. #23845 made the matcher skip candidates whose history cannot be read, but three gaps remained: the generator still returned the last loadable version at an unreadable revision, both walks treated the end of a truncated rev-list (a shallow clone or a formula with no git history) as the start of history and could turn it into `:never_affected` or a graft version, and a historical resource with a reused label inherited the formula's own version through `SoftwareSpec#owner=` and was compared against the wrong package.

This moves the walk into a shared `Homebrew::Vulns::History` used by both commands. It returns `:history_unavailable` for a shallow tap, an empty rev-list or an unloadable revision and keeps the per-formula rev-list cache. The generator skips such records with a warning while `OsvExport.run` leaves existing records untouched and rejects unknown results. Historical resource identity is now proven by the registry URL: a reused label with an unidentifiable URL searches the other resources for the renamed package and is otherwise uncheckable, and a verified package with no version in its URL is uncheckable rather than falling back to the resource version. `--output` runs summarize history-unavailable skips per formula at completion; `--json` output is unchanged.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Fable 5.1) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the change and pass with it, and ran `brew lgtm` plus targeted specs.

-----
