### PR TITLE
Fix temporary service plist suffix

### DIFF
--- a/Library/Homebrew/services/cli.rb
+++ b/Library/Homebrew/services/cli.rb
@@ -498,7 +498,7 @@ module Homebrew
           service.path_dirs.each(&:mkpath)
           if file.nil? && !enable && service.service_file_generated? &&
              (contents = service.service_contents) != service.source_service_file.read
-            Tempfile.create(service.service_name) do |tempfile|
+            Tempfile.create([service.service_name, ".plist"]) do |tempfile|
               tempfile.write(contents)
               tempfile.flush
               loaded_service_name = launchctl_load(service, file: Pathname(tempfile.path), enable:)

--- a/Library/Homebrew/test/services/cli_spec.rb
+++ b/Library/Homebrew/test/services/cli_spec.rb
@@ -1250,7 +1250,8 @@ RSpec.describe Homebrew::Services::Cli do
 
       services_cli.service_load(service, nil, enable: false)
 
-      expect([loaded_contents, loaded_file.exist?]).to eq(["generated service with overrides", false])
+      expect([loaded_contents, loaded_file.extname, loaded_file.exist?])
+        .to eq(["generated service with overrides", ".plist", false])
     end
 
     it "creates service path directories before loading" do


### PR DESCRIPTION
Follow-up to #23869.

`launchctl bootstrap` rejects plist contents loaded from a path without a
`.plist` suffix with exit status 5. The temporary file introduced for
`brew services run` in #23869 did not specify a suffix, so macOS could not
bootstrap the generated service file.

This gives that `Tempfile` a `.plist` suffix and extends the existing test to
assert both the suffix and cleanup behaviour.

@MikeMcQuaid, I am very sorry I missed the required `.plist` suffix in
#23869. I reproduced the failure locally and tested this correction against
the real macOS `launchctl`, not only the mocked unit path:

- the same valid test plist failed with status 5 without the suffix and loaded
  successfully with the suffix;
- after applying this change to a Homebrew checkout on current `main`,
  `brew services run cc-connect` succeeded;
- `launchctl print` showed the generated `.plist` path and all values from
  `~/.homebrew/services/cc-connect.env`;
- the temporary plist was removed after bootstrap while the service remained
  running.

Steps to reproduce the regression on macOS before this change:

```sh
mkdir -p "${HOMEBREW_USER_CONFIG_HOME:-$HOME/.homebrew}/services"
echo 'CC_LOG_MAX_BACKUPS=3' > "${HOMEBREW_USER_CONFIG_HOME:-$HOME/.homebrew}/services/cc-connect.env"
brew services run cc-connect
```

The last command fails while executing `launchctl bootstrap` against a
temporary path without a `.plist` suffix.

Verification:

```sh
./bin/brew tests --only=services/cli:1228
./bin/brew lgtm --online
```

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

OpenAI Codex (GPT-5) was used to prepare and test this follow-up under the
contributor's direction. The diff was reviewed, the regression test was run
red then green, the full `brew lgtm --online` gate passed and the change was
verified with a live macOS `launchctl` service run as described above.

-----
