### PR TITLE
bundle: install batched casks as casks

### DIFF
--- a/Library/Homebrew/bundle/installer.rb
+++ b/Library/Homebrew/bundle/installer.rb
@@ -285,11 +285,26 @@ module Homebrew
           end
         end
 
-        install_args = []
-        install_args << "--adopt" if !force && actionable.any? { |entry| entry.cls == Cask }
-        install_args.push("--force", "--overwrite") if force
-        batch_succeeded = actionable.empty? || with_env("HOMEBREW_NO_INSTALL_UPGRADE" => nil) do
-          Bundle.brew("install", *install_args, *actionable.map(&:install_name), verbose:)
+        # A bare `brew install` resolves an ambiguous name to the formula, and the type
+        # flags conflict with each other, so each type needs its own invocation.
+        formulae, casks = actionable.partition { |entry| entry.cls == Brew }
+        batches = []
+        if formulae.any?
+          batches << [
+            "--formula",
+            *(["--force", "--overwrite"] if force),
+            *formulae.map(&:install_name),
+          ]
+        end
+        if casks.any?
+          batches << [
+            "--cask",
+            force ? "--force" : "--adopt",
+            *casks.map(&:install_name),
+          ]
+        end
+        batch_succeeded = with_env("HOMEBREW_NO_INSTALL_UPGRADE" => nil) do
+          batches.map { |batch_args| Bundle.brew("install", *batch_args, verbose:) }.all?
         end
 
         # The batch changed what is installed, so the memoised views of it are stale.

--- a/Library/Homebrew/test/bundle/installer_spec.rb
+++ b/Library/Homebrew/test/bundle/installer_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe Homebrew::Bundle::Installer do
     allow(Formula).to receive(:[]).and_return(instance_double(Formula))
     allow(::Cask::CaskLoader).to receive(:load)
       .and_return(instance_double(::Cask::Cask, full_name: "homebrew/cask/google-chrome"))
-    # Formula and cask entries are installed in one batched `brew install`, so specs
-    # asserting a specific `Bundle.brew` call need the others to fall through to a stub.
+    # Entries are installed by one batched `brew install` per type, so specs asserting a
+    # specific `Bundle.brew` call need the others to fall through to a stub.
     allow(Homebrew::Bundle).to receive(:brew).and_return(true)
     # Entries can name a tap the Brewfile does not, which is otherwise cloned for real.
     allow_any_instance_of(::Tap).to receive(:ensure_installed!)
@@ -49,7 +49,7 @@ RSpec.describe Homebrew::Bundle::Installer do
     described_class.install!([cask_entry], verbose: false, force: false, quiet: true)
   end
 
-  it "fetches and installs formulae and casks in one `brew install`" do
+  it "fetches and installs formulae and casks in one `brew install` per type" do
     allow(Homebrew::Bundle::Tap).to receive(:installed_taps).and_return(["homebrew/cask"])
 
     expect(Homebrew::Bundle::Brew).to receive(:preinstall!)
@@ -61,7 +61,11 @@ RSpec.describe Homebrew::Bundle::Installer do
       .ordered
       .and_return(true)
     expect(Homebrew::Bundle).to receive(:brew)
-      .with("install", "--adopt", "mysql", "homebrew/cask/google-chrome", verbose: false)
+      .with("install", "--formula", "mysql", verbose: false)
+      .ordered
+      .and_return(true)
+    expect(Homebrew::Bundle).to receive(:brew)
+      .with("install", "--cask", "--adopt", "homebrew/cask/google-chrome", verbose: false)
       .ordered
       .and_return(true)
 
@@ -181,7 +185,7 @@ RSpec.describe Homebrew::Bundle::Installer do
 
     it "installs formulae needing installation in a single `brew install`" do
       expect(Homebrew::Bundle).to receive(:brew)
-        .with("install", "mysql", "redis", verbose: false)
+        .with("install", "--formula", "mysql", "redis", verbose: false)
         .and_return(true)
 
       described_class.install!([formula_entry, second_formula_entry], quiet: true)
@@ -192,7 +196,7 @@ RSpec.describe Homebrew::Bundle::Installer do
       allow(Homebrew::Bundle::Brew).to receive(:formula_installed?).with("redis").and_return(true)
 
       expect(Homebrew::Bundle).to receive(:brew)
-        .with("install", "mysql", "redis", verbose: false)
+        .with("install", "--formula", "mysql", "redis", verbose: false)
         .and_return(true)
 
       described_class.install!([formula_entry, second_formula_entry], quiet: true)
@@ -228,7 +232,7 @@ RSpec.describe Homebrew::Bundle::Installer do
       service_entry = Homebrew::Bundle::Dsl::Entry.new(:brew, "redis", { restart_service: :changed })
 
       expect(Homebrew::Bundle).to receive(:brew)
-        .with("install", "mysql", verbose: false)
+        .with("install", "--formula", "mysql", verbose: false)
         .and_return(true)
       expect(Homebrew::Bundle::Brew).to receive(:install!)
         .with("redis", restart_service: :changed, preinstall: true, no_upgrade: false, verbose: false, force: false)
