### PR TITLE
tests: group parallel runs by recorded runtime

### DIFF
--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -117,19 +117,28 @@ module Homebrew
           else
             "#{HOMEBREW_CACHE}/#{parallel_rspec_log_name}"
           end
-          ENV["PARALLEL_RSPEC_LOG_PATH"] = parallel_rspec_log_path
+          # A run that may not record every file must not replace the log a full run
+          # reads: `--only`, `--changed` and `--shard` cover a subset by design, and
+          # `--fail-fast` stops its workers early.
+          ENV["PARALLEL_RSPEC_LOG_PATH"] = if only || args.changed? || args.shard || args.fail_fast?
+            "#{parallel_rspec_log_path}.partial"
+          else
+            parallel_rspec_log_path
+          end
 
           parallel_args = if ENV["CI"]
-            %W[
+            %w[
               --combine-stderr
               --serialize-stdout
-              --runtime-log #{parallel_rspec_log_path}
             ]
           else
             %w[
               --nice
             ]
           end
+          # Group by recorded runtime rather than source file size, which barely
+          # correlates with how long a file takes.
+          parallel_args += ["--runtime-log", parallel_rspec_log_path]
 
           # Generate seed ourselves and output later to avoid multiple different
           # seeds being output when running parallel tests.

--- a/Library/Homebrew/test/dev-cmd/tests_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tests_spec.rb
@@ -87,6 +87,103 @@ RSpec.describe Homebrew::DevCmd::Tests do
       end
     end
 
+    context "when grouping parallel tests" do
+      def invoked_arguments
+        captured = T.let([], T::Array[String])
+        allow(tests).to receive(:system) do |*arguments|
+          captured = arguments
+          system "/usr/bin/true"
+        end
+        tests.run
+        captured
+      end
+
+      let(:log_path) { "#{HOMEBREW_CACHE}/parallel_runtime_rspec.log" }
+
+      before do
+        # The log lives in `HOMEBREW_CACHE` locally and in `tests/` on CI, so pin
+        # the local path rather than inheriting whichever the runner happens to be.
+        ENV.delete("CI")
+        allow(Dir).to receive(:glob).with("test/**/*_spec.rb")
+                                    .and_return(%w[test/a_spec.rb test/b_spec.rb])
+      end
+
+      it "groups by recorded runtime rather than file size" do
+        expect(invoked_arguments).to array_including_cons("--runtime-log", log_path)
+      end
+
+      it "records the runtimes of a full run" do
+        invoked_arguments
+
+        expect(ENV.fetch("PARALLEL_RSPEC_LOG_PATH")).to eq(log_path)
+      end
+
+      it "groups by the cached log on CI" do
+        ENV["CI"] = "1"
+
+        expect(invoked_arguments).to array_including_cons("--runtime-log", "tests/parallel_runtime_rspec.log")
+      end
+
+      context "when exiting on the first failure" do
+        let(:args) { ["--fail-fast"] }
+
+        it "does not replace the recorded runtimes" do
+          invoked_arguments
+
+          expect(ENV.fetch("PARALLEL_RSPEC_LOG_PATH")).to eq("#{log_path}.partial")
+        end
+      end
+
+      context "when only one shard is selected" do
+        let(:args) { ["--shard=1/2"] }
+
+        before do
+          allow(ParallelTests::RSpec::Runner).to receive(:tests_in_groups)
+            .and_return([%w[test/a_spec.rb], %w[test/b_spec.rb]])
+        end
+
+        it "does not replace the recorded runtimes" do
+          invoked_arguments
+
+          expect(ENV.fetch("PARALLEL_RSPEC_LOG_PATH")).to eq("#{log_path}.partial")
+        end
+      end
+
+      context "when only changed files are selected" do
+        let(:args) { ["--changed"] }
+
+        before do
+          allow(Utils::Git).to receive(:changed_files)
+            .and_return(["Library/Homebrew/test/warnings_spec.rb"])
+        end
+
+        it "does not replace the recorded runtimes" do
+          invoked_arguments
+
+          expect(ENV.fetch("PARALLEL_RSPEC_LOG_PATH")).to eq("#{log_path}.partial")
+        end
+      end
+
+      context "when only some files are selected" do
+        let(:args) { ["--only=warnings"] }
+
+        before do
+          allow(Dir).to receive(:glob).with("test/{warnings,warnings/**/*}_spec.rb")
+                                      .and_return(%w[test/warnings_spec.rb])
+        end
+
+        it "still groups by the recorded runtimes" do
+          expect(invoked_arguments).to array_including_cons("--runtime-log", log_path)
+        end
+
+        it "does not replace the recorded runtimes" do
+          invoked_arguments
+
+          expect(ENV.fetch("PARALLEL_RSPEC_LOG_PATH")).to eq("#{log_path}.partial")
+        end
+      end
+    end
+
     context "when sharding tests" do
       let(:args) { ["--shard=2/2"] }
 


### PR DESCRIPTION
`brew tests` records per-file runtimes on every parallel run through `.rspec_parallel`, but only passed `--runtime-log` under `ENV["CI"]`, so local runs fell back to `sort_by_filesize`, which barely tracks runtime: `test/utils/git_spec.rb` is 260 lines and 98.6s of examples, `test/formula_spec.rb` is 3774 lines and 86.3s. Pass it unconditionally so local runs group by the log they already write.

Two full offline runs, the second reading the log the first wrote:

| | `main` (file size) | this change (runtime) |
| --- | --- | --- |
| slowest worker | 267.3s | 240.7s |
| fastest worker | 121.0s | 207.1s |
| imbalance | 2.21x | 1.16x |
| wall clock | 270s | 246s |

Wall clock understates it: the second run had 13.5% more total example time on a busier machine and still finished sooner. `brew benchmark` covers `brew install` and `brew fetch`, so it has nothing to measure here.

A run that may not record every file now writes to a `.partial` path instead of replacing the real log: `--only`, `--changed` and `--shard` cover a subset by design, and `--fail-fast` stops its workers early. a missing or thin log falls back to file size as today. Completes the local half of #10507.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Claude Code with Opus 5, with local review and testing.




