### PR TITLE
tests: run brew.sh smoke checks in the test prefix

### DIFF
--- a/Library/Homebrew/test/cmd/casks_spec.rb
+++ b/Library/Homebrew/test/cmd/casks_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "brew casks", type: :system do
-  it "prints all installed Casks", :integration_test do
+  it "prints all installed Casks", :integration_test, :test_prefix_taps do
     expect { brew_sh "casks" }
       .to be_a_success
       .and not_to_output.to_stderr

--- a/Library/Homebrew/test/cmd/formulae_spec.rb
+++ b/Library/Homebrew/test/cmd/formulae_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "brew formulae", type: :system do
-  it "prints all installed Formulae", :integration_test do
+  it "prints all installed Formulae", :integration_test, :test_prefix_taps do
     expect { brew_sh "formulae" }
       .to be_a_success
       .and not_to_output.to_stderr

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -134,6 +134,18 @@ module Test
         end
       end
 
+      # A copy, not a symlink: `bin/brew` resolves a symlinked entry point back
+      # to the real repository.
+      sig { returns(String) }
+      def test_prefix_brew_sh
+        test_prefix_library = HOMEBREW_PREFIX/"Library"
+        test_prefix_library.mkpath
+        FileUtils.ln_sf HOMEBREW_LIBRARY_PATH, test_prefix_library/"Homebrew"
+        # `cp` would keep the touched file's non-executable mode.
+        FileUtils.install HOMEBREW_ORIGINAL_BREW_FILE, HOMEBREW_PREFIX/"bin/brew", mode: 0755
+        (HOMEBREW_PREFIX/"bin/brew").to_s
+      end
+
       sig { params(args: T.untyped).returns(Process::Status) }
       def brew_sh(*args)
         env = args.last.is_a?(Hash) ? args.pop : {}
@@ -143,7 +155,13 @@ module Test
           "HOMEBREW_INTEGRATION_TEST"   => command_id,
         }.merge(env)
         Bundler.with_unbundled_env do
-          brew_sh_path = env.delete("HOMEBREW_BREW_SH") || "#{ENV.fetch("HOMEBREW_PREFIX")}/bin/brew"
+          brew_sh_path = env.delete("HOMEBREW_BREW_SH")
+          # Other specs assert the real prefix, which the test one is not.
+          brew_sh_path ||= if RSpec.current_example.metadata[:test_prefix_taps]
+            test_prefix_brew_sh
+          else
+            "#{ENV.fetch("HOMEBREW_PREFIX")}/bin/brew"
+          end
           stdout, stderr, status = Open3.capture3(
             env,
             brew_sh_path,
@@ -298,7 +316,7 @@ RSpec.shared_context "integration test" do # rubocop:disable RSpec/ContextWordin
 
     example.run
   ensure
-    FileUtils.rm_rf HOMEBREW_PREFIX/"bin"
+    FileUtils.rm_rf [HOMEBREW_PREFIX/"bin", HOMEBREW_PREFIX/"Library/Homebrew"]
     ENV.delete("HOMEBREW_INTEGRATION_TEST")
   end
 end


### PR DESCRIPTION
### What does this change do, and why?

`brew_sh` runs the real `brew.sh`, which resolves `HOMEBREW_REPOSITORY` from its own location, so `brew formulae` and `brew casks` enumerated the developer's own `Library/Taps`. The default tap trust path then warns once per untrusted tap, so `not_to_output.to_stderr` failed for anyone with a third-party tap installed.

Point those two at a `bin/brew` inside the test prefix instead, so the tap list is the one the tests control. It has to be a copy rather than a symlink: `bin/brew` resolves a symlinked entry point back to the real repository, which is why `test/cmd/exec_spec.rb`'s existing `ln_sf` does not isolate the tap list.

Opt in with a `:test_prefix_taps` tag rather than an env var. It cannot be unconditional: `cmd/--prefix`, `--cellar`, `--caskroom`, `shellenv`, `setup-ruby` and `mcp-server` assert the real prefix, and `brew.sh` refuses the test one with "Your HOMEBREW_PREFIX is in the Homebrew temporary directory".

Reproduce on `main` by creating a formula under `"$(brew --repository)/Library/Taps/example/homebrew-example/Formula"`, then running `brew tests --only=cmd/formulae,cmd/casks`.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

AI was used. Claude Code (Claude Opus 5) wrote this and reworked it in response to review. I ran `brew lgtm` and the affected specs.

-----
