### PR TITLE
Deduplicate advisory alias hits

### DIFF
--- a/Library/Homebrew/test/vulns/match_spec.rb
+++ b/Library/Homebrew/test/vulns/match_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe Homebrew::Vulns::Match do
           "ranges"  => [{ "type"   => "ECOSYSTEM",
                           "events" => [{ "introduced" => "0" }, { "fixed" => "2.32.4" }] }] },
       ])
-      merged = matcher.dedup_by_cve([
+      merged = matcher.dedup_by_aliases([
         make_hit(cve, ev(:git, ecosystem: "GIT", name: "https://github.com/psf/requests",
                                subject_version: "2.31.0")),
         make_hit(ghsa, ev(:registry, ecosystem: "PyPI", name: "requests", subject_version: "2.31.0")),
@@ -377,6 +377,79 @@ RSpec.describe Homebrew::Vulns::Match do
       expect(hits.first.vulnerability.references).to eq [{ "type" => "WEB", "url" => "https://x" }]
       expect(matcher.range_status(hits.first)&.first)
         .to have_attributes(state: :affected, fixed_in: "1.0")
+    end
+  end
+
+  describe "#dedup_by_aliases" do
+    it "coalesces mutually aliased records without a CVE deterministically" do
+      ghsa = make_hit(vuln("id" => "GHSA-9ppg-jx86-fqw7", "aliases" => ["MAL-2026-1380"]),
+                      ev(:registry, key: "ghsa"))
+      malware = make_hit(vuln("id" => "MAL-2026-1380", "aliases" => ["GHSA-9ppg-jx86-fqw7"]),
+                         ev(:registry, key: "malware"))
+
+      results = [[ghsa, malware], [malware, ghsa]].map do |hits|
+        merged = matcher.dedup_by_aliases(hits)
+        hit = merged.fetch(0)
+        [merged.length, hit.canonical_id, hit.identifiers.sort, hit.evidence.map(&:key).sort]
+      end
+
+      expect(results).to eq Array.new(2, [
+        1,
+        "GHSA-9ppg-jx86-fqw7",
+        ["GHSA-9ppg-jx86-fqw7", "MAL-2026-1380"],
+        %w[ghsa malware],
+      ])
+    end
+
+    it "merges a one-sided alias chain through its intermediate record" do
+      hits = [
+        make_hit(vuln("id" => "GHSA-a", "aliases" => ["GHSA-b"]), ev(:registry, key: "a")),
+        make_hit(vuln("id" => "GHSA-b", "aliases" => ["GHSA-c"]), ev(:registry, key: "b")),
+        make_hit(vuln("id" => "GHSA-c"), ev(:registry, key: "c")),
+      ]
+
+      merged = matcher.dedup_by_aliases(hits)
+
+      expect(merged.map { |hit| [hit.canonical_id, hit.identifiers, hit.evidence.map(&:key)] })
+        .to eq [["GHSA-a", %w[GHSA-a GHSA-b GHSA-c], %w[a b c]]]
+    end
+
+    it "picks the same record in either order when a group ties on strategy and canonical id" do
+      ghsa = make_hit(vuln("id"       => "GHSA-5v8v-66v8-mwm7",
+                           "aliases"  => ["CVE-2020-36846", "CVE-2020-8927"],
+                           "summary"  => "brotli buffer overflow",
+                           "severity" => [{ "type" => "CVSS_V3", "score" => "..." }]),
+                      ev(:registry, key: "ghsa"))
+      pysec = make_hit(vuln("id"      => "PYSEC-2020-29",
+                            "aliases" => ["CVE-2020-36846", "CVE-2020-8927"],
+                            "summary" => "brotli integer overflow"),
+                       ev(:registry, key: "pysec"))
+
+      selected = [[ghsa, pysec], [pysec, ghsa]].map do |hits|
+        hit = matcher.dedup_by_aliases(hits).fetch(0)
+        [hit.canonical_id, hit.vulnerability.id, hit.vulnerability.summary,
+         hit.vulnerability.severity_entries, hit.evidence.map(&:key)]
+      end
+
+      expect(selected).to eq Array.new(2, [
+        "CVE-2020-36846",
+        "GHSA-5v8v-66v8-mwm7",
+        "brotli buffer overflow",
+        [{ "type" => "CVSS_V3", "score" => "..." }],
+        %w[ghsa pysec],
+      ])
+    end
+
+    it "keeps distinct vulnerabilities reached through the same upstream record" do
+      upstream = vuln("id" => "DSA-1")
+      evidence = Homebrew::Vulns::Match::Evidence.new(strategy: :distro, key: "Debian/pkg",
+                                                      source_record: upstream)
+      hits = [
+        make_hit(vuln("id" => "CVE-2026-1"), evidence),
+        make_hit(vuln("id" => "CVE-2026-2"), evidence),
+      ]
+
+      expect(matcher.dedup_by_aliases(hits).map(&:canonical_id)).to eq %w[CVE-2026-1 CVE-2026-2]
     end
   end
 
@@ -1039,7 +1112,7 @@ RSpec.describe Homebrew::Vulns::Match do
           "ranges"  => [{ "type"   => "ECOSYSTEM",
                           "events" => [{ "introduced" => "0" }, { "fixed" => "2.28.1" }] }] },
       ])
-      hit = matcher.dedup_by_cve([
+      hit = matcher.dedup_by_aliases([
         make_hit(registry_record,
                  ev(:registry, ecosystem: "PyPI", name: "requests", subject_version: "2.31.0")),
         make_hit(distro_record,

--- a/Library/Homebrew/vulns/match.rb
+++ b/Library/Homebrew/vulns/match.rb
@@ -62,7 +62,7 @@ module Homebrew
       # `:cpansa` evidence so its constraint strings survive to
       # {#range_status}. `source_record` is the {Vulnerability} this evidence
       # was matched against (attached at hit-construction time), so after
-      # {#dedup_by_cve} merges hits each evidence still points at the record
+      # {#dedup_by_aliases} merges hits each evidence still points at the record
       # whose `affected[]` it should be checked against.
       Evidence = Struct.new(:strategy, :ecosystem, :name, :subject_version, :key, :resource,
                             :advisory, :source_record, keyword_init: true) do
@@ -158,11 +158,11 @@ module Homebrew
         ).freeze
       end
 
-      # Returns one {Hit} per distinct vulnerability (grouped by CVE alias)
-      # reached by any strategy. Distro-ecosystem records are resolved to their
-      # `upstream` CVE(s) so multi-CVE advisories split into per-CVE hits and
-      # collapse onto the same CVE reached via GIT/registry. All queries are
-      # versionless so historic bump-fixed advisories are returned;
+      # Returns one {Hit} per distinct vulnerability reached by any strategy,
+      # grouped by its connected id/alias family. Distro-ecosystem records are
+      # resolved to their `upstream` CVE(s), so multi-CVE advisories split into
+      # per-CVE hits and collapse onto the same CVE reached via GIT/registry.
+      # All queries are versionless so historic bump-fixed advisories are returned;
       # {#range_status} evaluates each hit against the shipped version.
       sig { params(formula: Formula).returns(T::Array[Hit]) }
       def advisories_for(formula)
@@ -240,7 +240,7 @@ module Homebrew
             end
           end
         end
-        dedup_by_cve(hits)
+        dedup_by_aliases(hits)
       end
 
       # Synthesise a {Vulnerability} for a CPANSA advisory when OSV has no
@@ -444,15 +444,42 @@ module Homebrew
       end
 
       sig { params(hits: T::Array[Hit]).returns(T::Array[Hit]) }
-      def dedup_by_cve(hits)
-        hits.group_by(&:canonical_id).map do |_, group|
+      def dedup_by_aliases(hits)
+        groups = T.let([], T::Array[T::Array[Hit]])
+        pending = hits.dup
+        until pending.empty?
+          first = pending.shift
+          raise ArgumentError, "Cannot start an empty alias group" if first.nil?
+
+          # Evidence provenance can legitimately lead to several vulnerabilities,
+          # so only the vulnerability's own identifiers connect hits.
+          identifiers = T.let({}, T::Hash[String, T::Boolean])
+          first.vulnerability.identifiers.each { |identifier| identifiers[identifier] = true }
+          group = T.let([first], T::Array[Hit])
+          loop do
+            connected, remaining = pending.partition do |hit|
+              hit.vulnerability.identifiers.any? { |identifier| identifiers.key?(identifier) }
+            end
+            break if connected.empty?
+
+            connected.each do |hit|
+              hit.vulnerability.identifiers.each { |identifier| identifiers[identifier] = true }
+            end
+            group.concat(connected)
+            pending = remaining
+          end
+          groups << group
+        end
+
+        groups.map do |group|
           next group.fetch(0) if group.one?
 
-          primary = group.max_by { |h| STRATEGY_PRECISION.fetch(h.strategy) }
-          raise ArgumentError, "Cannot pick a primary hit from an empty group" if primary.nil?
-
-          Hit.new(vulnerability: primary.vulnerability,
-                  evidence:      group.flat_map(&:evidence).uniq)
+          # Members of one alias family usually share a `canonical_id`, so the
+          # record id is what actually settles the order for most groups. Rank
+          # once so the merged evidence order is fixed too, not just the primary.
+          ranked = group.sort_by { |h| [-STRATEGY_PRECISION.fetch(h.strategy), h.canonical_id, h.vulnerability.id] }
+          Hit.new(vulnerability: ranked.fetch(0).vulnerability,
+                  evidence:      ranked.flat_map(&:evidence).uniq)
         end
       end
 


### PR DESCRIPTION
Ingest fails on the mutually aliased OSV records for the npm package `cline`: `MAL-2026-1380` and `GHSA-9ppg-jx86-fqw7` alias each other and neither carries a CVE. `dedup_by_cve` grouped hits by `Hit#canonical_id`, so both stayed separate hits and `prepare_aliases` refused to let them claim the same identity: `BREW-cline-MAL-2026-1380: identity also belongs to BREW-cline-GHSA-9ppg-jx86-fqw7`. See https://github.com/Homebrew/advisory-database/actions/runs/34101780874.

`dedup_by_aliases` groups hits into connected components over each record's own `id` and `aliases`, covering reciprocal, one-sided and transitive families. Evidence provenance is deliberately excluded, since one upstream record can lead to several distinct vulnerabilities. Merged evidence keeps its `source_record`, and the primary is picked by strategy precision, then `canonical_id`, then record id, so the emitted metadata does not depend on OSV response order.

The existing `BREW-cline-GHSA-9ppg-jx86-fqw7.json` stays canonical and no `MAL` record is created.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the fix and pass with it, and ran `brew lgtm --online` plus targeted specs.

-----
