### PR TITLE
trust: ignore a bare tap name in ARGV

### DIFF
--- a/Library/Homebrew/test/trust_spec.rb
+++ b/Library/Homebrew/test/trust_spec.rb
@@ -625,6 +625,21 @@ RSpec.describe Homebrew::Trust, :trust_store do
     FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
   end
 
+  it "does not allow files from a tap named as a bare argument when trust checks are enabled" do
+    old_argv = ARGV.dup
+    tap = Tap.fetch("thirdparty", "foo")
+    formula_path = tap.formula_dir/"default-trust.rb"
+    formula_path.dirname.mkpath
+
+    ARGV.replace(["info", "thirdparty/foo"])
+    expect(described_class.trusted_formula_file?(formula_path)).to be(false)
+  ensure
+    ARGV.replace(old_argv) if old_argv
+    described_class.clear!(:tap)
+    described_class.clear!(:formula)
+    FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+  end
+
   it "does not allow explicitly named command files when trust checks are enabled" do
     old_argv = ARGV.dup
     tap = Tap.fetch("thirdparty", "foo")

--- a/Library/Homebrew/trust.rb
+++ b/Library/Homebrew/trust.rb
@@ -572,7 +572,6 @@ module Homebrew
       downcased_full_name = full_name.downcase
       tap_name = tap.name.downcase
       downcased_args.include?(downcased_full_name) ||
-        downcased_args.include?(tap_name) ||
         downcased_args.include?("--tap=#{tap_name}") ||
         downcased_args.each_cons(2).any? { |option, value| option == "--tap" && value == tap_name }
     end


### PR DESCRIPTION
### What does this change do, and why?

`Trust.explicitly_allowed?` treated a bare tap name appearing anywhere in `ARGV` as blanket trust for every formula and cask in that tap. Because it scans `ARGV` rather than the parsed arguments of the running command, this is not limited to `brew tap` and `brew untap`: any command whose arguments happen to include the tap name loads that tap's files without trust.

`docs/Tap-Trust.md` already documents the narrower rule, that an untrusted tap is not loaded "unless you explicitly install a fully qualified formula or cask from that tap". Removing the bare-name arm restores that, so no documentation change is needed.

The `--tap=<name>` and `--tap <name>` arms are kept, because `trust_spec.rb` asserts them in "allows files from explicitly named taps when trust checks are enabled". Whether an explicit `--tap` should confer trust on a whole tap is a separate question, and this change does not touch it.

Reproduce on `main`, with any untrusted tap installed:

```
brew ruby -e '
require "trust"
Homebrew::Trust.public_class_method(:trusted_file?)
tap = Homebrew::Trust.untrusted_taps.find { |t| t.formula_files.any? }
path = tap.formula_files.first
ARGV.replace(["install", "unrelated"])
puts "tap not named in ARGV: #{Homebrew::Trust.trusted_file?(:formula, path)}"
ARGV.replace(["info", tap.name])
puts "bare tap name in ARGV: #{Homebrew::Trust.trusted_file?(:formula, path)}"
'
```

That prints `false` then `true`. After this change both print `false`, and naming a fully qualified formula or cask still returns `true`.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

AI was used. Claude Code (Claude Opus 5) verified the bypass against an untrusted tap on a real installation, found that it is not limited to `brew tap`, established that the docs already describe the narrowed behaviour, wrote the fix and the spec, and ran the full `brew tests` suite as well as `brew lgtm`. I reviewed the change and the reproduction.

-----
