### PR TITLE
Restore mixed bundle install batches

### DIFF
--- a/Library/Homebrew/bundle/installer.rb
+++ b/Library/Homebrew/bundle/installer.rb
@@ -252,14 +252,23 @@ module Homebrew
         end
         return false if tap_dependencies(entry, entries:, installed_taps:).present?
 
-        if entry.cls == Brew
+        package = if entry.cls == Brew
           require "formula"
           Formula[entry.full_name]
         else
           require "cask/cask_loader"
-          entry.install_name = ::Cask::CaskLoader.load(entry.full_name).full_name
+          ::Cask::CaskLoader.load(entry.full_name)
         end
-        true
+        return false unless (tap = package.tap)
+
+        entry.install_name = ::Utils.fully_qualified_name(package)
+        return true if tap.core_tap? || tap.core_cask_tap?
+
+        if entry.cls == Brew
+          tap.cask_tokens.exclude?(entry.install_name)
+        else
+          tap.formula_names.exclude?(entry.install_name) && tap.aliases.exclude?(entry.install_name)
+        end
       rescue
         false
       end
@@ -285,26 +294,11 @@ module Homebrew
           end
         end
 
-        # A bare `brew install` resolves an ambiguous name to the formula, and the type
-        # flags conflict with each other, so each type needs its own invocation.
-        formulae, casks = actionable.partition { |entry| entry.cls == Brew }
-        batches = []
-        if formulae.any?
-          batches << [
-            "--formula",
-            *(["--force", "--overwrite"] if force),
-            *formulae.map(&:install_name),
-          ]
-        end
-        if casks.any?
-          batches << [
-            "--cask",
-            force ? "--force" : "--adopt",
-            *casks.map(&:install_name),
-          ]
-        end
-        batch_succeeded = with_env("HOMEBREW_NO_INSTALL_UPGRADE" => nil) do
-          batches.map { |batch_args| Bundle.brew("install", *batch_args, verbose:) }.all?
+        install_args = []
+        install_args << "--adopt" if !force && actionable.any? { |entry| entry.cls == Cask }
+        install_args.push("--force", "--overwrite") if force
+        batch_succeeded = actionable.empty? || with_env("HOMEBREW_NO_INSTALL_UPGRADE" => nil) do
+          Bundle.brew("install", *install_args, *actionable.map(&:install_name), verbose:)
         end
 
         # The batch changed what is installed, so the memoised views of it are stale.

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -612,14 +612,14 @@ module Homebrew
         case package
         when Formula, Keg, Array
           message += " For the formula, "
-          if package.is_a?(Formula) && (tap = package.tap)
-            message += "use #{tap.name}/#{package.name} or "
+          if package.is_a?(Formula) && package.tap
+            message += "use #{Utils.fully_qualified_name(package)} or "
           end
           message += "specify the `--formula` flag. To silence this message, use the `--cask` flag."
         when Cask::Cask
           message += " For the cask, "
-          if (tap = package.tap)
-            message += "use #{tap.name}/#{package.token} or "
+          if package.tap
+            message += "use #{Utils.fully_qualified_name(package)} or "
           end
           message += "specify the `--cask` flag. To silence this message, use the `--formula` flag."
         end

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -349,11 +349,9 @@ module Homebrew
       def formula_qualified_by_user?(formula_or_cask, qualified_inputs)
         return false if qualified_inputs.empty?
 
-        names = T.let([formula_or_cask.full_name.downcase], T::Array[String])
-        if (tap = formula_or_cask.tap)
-          names << "#{tap.name.downcase}/#{Utils.name_or_token(formula_or_cask).downcase}"
+        [formula_or_cask.full_name, Utils.fully_qualified_name(formula_or_cask)].any? do |name|
+          qualified_inputs.include?(name.downcase)
         end
-        names.any? { |n| qualified_inputs.include?(n) }
       end
 
       sig { params(formula: Formula).returns([Formula, T.nilable(Tap)]) }
@@ -451,8 +449,8 @@ module Homebrew
                               kegs.max_by(&:scheme_and_version)&.version
           specs[0] = "#{installed_version} → #{upgrade_version}"
         end
-        title_name = if shadowing_formula && (formula_tap = formula.tap)
-          "#{formula_tap}/#{formula.name}"
+        title_name = if shadowing_formula && formula.tap
+          Utils.fully_qualified_name(formula)
         elsif shadowed_by
           formula.name
         else

--- a/Library/Homebrew/test/bundle/installer_spec.rb
+++ b/Library/Homebrew/test/bundle/installer_spec.rb
@@ -6,6 +6,7 @@ require "attestation"
 require "bundle/dsl"
 require "bundle/installer"
 require "trust"
