### PR TITLE
curl: only expand secrets the download declared

### DIFF
--- a/Library/Homebrew/download_strategy/curl_download_strategy.rb
+++ b/Library/Homebrew/download_strategy/curl_download_strategy.rb
@@ -313,8 +313,28 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
   def expand_deferred_environment_args(args)
     return args unless @expand_deferred_environment
 
+    # Variables the formula or cask actually named. A server can put a
+    # placeholder in a `Location:` target, and expanding one it never declared
+    # would send it a secret it was never given.
+    declared = [url, *@mirrors, *meta.fetch(:headers, [])]
+    placeholder_pattern = /#{Regexp.escape(EnvSensitive::DEFERRED_PLACEHOLDER_PREFIX)}\w+
+                           #{Regexp.escape(EnvSensitive::DEFERRED_PLACEHOLDER_SUFFIX)}/xo
+
     with_context(deferred_environment_expansion: true) do
-      args.map { |arg| ENV.expand_deferred_environment(arg) }
+      args.map do |arg|
+        next arg unless arg.include?(EnvSensitive::DEFERRED_PLACEHOLDER_PREFIX)
+
+        undeclared = arg.gsub(placeholder_pattern) do |placeholder|
+          (declared.any? { |value| value.include?(placeholder) }) ? "" : placeholder
+        end
+        next ENV.expand_deferred_environment(arg) if undeclared.exclude?(
+          EnvSensitive::DEFERRED_PLACEHOLDER_PREFIX,
+        )
+
+        raise CurlDownloadStrategyError.new(
+          url, "Refusing to expand a deferred secret the download did not declare."
+        )
+      end
     end
   end
 

--- a/Library/Homebrew/test/download_strategies/curl_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_spec.rb
@@ -231,6 +231,56 @@ RSpec.describe CurlDownloadStrategy do
       end
     end
 
+    context "when a redirect target names a variable the download did not declare" do
+      let(:redirect_url) do
+        "https://example.com/elsewhere/foo.tar.gz?leak=" \
+          "#{EnvSensitive::DEFERRED_PLACEHOLDER_PREFIX}HOMEBREW_GITHUB_API_TOKEN" \
+          "#{EnvSensitive::DEFERRED_PLACEHOLDER_SUFFIX}"
+      end
+
+      before do
+        ENV["HOMEBREW_GITHUB_API_TOKEN"] = "ghp-victim-token"
+        strategy.allow_deferred_environment_expansion!
+        allow(strategy).to receive(:resolve_url_basename_time_file_size)
+          .and_return([redirect_url, "foo.tar.gz", nil, 0, nil, true])
+      end
+
+      it "refuses to send a secret the download never named" do
+        expect { strategy.fetch }.to raise_error(CurlDownloadStrategyError, /did not declare/)
+      end
+    end
+
+    context "when a redirect target carries a secret the download declared" do
+      let(:url) do
+        "https://example.com/foo.tar.gz?t=" \
+          "#{EnvSensitive::DEFERRED_PLACEHOLDER_PREFIX}HOMEBREW_PRIVATE_TOKEN" \
+          "#{EnvSensitive::DEFERRED_PLACEHOLDER_SUFFIX}"
+      end
+      let(:redirect_url) do
+        "https://cdn.example.org/foo.tar.gz?t=" \
+          "#{EnvSensitive::DEFERRED_PLACEHOLDER_PREFIX}HOMEBREW_PRIVATE_TOKEN" \
+          "#{EnvSensitive::DEFERRED_PLACEHOLDER_SUFFIX}"
+      end
+
+      before do
+        ENV["HOMEBREW_PRIVATE_TOKEN"] = "glpat-secret"
+        strategy.allow_deferred_environment_expansion!
+        allow(strategy).to receive(:resolve_url_basename_time_file_size)
+          .and_return([redirect_url, "foo.tar.gz", nil, 0, nil, true])
+      end
+
+      it "still expands it, as redirects carrying declared secrets are supported" do
+        seen = []
+        allow(strategy).to receive(:system_command) do |_command, options|
+          seen.concat(options[:args])
+          instance_double(SystemCommand::Result, success?: true, stdout: "", assert_success!: nil)
+        end
+        strategy.fetch
+
+        expect(seen).to include(a_string_including("t=glpat-secret"))
+      end
+    end
+
     context "with artifact_domain set" do
       let(:artifact_domain) { "https://mirror.example.com/oci" }
 


### PR DESCRIPTION
### What does this change do, and why?

Deferred secret expansion runs over every argument handed to `curl`, and `AbstractDownloadStrategy.expand_deferred_environment_for?` enables it for every Homebrew-controlled strategy, which includes the plain `CurlDownloadStrategy` used by ordinary formulae and casks. It is not gated on the download declaring a secret.

So any host a formula downloads from can name a masked `HOMEBREW_*` variable in its `Location:` target and be sent that secret, including one it was never entrusted with. On `main`:

```
brew ruby -e '
require "download_strategy"
ENV["HOMEBREW_GITHUB_API_TOKEN"] = "ghp-victim-token"
class Probe < CurlDownloadStrategy; public :expand_deferred_environment_args; end
# An ordinary public host. This formula declares no secret at all.
p = Probe.new("https://downloads.example.com/pkg-1.0.tar.gz", "pkg", "1.0")
p.allow_deferred_environment_expansion!
puts p.expand_deferred_environment_args(
  ["https://downloads.example.com/x?leak={{HOMEBREW_DEFERRED_ENV:HOMEBREW_GITHUB_API_TOKEN}}"]
).first
'
```

That prints `https://downloads.example.com/x?leak=ghp-victim-token`. The download declared nothing, so this is not a host receiving a secret it already held.

A placeholder is now expanded only when the download itself named that variable, in its URL, its mirrors or its headers. Anything else raises.

Redirects carrying a declared secret keep working, which is deliberate: a private registry URL that redirects to a CDN still has its token expanded, and there is a spec for it. This only refuses variables the download never mentioned.

One interaction worth knowing. `fetch` already deletes `meta[:headers]` on a cross-host redirect, so a secret declared only in a header is no longer declared once that happens and will be refused if it also appears in the redirect target. That is consistent with why the headers are stripped in the first place.

Verified against both official taps, since this is the sort of change that needs it. No formula or cask in homebrew/core or homebrew/cask can be affected: 137 core formulae reference a `HOMEBREW_*` variable and none is maskable under `EnvSensitive#sensitive?` (117 are `HOMEBREW_GITHUB_ACTIONS`, the rest are build variables such as `HOMEBREW_OPTFLAGS`), none appears in a `url`, `mirror` or `header`, and no cask references one at all. The feature is exercised by private registries and third-party taps, which cannot be enumerated from here.

I also checked for a previous attempt at this that was reverted, and could not find one. The only commits adding a declared-variable check are on this branch. #22886 broadened expansion to URLs, but it fixed #22879, where the token was missing from the re-exec environment, rather than undoing a narrowing. #22945 narrowed the same area with `--max-redirs 0` for secret-bearing headers and stuck.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

AI was used. Claude Code (Claude Opus 5) found the leak, wrote the fix and the specs, and surveyed homebrew/core and homebrew/cask for affected formulae. I ran `brew lgtm` and the full `brew tests` suite, reproduced the expansion of an undeclared variable against current `main` and verified each example red/green.

-----
