### PR TITLE
install: report formulae in a mixed dry run

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -224,18 +224,20 @@ module Homebrew
 
           if args.dry_run?
             Install.print_dry_run_casks(casks, skip_cask_deps: args.skip_cask_deps?, include_installed: false)
-            return
-          end
-
-          installed_casks, new_casks = casks.partition(&:installed?)
-
-          fetch_casks = if Homebrew::EnvConfig.no_install_upgrade?
-            new_casks
+            # Only a mixed invocation has formulae left to report. The formula
+            # path below runs preinstall checks that are not dry-run guarded.
+            return if formulae.empty?
           else
-            upgrade_casks = Cask::Upgrade.outdated_casks(casks, args:, force: true, quiet: true)
-            new_casks | upgrade_casks
+            installed_casks, new_casks = casks.partition(&:installed?)
+
+            fetch_casks = if Homebrew::EnvConfig.no_install_upgrade?
+              new_casks
+            else
+              upgrade_casks = Cask::Upgrade.outdated_casks(casks, args:, force: true, quiet: true)
+              new_casks | upgrade_casks
+            end
+            Install.ask_casks fetch_casks, skip_cask_deps: args.skip_cask_deps? if ask
           end
-          Install.ask_casks fetch_casks, skip_cask_deps: args.skip_cask_deps? if ask
         end
 
         if Homebrew::EnvConfig.verify_attestations?

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -579,6 +579,14 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
       RUBY
       appdir = mktmpdir
 
+      expect do
+        brew "install", "--dry-run", "--no-ask", "--appdir=#{appdir}", source_formula_name,
+             cask_path("local-caffeine"),
+             "HOMEBREW_NO_INSTALL_FROM_API" => "1", "HOMEBREW_TEST_GENERIC_OS" => "1"
+      end
+        .to output(/Would install 1 cask:.*Would install 1 formula:/m).to_stdout
+        .and be_a_success
+
       with_env(HOMEBREW_NO_INSTALL_FROM_API: "1") do
         expect do
           brew "install", "--yes", "--no-ask", "--appdir=#{appdir}", source_formula_name, bottle_formula_name,


### PR DESCRIPTION
### What does this change do, and why?

`brew install --dry-run` reports only casks when given both a formula and a cask, silently omitting the formulae. The dry-run branch inside `if casks.any?` printed the cask plan and then returned from the whole command, so formula handling was never reached.

Reproduce on `main`:

```
$ brew install --dry-run homebrew/core/wget
==> Would install 1 formula:
wget
...

$ brew install --dry-run homebrew/cask/transmission
==> Would install 1 cask:
transmission

$ brew install --dry-run homebrew/core/wget homebrew/cask/transmission
==> Would install 1 cask:
transmission
```

The formula is reported on its own and disappears when a cask joins it. The exit status is 0 either way, so nothing signals that half the plan is missing.

Replacing the `return` with an `else` skips the real cask work in a dry run, as before, while letting the command continue into formula handling. The formula path already threads `dry_run:` through to its installers, so it reports itself once reached. The `installed_casks`, `new_casks` and `fetch_casks` locals are declared above with `T.let`, so leaving them unassigned in a dry run keeps the later `fetch_casks` reference safe.

This surfaced while reviewing #23871, which restores mixed formula and cask batches for `brew bundle`. Hand-testing a mixed batch with `--dry-run` makes it look as though the formulae are being dropped, when the install itself is fine and only the report is incomplete. The bug predates that PR and is independent of it.

Covered by extending the existing mixed `installs Formulae and a Cask` integration test with a dry-run assertion, rather than adding a third integration test to this command. Verified red against `main`, where the output is `==> Would install 1 cask:\nlocal-caffeine\n` with no formula.

One related problem is left alone: a formula dry-run plan is printed twice, for a formula-only invocation as well as a mixed one. That reproduces identically on `main` and has a different cause, so it wants its own change.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

AI was used. Claude Code (Claude Opus 5) found the bug while reviewing #23871, traced the early return, wrote the fix and extended the integration test. I ran `brew lgtm` and the full `brew tests` suite, reproduced the missing formula report against current `main` and verified the test red/green.

-----
