### PR TITLE
Apply service env overrides to run

### DIFF
--- a/Library/Homebrew/services/cli.rb
+++ b/Library/Homebrew/services/cli.rb
@@ -495,9 +495,18 @@ module Homebrew
 
         loaded_service_name = service.service_name
         if System.launchctl?
-          file ||= enable ? service.dest : service.source_service_file
           service.path_dirs.each(&:mkpath)
-          loaded_service_name = launchctl_load(service, file:, enable:)
+          if file.nil? && !enable && service.service_file_generated? &&
+             (contents = service.service_contents) != service.source_service_file.read
+            Tempfile.create(service.service_name) do |tempfile|
+              tempfile.write(contents)
+              tempfile.flush
+              loaded_service_name = launchctl_load(service, file: Pathname(tempfile.path), enable:)
+            end
+          else
+            file ||= enable ? service.dest : service.source_service_file
+            loaded_service_name = launchctl_load(service, file:, enable:)
+          end
         elsif System.systemctl?
           # Systemctl loads based upon location so only install service
           # file when it is not installed. Used with the `run` command.

--- a/Library/Homebrew/test/services/cli_spec.rb
+++ b/Library/Homebrew/test/services/cli_spec.rb
@@ -1161,11 +1161,12 @@ RSpec.describe Homebrew::Services::Cli do
         services_cli.service_load(
           instance_double(
             Homebrew::Services::FormulaWrapper,
-            name:                "name",
-            service_name:        "service.name",
-            service_startup?:    false,
-            source_service_file: instance_double(Pathname, exist?: false),
-            path_dirs:           [],
+            name:                    "name",
+            service_name:            "service.name",
+            service_startup?:        false,
+            service_file_generated?: false,
+            source_service_file:     instance_double(Pathname, exist?: false),
+            path_dirs:               [],
           ),
           nil,
           enable: false,
@@ -1181,12 +1182,13 @@ RSpec.describe Homebrew::Services::Cli do
       source_service_file.write("service")
       service = instance_double(
         Homebrew::Services::FormulaWrapper,
-        name:                "name",
-        service_name:        "sh.brew.name",
-        service_startup?:    false,
+        name:                    "name",
+        service_name:            "sh.brew.name",
+        service_startup?:        false,
+        service_file_generated?: false,
         service_file:,
         source_service_file:,
-        path_dirs:           [],
+        path_dirs:               [],
       )
       expect(services_cli).to receive(:launchctl_load)
         .with(service, file: source_service_file, enable: false)
@@ -1195,6 +1197,60 @@ RSpec.describe Homebrew::Services::Cli do
       expect do
         services_cli.service_load(service, nil, enable: false)
       end.to output("==> Successfully ran `name` (label: sh.brew.name)\n").to_stdout
+    end
+
+    it "runs an unchanged generated macOS service from its source file" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: true, root?: false, systemctl?: false)
+
+      source_service_file = mktmpdir/"sh.brew.name.plist"
+      source_service_file.write("generated service")
+      service = instance_double(
+        Homebrew::Services::FormulaWrapper,
+        name:                    "name",
+        service_name:            "sh.brew.name",
+        service_startup?:        false,
+        service_file_generated?: true,
+        service_contents:        "generated service",
+        source_service_file:,
+        path_dirs:               [],
+      )
+      loaded_file = mktmpdir/"not-loaded"
+      allow(services_cli).to receive(:launchctl_load) do |_target, file:, **_options|
+        loaded_file = Pathname(file)
+        "sh.brew.name"
+      end
+
+      services_cli.service_load(service, nil, enable: false)
+
+      expect(loaded_file).to eq(source_service_file)
+    end
+
+    it "runs a generated macOS service with user environment overrides" do
+      allow(Homebrew::Services::System).to receive_messages(launchctl?: true, root?: false, systemctl?: false)
+
+      source_service_file = mktmpdir/"sh.brew.name.plist"
+      source_service_file.write("source service")
+      service = instance_double(
+        Homebrew::Services::FormulaWrapper,
+        name:                    "name",
+        service_name:            "sh.brew.name",
+        service_startup?:        false,
+        service_file_generated?: true,
+        service_contents:        "generated service with overrides",
+        source_service_file:,
+        path_dirs:               [],
+      )
+      loaded_contents = ""
+      loaded_file = mktmpdir/"not-loaded"
+      allow(services_cli).to receive(:launchctl_load) do |_target, file:, **_options|
+        loaded_file = Pathname(file)
+        loaded_contents = loaded_file.read
+        "sh.brew.name"
+      end
+
+      services_cli.service_load(service, nil, enable: false)
+
+      expect([loaded_contents, loaded_file.exist?]).to eq(["generated service with overrides", false])
     end
 
     it "creates service path directories before loading" do
@@ -1215,10 +1271,11 @@ RSpec.describe Homebrew::Services::Cli do
         services_cli.service_load(
           instance_double(
             Homebrew::Services::FormulaWrapper,
-            name:                "name",
-            service_name:        "service.name",
-            service_startup?:    false,
-            source_service_file: instance_double(Pathname, exist?: false),
+            name:                    "name",
+            service_name:            "service.name",
+            service_startup?:        false,
+            service_file_generated?: false,
+            source_service_file:     instance_double(Pathname, exist?: false),
             path_dirs:,
           ),
           nil,


### PR DESCRIPTION
`brew services` documents per-formula environment overrides in
`$HOMEBREW_USER_CONFIG_HOME/services/<formula>.env`. These overrides are
included when a service file is generated for `start`, but `run` currently
loads the formula's source plist directly on macOS. As a result, overrides are
silently ignored specifically when users choose the non-login `run` mode.

For macOS `run` calls where the formula uses the service DSL and no explicit
`--file` was supplied, `service_load` now compares the current generated
contents with the source plist. Unchanged services continue loading their
source file without another write. When user overrides change the generated
contents, Homebrew writes them to a temporary plist and removes it after
`launchctl` bootstraps it, so the service is still not registered for login.
The persistent `start` installation path, package-provided service files, and
explicit `--file` calls keep their existing behavior.

Steps to reproduce the bug:

```sh
mkdir -p "${HOMEBREW_USER_CONFIG_HOME:-$HOME/.homebrew}/services"
echo 'PATH=/custom/path' > "${HOMEBREW_USER_CONFIG_HOME:-$HOME/.homebrew}/services/cc-connect.env"
brew services run cc-connect
launchctl print "gui/$(id -u)/homebrew.mxcl.cc-connect"
```

Before this change, the printed environment contains the formula-defined
`PATH`, not `/custom/path`.

Verification:

```sh
./bin/brew lgtm --online
```

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

OpenAI Codex (GPT-5) was used to investigate, implement and test this change
under the contributor's direction. The full `brew lgtm --online` gate passes.

-----
