### PR TITLE
Broaden formula history error handling

### DIFF
--- a/Library/Homebrew/formula_versions.rb
+++ b/Library/Homebrew/formula_versions.rb
@@ -53,21 +53,33 @@ class FormulaVersions
   def formula_at_revision(revision, formula_relative_path = relative_path, &_block)
     Homebrew.raise_deprecation_exceptions = true
 
-    yield @formula_at_revision[revision] ||= begin
-      contents = file_contents_at_revision(revision, formula_relative_path)
+    formula = @formula_at_revision[revision] || begin
       BottleSpecification.with_legacy_syntax do
-        nostdout { Formulary.from_contents(name, path, contents, ignore_errors: true) }
+        nostdout do
+          Formulary.from_contents(
+            name, path, file_contents_at_revision(revision, formula_relative_path), ignore_errors: true
+          )
+        end
       end
-    end
-  rescue *IGNORED_EXCEPTIONS => e
-    require "utils/backtrace"
+    rescue FormulaUnavailableError
+      nil
+    rescue Homebrew::UntrustedTapError, MacOSVersion::Error
+      raise
+    rescue StandardError, ScriptError => e
+      raise if Homebrew::EnvConfig.disable_load_formula?
 
-    # We rescue these so that we can skip bad versions and
-    # continue walking the history
-    odebug "#{e} in #{name} at revision #{revision}", Utils::Backtrace.clean(e)
-    nil
-  rescue FormulaUnavailableError
-    nil
+      require "utils/backtrace"
+
+      # We rescue these so that we can skip bad versions and
+      # continue walking the history
+      odebug "#{e} in #{name} at revision #{revision}", Utils::Backtrace.clean(e)
+      nil
+    end
+
+    return if formula.nil?
+
+    @formula_at_revision[revision] = formula
+    yield formula
   ensure
     Homebrew.raise_deprecation_exceptions = false
   end

--- a/Library/Homebrew/test/formula_versions_spec.rb
+++ b/Library/Homebrew/test/formula_versions_spec.rb
@@ -31,4 +31,66 @@ RSpec.describe FormulaVersions do
 
     expect(result).to eq ["1.0", digest, :any_skip_relocation]
   end
+
+  describe "#formula_at_revision error handling" do
+    subject(:versions) { described_class.new(current) }
+
+    let(:current) do
+      formula("history-errors") do
+        T.bind(self, T.class_of(Formula))
+        url "https://brew.sh/history-errors-2.0.tar.gz"
+      end
+    end
+
+    before do
+      allow(versions).to receive(:file_contents_at_revision).and_return("")
+    end
+
+    it "skips unexpected standard errors while loading" do
+      allow(Formulary).to receive(:from_contents).and_raise("boom")
+
+      expect(versions.formula_at_revision("abc123") { raise "unreachable" }).to be_nil
+    end
+
+    it "skips unexpected script errors while loading" do
+      allow(Formulary).to receive(:from_contents).and_raise(NotImplementedError, "boom")
+
+      expect(versions.formula_at_revision("abc123") { raise "unreachable" }).to be_nil
+    end
+
+    it "does not skip macOS version errors while loading" do
+      allow(Formulary).to receive(:from_contents).and_raise(MacOSVersion::Error.new(:unsupported))
+
+      expect { versions.formula_at_revision("abc123") { raise "unreachable" } }
+        .to raise_error(MacOSVersion::Error)
+    end
+
+    it "does not skip untrusted taps while loading" do
+      allow(Formulary).to receive(:from_contents).and_raise(Homebrew::UntrustedTapError, "boom")
+
+      expect { versions.formula_at_revision("abc123") { raise "unreachable" } }
+        .to raise_error(Homebrew::UntrustedTapError, "boom")
+    end
+
+    it "does not skip disabled formula loading" do
+      allow(Homebrew::EnvConfig).to receive(:disable_load_formula?).and_return(true)
+
+      expect { versions.formula_at_revision("abc123") { raise "unreachable" } }
+        .to raise_error(RuntimeError, /HOMEBREW_DISABLE_LOAD_FORMULA/)
+    end
+
+    it "does not skip errors from the history consumer" do
+      allow(Formulary).to receive(:from_contents).and_return(current)
+
+      expect { versions.formula_at_revision("abc123") { raise ArgumentError, "boom" } }
+        .to raise_error(ArgumentError, "boom")
+    end
+
+    it "does not skip process exits while loading" do
+      allow(Formulary).to receive(:from_contents).and_raise(SystemExit, "boom")
+
+      expect { versions.formula_at_revision("abc123") { raise "unreachable" } }
+        .to raise_error(SystemExit, "boom")
+    end
+  end
 end


### PR DESCRIPTION
`FormulaVersions#formula_at_revision` only skipped the exceptions listed in `IGNORED_EXCEPTIONS`, so one historical revision that failed any other way ended the whole walk behind `brew audit --git`, livecheck version-update detection and the vulns advisory history. Follow-up to #23858.

This widens the skip to `StandardError` and `ScriptError` so a bad revision is stepped over, and keeps the failures that should not be skipped escaping. `Homebrew::UntrustedTapError`, `MacOSVersion::Error` and `HOMEBREW_DISABLE_LOAD_FORMULA` hold for every revision rather than one, so swallowing them would turn a loud failure into a walk that silently yields nothing. Errors from the block passed to `formula_at_revision` now propagate instead of being reported as a revision that failed to load.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the change and pass with it, and ran `brew lgtm --online` plus targeted specs.

-----