+require "formulary"
 
 RSpec.describe Homebrew::Bundle::Installer do
   let(:formula_entry) { Homebrew::Bundle::Dsl::Entry.new(:brew, "mysql") }
@@ -27,10 +28,11 @@ RSpec.describe Homebrew::Bundle::Installer do
                                                       installable_or_upgradable?:     true,
                                                       preinstall!:                    true)
     allow(Homebrew::Bundle::Tap).to receive_messages(preinstall!: true, install!: true, installed_taps: [])
-    allow(Formula).to receive(:[]).and_return(instance_double(Formula))
+    allow(Formula).to receive(:[]) { |name| instance_double(Formula, full_name: name, tap: CoreTap.instance) }
     allow(::Cask::CaskLoader).to receive(:load)
-      .and_return(instance_double(::Cask::Cask, full_name: "homebrew/cask/google-chrome"))
-    # Entries are installed by one batched `brew install` per type, so specs asserting a
+      .and_return(instance_double(::Cask::Cask, full_name: "google-chrome",
+                                                tap:       CoreCaskTap.instance))
+    # Formula and cask entries share one batched `brew install`, so specs asserting a
     # specific `Bundle.brew` call need the others to fall through to a stub.
     allow(Homebrew::Bundle).to receive(:brew).and_return(true)
     # Entries can name a tap the Brewfile does not, which is otherwise cloned for real.
@@ -49,27 +51,12 @@ RSpec.describe Homebrew::Bundle::Installer do
     described_class.install!([cask_entry], verbose: false, force: false, quiet: true)
   end
 
-  it "fetches and installs formulae and casks in one `brew install` per type" do
-    allow(Homebrew::Bundle::Tap).to receive(:installed_taps).and_return(["homebrew/cask"])
-
-    expect(Homebrew::Bundle::Brew).to receive(:preinstall!)
-      .with("mysql", no_upgrade: false, verbose: false)
-      .ordered
-      .and_return(true)
-    expect(Homebrew::Bundle::Cask).to receive(:preinstall!)
-      .with("google-chrome", **cask_options, no_upgrade: false, verbose: false)
-      .ordered
-      .and_return(true)
+  it "fetches and installs formulae and casks in one `brew install`" do
     expect(Homebrew::Bundle).to receive(:brew)
-      .with("install", "--formula", "mysql", verbose: false)
-      .ordered
-      .and_return(true)
-    expect(Homebrew::Bundle).to receive(:brew)
-      .with("install", "--cask", "--adopt", "homebrew/cask/google-chrome", verbose: false)
-      .ordered
-      .and_return(true)
+      .with("install", "--adopt", "homebrew/core/mysql", "homebrew/cask/google-chrome", verbose: false)
+      .once.and_return(true)
 
-    described_class.install!([formula_entry, cask_entry], verbose: false, force: false, quiet: true)
+    described_class.install!([formula_entry, cask_entry], quiet: true)
   end
 
   it "does not run a separate fetch" do
@@ -103,7 +90,9 @@ RSpec.describe Homebrew::Bundle::Installer do
     allow(Homebrew::Bundle::Tap).to receive(:installed_taps).and_return(["thirdparty/tap"])
 
     expect(Homebrew::Trust).to receive(:trust!).with(:formula, "thirdparty/tap/bar").ordered.and_return(true)
-    expect(Formula).to receive(:[]).with("thirdparty/tap/bar").ordered.and_return(instance_double(Formula))
+    expect(Formula).to receive(:[]).with("thirdparty/tap/bar").ordered
+                                   .and_return(instance_double(Formula, full_name: "thirdparty/tap/bar",
+                                                                        tap:       Tap.fetch("thirdparty/tap")))
 
     described_class.install!([trusted_formula_entry], quiet: true)
   end
@@ -117,7 +106,8 @@ RSpec.describe Homebrew::Bundle::Installer do
     expect(Homebrew::Trust).to receive(:trust!).with(:cask, "thirdparty/tap/baz").ordered.and_return(true)
     expect(::Cask::CaskLoader).to receive(:load).with("thirdparty/tap/baz").ordered
                                                 .and_return(instance_double(::Cask::Cask,
-                                                                            full_name: "thirdparty/tap/baz"))
+                                                                            full_name: "thirdparty/tap/baz",
+                                                                            tap:       Tap.fetch("thirdparty/tap")))
 
     described_class.install!([trusted_cask_entry], quiet: true)
   end
@@ -185,7 +175,7 @@ RSpec.describe Homebrew::Bundle::Installer do
 
     it "installs formulae needing installation in a single `brew install`" do
       expect(Homebrew::Bundle).to receive(:brew)
