### PR TITLE
Detect shallow taps through linked worktrees

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -165,6 +165,11 @@ read_current_revision() {
   git rev-parse -q --verify HEAD
 }
 
+# Keep in sync with `GitRepository#shallow?` in `git_repository.rb`.
+shallow_repository() {
+  [[ -d "$1" && "$(git -C "$1" rev-parse --is-shallow-repository 2>/dev/null)" == "true" ]]
+}
+
 pop_stash() {
   [[ -z "${STASHED}" ]] && return
   if [[ -n "${HOMEBREW_VERBOSE}" ]]
@@ -611,8 +616,8 @@ EOS
     setup_git
   fi
 
-  [[ -f "${HOMEBREW_CORE_REPOSITORY}/.git/shallow" ]] && HOMEBREW_CORE_SHALLOW=1
-  [[ -f "${HOMEBREW_CASK_REPOSITORY}/.git/shallow" ]] && HOMEBREW_CASK_SHALLOW=1
+  shallow_repository "${HOMEBREW_CORE_REPOSITORY}" && HOMEBREW_CORE_SHALLOW=1
+  shallow_repository "${HOMEBREW_CASK_REPOSITORY}" && HOMEBREW_CASK_SHALLOW=1
   if [[ -n "${HOMEBREW_CORE_SHALLOW}" && -n "${HOMEBREW_CASK_SHALLOW}" ]]
   then
     SHALLOW_COMMAND_PHRASE="These commands"

--- a/Library/Homebrew/git_repository.rb
+++ b/Library/Homebrew/git_repository.rb
@@ -20,6 +20,15 @@ class GitRepository
     pathname.join(".git").exist?
   end
 
+  # Check whether this repository is a shallow clone. A linked worktree keeps
+  # the shallow marker in the shared Git directory, so ask Git rather than
+  # looking for `.git/shallow`.
+  # Keep in sync with `shallow_repository` in `cmd/update.sh`.
+  sig { returns(T::Boolean) }
+  def shallow?
+    popen_git("rev-parse", "--is-shallow-repository") == "true"
+  end
+
   # Gets the URL of the Git origin remote.
   sig { returns(T.nilable(String)) }
   def origin_url

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -521,7 +521,7 @@ class Tap
   # Check whether this {Tap} is a shallow clone.
   sig { returns(T::Boolean) }
   def shallow?
-    (path/".git/shallow").exist?
+    git_repository.shallow?
   end
 
   sig { overridable.returns(T::Boolean) }

--- a/Library/Homebrew/test/cmd/update_spec.rb
+++ b/Library/Homebrew/test/cmd/update_spec.rb
@@ -36,6 +36,42 @@ RSpec.describe Homebrew::Cmd::Update do
     end
   end
 
+  it "detects shallow clones and their linked worktrees but not full clones" do
+    setup_update_utils
+    FileUtils.ln_s repository_root/"Library/Homebrew/shims", test_root/"Library/Homebrew/shims"
+    repositories = test_root/"repositories"
+
+    stdout, stderr, status = run_update_shell(
+      <<~SH,
+        source "#{update_script}"
+        git() {
+          "#{Utils::Git.git}" -c init.defaultBranch=main -c user.name=Homebrew \\
+            -c user.email=homebrew@example.com "$@"
+        }
+        mkdir -p "#{repositories}" && cd "#{repositories}"
+        git init -q remote
+        git -C remote commit -q --allow-empty -m init
+        git clone -q remote full
+        git clone -q --depth 1 "file://#{repositories}/remote" shallow
+        git -C shallow worktree add -q --detach "#{repositories}/shallow-worktree"
+        for repository in full shallow shallow-worktree missing
+        do
+          if shallow_repository "#{repositories}/${repository}"
+          then
+            echo "${repository}: shallow"
+          else
+            echo "${repository}: full"
+          fi
+        done
+      SH
+      { "HOMEBREW_LIBRARY" => (test_root/"Library").to_s },
+    )
+
+    expect([status.success?, stdout]).to eq(
+      [true, "full: full\nshallow: shallow\nshallow-worktree: shallow\nmissing: full\n"],
+    ), stderr
+  end
+
   it "retries a failed conditional API download without the time condition" do
     cache_path = test_root/"cache/api/formula.jws.json"
     requests_file = test_root/"requests.txt"

--- a/Library/Homebrew/test/git_repository_spec.rb
+++ b/Library/Homebrew/test/git_repository_spec.rb
@@ -50,6 +50,24 @@ RSpec.describe GitRepository do
     end
   end
 
+  describe "#shallow?" do
+    let(:shallow_path) { repo_root/"shallow" }
+    let(:worktree_path) { repo_root/"shallow-worktree" }
+
+    before do
+      SystemCommand.safe_system Utils::Git.git, "clone", "--depth", "1", "file://#{remote_path}", shallow_path
+      SystemCommand.safe_system Utils::Git.git, "-C", shallow_path, "worktree", "add", "--detach", worktree_path
+    end
+
+    it "detects a shallow clone through its linked worktree but not a full clone" do
+      expect([
+        described_class.new(shallow_path).shallow?,
+        described_class.new(worktree_path).shallow?,
+        git_repo.shallow?,
+      ]).to eq [true, true, false]
+    end
+  end
+
   describe "#origin_url" do
     it "reads the origin URL from .git/config without spawning Git" do
       allow(git_repo).to receive(:popen_git).and_raise("Git should not be spawned")


### PR DESCRIPTION
`Tap#shallow?` and `brew update` look for `.git/shallow`, but that marker lives in the shared Git directory. A tap installed as a linked worktree of a shallow clone, which `Tap#install` creates when the Homebrew repository is itself a worktree, therefore reads as a full clone: `brew update` skips its unshallow warning and `brew extract` and the advisory history walks trust truncated history.

Ask Git with `rev-parse --is-shallow-repository` in `GitRepository#shallow?` and in `update.sh`, keeping the two in sync, with a spec covering a shallow clone, its linked worktree and a full clone.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Fable 5.1) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the change and pass with it, and ran `brew lgtm` plus targeted specs.

-----
