### PR TITLE
trust: normalise the installed-tap reference

### DIFF
--- a/Library/Homebrew/test/cmd/untrust_spec.rb
+++ b/Library/Homebrew/test/cmd/untrust_spec.rb
@@ -57,6 +57,21 @@ RSpec.describe Homebrew::Cmd::Untrust, :trust_store do
     FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
   end
 
+  it "untrusts items stored under a custom remote whose case differs" do
+    tap = Tap.fetch("thirdparty", "custom")
+    tap.path.mkpath
+    system "git", "-C", tap.path.to_s, "init"
+    system "git", "-C", tap.path.to_s, "remote", "add", "origin", "https://GitLab.com/Other/Repo"
+    Homebrew::Trust.trust!(*Homebrew::Trust.target("thirdparty/custom/bar", type: :formula))
+
+    expect { described_class.new(["thirdparty/custom"]).run }
+      .to output("Untrusted tap: https://gitlab.com/other/repo\n").to_stdout
+    expect(Homebrew::Trust.trusted?(:formula, "thirdparty/custom/bar")).to be(false)
+  ensure
+    Homebrew::Trust.clear!(:formula)
+    FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"thirdparty"
+  end
+
   it "untrusts trusted items from a tap" do
     expect(Homebrew::Trust).to receive(:untrust!).with(:tap, "thirdparty/foo").and_return(false)
     allow(Homebrew::Trust).to receive(:trusted_entries).with(:formula).and_return(["thirdparty/foo/bar"])

--- a/Library/Homebrew/trust.rb
+++ b/Library/Homebrew/trust.rb
@@ -376,7 +376,7 @@ module Homebrew
 
           reference
         else
-          Tap.fetch(name).reference(remote: tap_remote)
+          normalise_name(Tap.fetch(name).reference(remote: tap_remote))
         end
       when :formula
         tap, formula_name = fully_qualified_package_name(name, "Formulae")


### PR DESCRIPTION
### What does this change do, and why?

`Trust.trust_name` returned `Tap#reference` verbatim for an installed tap, which is the raw git remote with its case intact. Every other branch returns a downcased, store-shaped name: `Tap.remote_to_reference` downcases inside `normalize_remote`, and `item_trust_name` writes items as `"#{normalise_name(reference)}/#{item_name}"`.

For a tap whose custom remote contains uppercase characters, that mismatch makes `brew untrust <tap>` build a prefix that matches no stored entry. The cascade at `cmd/untrust.rb:92` compares `entry.start_with?("#{trust_name}/")`, finds nothing, and reports `Not trusted` while leaving every per-item entry trusted. A user who believes they have revoked a tap has not.

Reproduce on `main`, using a scratch config home so your real trust store is untouched:

```
mkdir -p /tmp/trustdemo && cd /tmp/trustdemo
HOMEBREW_XDG_CONFIG_HOME=/tmp/trustdemo brew ruby -e '
require "cmd/untrust"
tap = Tap.fetch("thirdparty", "casetest")
tap.path.mkpath
system "git", "-C", tap.path.to_s, "init", "--quiet"
system "git", "-C", tap.path.to_s, "remote", "add", "origin", "https://GitLab.com/Other/Repo"
Homebrew::Trust.trust!(*Homebrew::Trust.target("thirdparty/casetest/bar", type: :formula))
puts "stored:   #{Homebrew::Trust.trusted_entries(:formula).inspect}"
Homebrew::Cmd::Untrust.new(["thirdparty/casetest"]).run
puts "after:    #{Homebrew::Trust.trusted_entries(:formula).inspect}"
puts "trusted?: #{Homebrew::Trust.trusted?(:formula, "thirdparty/casetest/bar")}"
FileUtils.rm_rf tap.path
'
```

On `main` that prints `Not trusted tap: https://GitLab.com/Other/Repo`, leaves the entry in place and reports `trusted?: true`. With this change it prints `Untrusted tap: https://gitlab.com/other/repo`, the entry is gone and `trusted?: false`.

Stored entries are unchanged in either direction, since `trust!`, `untrust!` and `replace!` already applied `normalise_name` before writing, so `trust.json` is byte-identical. The only user-visible difference is the echoed name, which now matches what is stored and what `brew trust` lists, so it is copy-pasteable.

One related gap is deliberately left alone, since closing it needs a decision about the stored entry format. Untrusting by remote URL routes through `Tap.remote_to_reference`, which also strips a `.git` suffix, so for a `.git`-suffixed remote the key is `https://github.com/other/repo` while items are stored under `https://github.com/other/repo.git/<item>`. Untrusting that tap by name works after this change, and I confirmed that, but untrusting it by URL still misses the items.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

AI was used. Claude Code (Claude Opus 5) verified the defect through `brew untrust` against an isolated trust store, checked that every other reference used as a trust key or prefix is already normalised, wrote the fix and the spec, and ran the full `brew tests` suite and `brew lgtm`. I reviewed the change and the reproduction.

-----