-        .with("install", "--formula", "mysql", "redis", verbose: false)
+        .with("install", "homebrew/core/mysql", "homebrew/core/redis", verbose: false)
         .and_return(true)
 
       described_class.install!([formula_entry, second_formula_entry], quiet: true)
@@ -196,7 +186,7 @@ RSpec.describe Homebrew::Bundle::Installer do
       allow(Homebrew::Bundle::Brew).to receive(:formula_installed?).with("redis").and_return(true)
 
       expect(Homebrew::Bundle).to receive(:brew)
-        .with("install", "--formula", "mysql", "redis", verbose: false)
+        .with("install", "homebrew/core/mysql", "homebrew/core/redis", verbose: false)
         .and_return(true)
 
       described_class.install!([formula_entry, second_formula_entry], quiet: true)
@@ -232,7 +222,7 @@ RSpec.describe Homebrew::Bundle::Installer do
       service_entry = Homebrew::Bundle::Dsl::Entry.new(:brew, "redis", { restart_service: :changed })
 
       expect(Homebrew::Bundle).to receive(:brew)
-        .with("install", "--formula", "mysql", verbose: false)
+        .with("install", "homebrew/core/mysql", verbose: false)
         .and_return(true)
       expect(Homebrew::Bundle::Brew).to receive(:install!)
         .with("redis", restart_service: :changed, preinstall: true, no_upgrade: false, verbose: false, force: false)
@@ -265,7 +255,7 @@ RSpec.describe Homebrew::Bundle::Installer do
 
     it "batches casks with Homebrew's native download queue" do
       expect(Homebrew::Bundle).to receive(:brew)
-        .with("install", "--cask", "--adopt", "homebrew/cask/google-chrome", verbose: false)
+        .with("install", "--adopt", "homebrew/cask/google-chrome", verbose: false)
         .and_return(true)
       expect(Homebrew::Bundle::Cask).to receive(:install!)
         .with("google-chrome", **cask_options, preinstall: false, no_upgrade: false, verbose: false, force: false)
@@ -277,35 +267,147 @@ RSpec.describe Homebrew::Bundle::Installer do
     it "installs a cask sharing a token with a formula as a cask" do
       options = { args: {}, full_name: "ambiguous" }
       entry = Homebrew::Bundle::Dsl::Entry.new(:cask, "ambiguous", options)
-      # `Cask#full_token` leaves core cask tokens unqualified, so only `--cask` stops
-      # `brew install` resolving the name to a formula of the same name.
-      allow(::Cask::CaskLoader).to receive(:load).with("ambiguous")
-                                                 .and_return(instance_double(::Cask::Cask, full_name: "ambiguous"))
+      allow(::Cask::CaskLoader).to receive(:load)
+        .with("ambiguous")
+        .and_return(instance_double(::Cask::Cask, full_name: "ambiguous", tap: CoreCaskTap.instance))
 
       expect(Homebrew::Bundle).to receive(:brew)
-        .with("install", "--cask", "--adopt", "ambiguous", verbose: false)
+        .with("install", "--adopt", "homebrew/cask/ambiguous", verbose: false)
         .and_return(true)
 
       described_class.install!([entry], quiet: true)
     end
 
-    it "keeps `--overwrite` out of the cask batch when forcing" do
+    it "uses the resolved formula name when batching an alias" do
+      allow(Formula).to receive(:[]).with("mysql").and_return(instance_double(Formula, full_name: "mysql@9.7",
+                                                                                       tap:       CoreTap.instance))
+
       expect(Homebrew::Bundle).to receive(:brew)
-        .with("install", "--formula", "--force", "--overwrite", "mysql", verbose: false)
+        .with("install", "homebrew/core/mysql@9.7", verbose: false)
         .and_return(true)
+
+      described_class.install!([formula_entry], quiet: true)
+    end
+
+    it "preserves third-party tap names in a mixed batch" do
+      allow(Formula).to receive(:[]).with("mysql")
+                                    .and_return(instance_double(Formula, full_name: "thirdparty/tap/mysql",
+                                                                         tap:       Tap.fetch("thirdparty/tap")))
+      allow(::Cask::CaskLoader).to receive(:load)
+        .and_return(instance_double(::Cask::Cask, full_name: "thirdparty/tap/google-chrome",
+                                                  tap:       Tap.fetch("thirdparty/tap")))
+
       expect(Homebrew::Bundle).to receive(:brew)
