### PR TITLE
cask/installer.rb: cast Artifact::GeneratedScript

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -341,6 +341,7 @@ on_request: true)
           T.any(
             Artifact::AbstractFlightBlock,
             Artifact::GeneratedCompletion,
+            Artifact::GeneratedScript,
             Artifact::Installer,
             Artifact::KeyboardLayout,
             Artifact::Mdimporter,


### PR DESCRIPTION
Add `Artifact::GeneratedScript` to the type cast in
`Library/Homebrew/cask/installer.rb`.

`generated_script` was added by #23184, but didn't update the cask installer.

This fixes cask installation with `HOMEBREW_SORBET_RUNTIME` enabled.

Reproducer:

```shell
brew install --cask libreoffice
brew install --cask libreoffice-language-pack --language=de
HOMEBREW_SORBET_RUNTIME=1 brew reinstall --cask libreoffice-language-pack --language=de
```

The third command fails with `T.cast: ... got type Cask::Artifact::GeneratedScript`.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

ChatGPT-5.6 to investigate the error, identify the missing `Artifact::GeneratedScript` type in `T.cast`, and draft the PR description. I reviewed the code and history, reproduced the failure, verified the fix, and ran `brew lgtm` locally.