@@ -261,7 +265,7 @@ RSpec.describe Homebrew::Bundle::Installer do
 
     it "batches casks with Homebrew's native download queue" do
       expect(Homebrew::Bundle).to receive(:brew)
-        .with("install", "--adopt", "homebrew/cask/google-chrome", verbose: false)
+        .with("install", "--cask", "--adopt", "homebrew/cask/google-chrome", verbose: false)
         .and_return(true)
       expect(Homebrew::Bundle::Cask).to receive(:install!)
         .with("google-chrome", **cask_options, preinstall: false, no_upgrade: false, verbose: false, force: false)
@@ -270,18 +274,41 @@ RSpec.describe Homebrew::Bundle::Installer do
       described_class.install!([cask_entry], quiet: true)
     end
 
-    it "fully qualifies cask names before batching them" do
+    it "installs a cask sharing a token with a formula as a cask" do
       options = { args: {}, full_name: "ambiguous" }
       entry = Homebrew::Bundle::Dsl::Entry.new(:cask, "ambiguous", options)
+      # `Cask#full_token` leaves core cask tokens unqualified, so only `--cask` stops
+      # `brew install` resolving the name to a formula of the same name.
       allow(::Cask::CaskLoader).to receive(:load).with("ambiguous")
-                                                 .and_return(instance_double(::Cask::Cask,
-                                                                             full_name: "homebrew/cask/ambiguous"))
+                                                 .and_return(instance_double(::Cask::Cask, full_name: "ambiguous"))
 
       expect(Homebrew::Bundle).to receive(:brew)
-        .with("install", "--adopt", "homebrew/cask/ambiguous", verbose: false)
+        .with("install", "--cask", "--adopt", "ambiguous", verbose: false)
         .and_return(true)
 
       described_class.install!([entry], quiet: true)
+    end
+
+    it "keeps `--overwrite` out of the cask batch when forcing" do
+      expect(Homebrew::Bundle).to receive(:brew)
+        .with("install", "--formula", "--force", "--overwrite", "mysql", verbose: false)
+        .and_return(true)
+      expect(Homebrew::Bundle).to receive(:brew)
+        .with("install", "--cask", "--force", "homebrew/cask/google-chrome", verbose: false)
+        .and_return(true)
+
+      described_class.install!([formula_entry, cask_entry], force: true, quiet: true)
+    end
+
+    it "still installs the casks when the formula batch fails" do
+      allow(Homebrew::Bundle).to receive(:brew)
+        .with("install", "--formula", any_args).and_return(false)
+
+      expect(Homebrew::Bundle).to receive(:brew)
+        .with("install", "--cask", "--adopt", "homebrew/cask/google-chrome", verbose: false)
+        .and_return(true)
+
+      described_class.install!([formula_entry, cask_entry], quiet: true)
     end
 
     it "attributes a failed batch to casks that are not installed afterwards" do
@@ -320,7 +347,7 @@ RSpec.describe Homebrew::Bundle::Installer do
       ENV["HOMEBREW_NO_INSTALL_UPGRADE"] = "1"
 
       expect(Homebrew::Bundle).to receive(:brew) do |*args, **options|
-        expect(args).to eq(["install", "mysql"])
+        expect(args).to eq(["install", "--formula", "mysql"])
         expect(options).to eq(verbose: false)
         expect(ENV.fetch("HOMEBREW_NO_INSTALL_UPGRADE", nil)).to be_nil
         true


### PR DESCRIPTION
### What does this change do, and why?

Fixes #23860. A Brewfile entry `cask "transmission"` installed the formula `transmission-cli` instead of the cask.

`brew bundle install` batches formula and cask entries into one `brew install`, which since #23659 passes neither `--formula` nor `--cask`. A bare `brew install` resolves an ambiguous name to the formula and only warns about the cask, so any cask sharing a token with a formula installs the wrong package. `transmission` is such a token: `Formulary.factory("transmission")` returns the core formula `transmission-cli`.

The batch was meant to be unambiguous because cask entries are passed by `Cask#full_name`, but `Cask#full_token` deliberately leaves core cask tokens unqualified, so there was nothing to disambiguate. `--overwrite` conflicts with `--cask` and `--adopt` with `--formula`, which is why the bare command avoided those errors, so this splits the batch into one `brew install --formula` and one `brew install --cask`, each carrying only the arguments valid for its own type. Both still run when the first fails, keeping `brew bundle`'s attempt-every-entry behaviour, and a Brewfile of one type still produces a single command.

The existing example covering this stubbed `full_name` as `homebrew/cask/ambiguous`, a value `full_token` cannot return for a core cask, so it passed while the real path was broken. It now uses an unqualified token and asserts `--cask` is passed.

### Step-by-step reproduction

```console
$ printf 'cask "transmission"\n' > /tmp/Brewfile && brew bundle install --file /tmp/Brewfile
```

Before this change that installs the formula `transmission-cli`. After it, the cask.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

AI was used. Claude Code (Claude Opus) diagnosed the resolution order, wrote the fix and the spec; I ran `brew lgtm`, reproduced the formula-vs-cask lookup against the real API and verified the new example red/green myself.