-        .with("install", "--cask", "--force", "homebrew/cask/google-chrome", verbose: false)
+        .with("install", "--adopt", "thirdparty/tap/mysql", "thirdparty/tap/google-chrome", verbose: false)
+        .once.and_return(true)
+
+      described_class.install!([formula_entry, cask_entry], quiet: true)
+    end
+
+    [:brew, :cask].each do |type|
+      it "preserves a tapless #{type} name" do
+        T.bind(self, RSpec::Core::ExampleGroup)
+
+        entry = Homebrew::Bundle::Dsl::Entry.new(type, "local")
+        if type == :brew
+          allow(Formula).to receive(:[]).with("local")
+                                        .and_return(instance_double(Formula, full_name: "local", tap: nil))
+        else
+          allow(::Cask::CaskLoader).to receive(:load).with("local")
+                                                     .and_return(instance_double(::Cask::Cask, full_name: "local",
+                                                                                               tap:       nil))
+        end
+
+        expect(Homebrew::Bundle.installable(type)).to receive(:install!)
+          .with("local", preinstall: true, no_upgrade: false, verbose: false, force: false).and_return(true)
+
+        described_class.install!([entry], quiet: true)
+      end
+    end
+
+    ["thirdparty/tap/collision", "collision"].product([false, true], [false, true]).each do |name, force, success|
+      it "installs the colliding #{name} cask with an explicit type (force: #{force}, success: #{success})" do
+        T.bind(self, RSpec::Core::ExampleGroup)
+
+        tap = Tap.fetch("thirdparty/tap") if name.include?("/")
+        if tap
+          allow(tap).to receive(:formula_dir).and_return(mktmpdir)
+          (tap.formula_dir/"collision.rb").write("class WrongClass < Formula; end")
+        end
+        allow(Homebrew::Bundle::Tap).to receive(:installed_taps).and_return(["thirdparty/tap"])
+        allow(::Cask::CaskLoader).to receive(:load).with(name)
+                                                   .and_return(instance_double(Cask::Cask, full_name: name, tap:))
+        expect(Formulary).not_to receive(:factory)
+        allow(Homebrew::Bundle::Cask).to receive(:install!).and_call_original
+        allow(Homebrew::Bundle::Cask).to receive(:cask_installed?).and_return(false)
+
+        expect(Homebrew::Bundle).to receive(:brew)
+          .with("install", *(["--force", "--overwrite"] if force), "homebrew/core/mysql", verbose: false)
+          .ordered.and_return(true)
+        expect(Homebrew::Bundle).to receive(:brew)
+          .with("install", "--cask", name, force ? "--force" : "--adopt", verbose: false)
+          .ordered.and_return(success)
+
+        expect do
+          expect(described_class.install!([
+            Homebrew::Bundle::Dsl::Entry.new(:brew, "mysql"),
+            Homebrew::Bundle::Dsl::Entry.new(:cask, name),
+          ], force:, quiet: true)).to be(success)
+        end.to output(success ? "" : /Installing #{name} has failed!/).to_stderr
+      end
+    end
+
+    it "keeps a cask matching a formula alias out of the batch without loading the formula" do
+      tap = Tap.fetch("thirdparty/tap")
+      allow(tap).to receive_messages(formula_dir: mktmpdir, alias_dir: mktmpdir)
+      (tap.formula_dir/"foo.rb").write("class WrongClass < Formula; end")
+      (tap.alias_dir/"google-chrome").make_symlink(tap.formula_dir/"foo.rb")
+      allow(::Cask::CaskLoader).to receive(:load)
+        .and_return(instance_double(Cask::Cask, full_name: "thirdparty/tap/google-chrome", tap:))
+
+      expect(Formulary).not_to receive(:factory)
+      expect(Homebrew::Bundle::Cask).to receive(:install!)
+        .with("google-chrome", **cask_options, preinstall: true, no_upgrade: false, verbose: false, force: false)
         .and_return(true)
+
+      described_class.install!([cask_entry], quiet: true)
+    end
+
+    it "installs a formula sharing a cask token with an explicit type" do
+      tap = Tap.fetch("thirdparty/tap")
+      allow(tap).to receive(:cask_dir).and_return(mktmpdir)
+      (tap.cask_dir/"collision.rb").write('raise "Do not load this cask"')
+      allow(Homebrew::Bundle::Tap).to receive(:installed_taps).and_return([tap.name])
+      allow(Formula).to receive(:[]).with("thirdparty/tap/collision")
+                                    .and_return(instance_double(Formula, full_name: "thirdparty/tap/collision", tap:))
+      allow(Homebrew::Bundle::Brew).to receive(:install!).and_call_original
+      allow(Homebrew::Bundle::Brew).to receive_messages(formula_installed?: false, formulae_by_full_name: nil,
+                                                        installed_formulae: [])
+
+      expect(::Cask::CaskLoader).not_to receive(:load)
+      expect(Homebrew::Bundle).to receive(:brew)
+        .with("install", "--formula", "thirdparty/tap/collision", verbose: false).and_return(true)
+
+      expect do
+        described_class.install!([Homebrew::Bundle::Dsl::Entry.new(:brew, "thirdparty/tap/collision")], quiet: true)
+      end.not_to output.to_stderr
+    end
+
+    it "forces formulae and casks in one batch" do
+      expect(Homebrew::Bundle).to receive(:brew)
+        .with("install", "--force", "--overwrite", "homebrew/core/mysql",
+              "homebrew/cask/google-chrome", verbose: false)
+        .once.and_return(true)
 
       described_class.install!([formula_entry, cask_entry], force: true, quiet: true)
     end
 
-    it "still installs the casks when the formula batch fails" do
-      allow(Homebrew::Bundle).to receive(:brew)
-        .with("install", "--formula", any_args).and_return(false)
+    it "finishes installed casks when a mixed batch fails" do
+      allow(Homebrew::Bundle).to receive(:brew).with("install", any_args).and_return(false)
+      allow(Homebrew::Bundle::Cask).to receive(:cask_installed_and_up_to_date?).and_return(true)
 
-      expect(Homebrew::Bundle).to receive(:brew)
-        .with("install", "--cask", "--adopt", "homebrew/cask/google-chrome", verbose: false)
+      expect(Homebrew::Bundle::Cask).to receive(:install!)
+        .with("google-chrome", **cask_options, preinstall: false, no_upgrade: false, verbose: false, force: false)
         .and_return(true)
 
       described_class.install!([formula_entry, cask_entry], quiet: true)
@@ -347,7 +449,7 @@ RSpec.describe Homebrew::Bundle::Installer do
       ENV["HOMEBREW_NO_INSTALL_UPGRADE"] = "1"
 
       expect(Homebrew::Bundle).to receive(:brew) do |*args, **options|
-        expect(args).to eq(["install", "--formula", "mysql"])
+        expect(args).to eq(["install", "homebrew/core/mysql"])
         expect(options).to eq(verbose: false)
         expect(ENV.fetch("HOMEBREW_NO_INSTALL_UPGRADE", nil)).to be_nil
         true

--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -5,6 +5,25 @@ require "timeout"
 require "utils"
 
 RSpec.describe Utils do
+  describe ".fully_qualified_name" do
+    [
+      [Formula, "homebrew/core", "foo", "homebrew/core/foo"],
+      [Cask::Cask, "homebrew/cask", "foo", "homebrew/cask/foo"],
+      [Formula, "thirdparty/tap", "thirdparty/tap/foo", "thirdparty/tap/foo"],
+      [Cask::Cask, "thirdparty/tap", "thirdparty/tap/foo", "thirdparty/tap/foo"],
+      [Formula, nil, "foo", "foo"],
+      [Cask::Cask, nil, "foo", "foo"],
+    ].each do |klass, tap_name, full_name, expected|
+      it "qualifies #{klass} from #{tap_name || "no tap"}" do
+        T.bind(self, RSpec::Core::ExampleGroup)
+
+        package = instance_double(klass, full_name:, tap: tap_name ? Tap.fetch(tap_name) : nil)
+
+        expect(described_class.fully_qualified_name(package)).to eq(expected)
+      end
+    end
+  end
+
   describe ".parallel_map" do
     it "runs all blocks concurrently" do
       # A barrier no block passes until every block has started: this

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -48,6 +48,17 @@ module Utils
     formula_or_cask.is_a?(Cask::Cask) ? formula_or_cask.token : formula_or_cask.name
   end
 
+  # Returns the package name with its tap, including core taps, or its full name if tapless.
+  sig { params(formula_or_cask: T.any(Formula, Cask::Cask)).returns(String) }
+  def self.fully_qualified_name(formula_or_cask)
+    tap = formula_or_cask.tap
+    if tap && (tap.core_tap? || tap.core_cask_tap?)
+      "#{tap.name}/#{formula_or_cask.full_name}"
+    else
+      formula_or_cask.full_name
+    end
+  end
+
   sig { params(full_name: String).returns(T.nilable(String)) }
   def self.tap_from_full_name(full_name)
     user, repository, name = full_name.split("/", 3)


### PR DESCRIPTION
- Qualify core names so ambiguous casks resolve correctly without splitting formulae and casks into separate install invocations.
- Preserve resolved aliases, third-party taps and force handling.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Codex with GPT 6 Astra at Medium effort, with local review and testing.

-----