### PR TITLE
Options: remove hash support from merge methods

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -641,7 +641,7 @@ module Homebrew
       livecheck = formula_or_cask.livecheck
       referenced_livecheck = referenced_formula_or_cask&.livecheck
 
-      livecheck_options = referenced_livecheck&.options&.merge(livecheck.options) || livecheck.options
+      livecheck_options = referenced_livecheck&.options&.merge(livecheck.options) || livecheck.options.deep_dup
       livecheck_url_options = livecheck_options.url_options.compact
       livecheck_url = livecheck.url || referenced_livecheck&.url
       livecheck_regex = livecheck.regex || referenced_livecheck&.regex
@@ -742,7 +742,7 @@ module Homebrew
           case strategy_name
           when "PageMatch", "HeaderMatch"
             if (homebrew_curl = use_homebrew_curl?(referenced_package, url))
-              livecheck_options = livecheck_options.merge({ homebrew_curl: })
+              livecheck_options.homebrew_curl = homebrew_curl
               livecheck_homebrew_curl = homebrew_curl
             end
           end
@@ -923,7 +923,7 @@ module Homebrew
       resource_version_info = {}
 
       livecheck = resource.livecheck
-      livecheck_options = livecheck.options
+      livecheck_options = livecheck.options.deep_dup
       livecheck_url_options = livecheck_options.url_options.compact
       livecheck_reference = livecheck.formula
       livecheck_url = livecheck.url

--- a/Library/Homebrew/livecheck/options.rb
+++ b/Library/Homebrew/livecheck/options.rb
@@ -88,16 +88,16 @@ module Homebrew
         return self if self == other
 
         other.instance_variables.each do |ivar|
-          next if (v = T.let(other.instance_variable_get(ivar), Object)).nil?
+          next if (val = T.let(other.instance_variable_get(ivar), Object)).nil?
 
-          instance_variable_set(ivar, v)
+          public_send(:"#{ivar.to_s.delete_prefix("@")}=", val)
         end
 
         # Merging one of these options should unset the opposite value in `self`
         if !other_post_form.nil?
-          @post_json = nil
+          self.post_json = nil
         elsif !other_post_json.nil?
-          @post_form = nil
+          self.post_form = nil
         end
 
         self

--- a/Library/Homebrew/livecheck/options.rb
+++ b/Library/Homebrew/livecheck/options.rb
@@ -90,7 +90,7 @@ module Homebrew
         other.instance_variables.each do |ivar|
           next if (val = T.let(other.instance_variable_get(ivar), Object)).nil?
 
-          public_send(:"#{ivar.to_s.delete_prefix("@")}=", val)
+          public_send(:"#{ivar.to_s.delete_prefix("@")}=", val.deep_dup)
         end
 
         # Merging one of these options should unset the opposite value in `self`

--- a/Library/Homebrew/livecheck/options.rb
+++ b/Library/Homebrew/livecheck/options.rb
@@ -62,42 +62,35 @@ module Homebrew
       # Returns a new object formed by merging `other` values with a copy of
       # `self`.
       #
-      # `nil` values are removed from `other` before merging if it is an
-      # `Options` object, as these are unitiailized values. This ensures that
-      # existing values in `self` aren't unexpectedly overwritten with defaults.
-      sig { params(other: T.any(Options, T::Hash[Symbol, T.untyped])).returns(Options) }
-      def merge(other) = dup.merge!(other)
+      # `nil` values from `other` are skipped, as these are uninitialized. This
+      # ensures that existing values in `self` aren't unexpectedly overwritten
+      # by defaults.
+      sig { params(other: Options).returns(Options) }
+      def merge(other) = deep_dup.merge!(other)
 
       # Merges values from `other` into `self` and returns `self`.
       #
-      # `nil` values are removed from `other` before merging if it is an
-      # `Options` object, as these are unitiailized values. This ensures that
-      # existing values in `self` aren't unexpectedly overwritten with defaults.
-      sig { params(other: T.any(Options, T::Hash[Symbol, T.untyped])).returns(Options) }
+      # `nil` values from `other` are skipped, as these are uninitialized. This
+      # ensures that existing values in `self` aren't unexpectedly overwritten
+      # by defaults.
+      sig { params(other: Options).returns(Options) }
       def merge!(other)
         return self if other.empty?
 
         # These options are mutually exclusive, so we can't know which should be
         # used when `other` has both
-        other_post_form = T.let(other.is_a?(Options) ? other.post_form : other[:post_form], Object)
-        other_post_json = T.let(other.is_a?(Options) ? other.post_json : other[:post_json], Object)
+        other_post_form = other.post_form
+        other_post_json = other.post_json
         if other_post_form && other_post_json
           raise ArgumentError, "Cannot merge provided options using both `post_form` and `post_json`"
         end
 
-        if other.is_a?(Options)
-          return self if self == other
+        return self if self == other
 
-          other.instance_variables.each do |ivar|
-            next if (v = T.let(other.instance_variable_get(ivar), Object)).nil?
+        other.instance_variables.each do |ivar|
+          next if (v = T.let(other.instance_variable_get(ivar), Object)).nil?
 
-            instance_variable_set(ivar, v)
-          end
-        else
-          other.each do |k, v|
-            cmd = :"#{k}="
-            send(cmd, v) if respond_to?(cmd)
-          end
+          instance_variable_set(ivar, v)
         end
 
         # Merging one of these options should unset the opposite value in `self`

--- a/Library/Homebrew/livecheck/strategy/crate.rb
+++ b/Library/Homebrew/livecheck/strategy/crate.rb
@@ -95,7 +95,10 @@ module Homebrew
           match_data[:url] = generated[:url]
 
           unless match_data[:cached]
-            options = options.merge(user_agent: :browser) unless options.user_agent
+            unless options.user_agent
+              options = options.deep_dup
+              options.user_agent = :browser
+            end
             match_data.merge!(Strategy.page_content(match_data[:url], options:))
             content = match_data[:content]
           end

--- a/Library/Homebrew/test/livecheck/options_spec.rb
+++ b/Library/Homebrew/test/livecheck/options_spec.rb
@@ -80,20 +80,10 @@ RSpec.describe Homebrew::Livecheck::Options do
   end
 
   describe "#merge" do
-    it "returns an Options object with merged values" do
-      expect(options.new(**args).merge(other_args))
-        .to eq(options.new(**merged_hash))
-      expect(options.new(**args).merge(options.new(**other_args)))
-        .to eq(options.new(**merged_hash))
-      expect(options.new(**args).merge(args))
-        .to eq(options.new(**args))
-      expect(options.new(**args).merge({}))
-        .to eq(options.new(**args))
-    end
-
-    it "doesn't modify `self`" do
+    it "returns an Options object with merged values and doesn't modify `self`" do
       o1 = options.new(**args)
-      expect(o1.merge(other_post_json_args)).to eq(options.new(**post_json_merged_hash))
+      expect(o1.merge(options.new(**other_post_json_args)))
+        .to eq(options.new(**post_json_merged_hash))
       expect(o1).to eq(base_options)
     end
   end
@@ -105,57 +95,37 @@ RSpec.describe Homebrew::Livecheck::Options do
       expect(o1).to eq(merged_options)
 
       o2 = options.new(**args)
-      expect(o2.merge!(other_args)).to eq(merged_options)
-      expect(o2).to eq(merged_options)
+      expect(o2.merge!(base_options)).to eq(base_options)
+      expect(o2).to eq(base_options)
 
       o3 = options.new(**args)
-      expect(o3.merge!(base_options)).to eq(base_options)
+      expect(o3.merge!(options.new)).to eq(base_options)
       expect(o3).to eq(base_options)
-
-      o4 = options.new(**args)
-      expect(o4.merge!(args)).to eq(base_options)
-      expect(o4).to eq(base_options)
-
-      o5 = options.new(**args)
-      expect(o5.merge!(options.new)).to eq(base_options)
-      expect(o5).to eq(base_options)
-
-      o6 = options.new(**args)
-      expect(o6.merge!({})).to eq(base_options)
-      expect(o6).to eq(base_options)
-    end
-
-    it "skips over hash values without a corresponding Options value" do
-      o1 = options.new(**args)
-      expect(o1.merge!({ nonexistent: true })).to eq(base_options)
-      expect(o1).to eq(base_options)
     end
 
     it "unsets the opposite value when `other` sets `post_form` or `post_json`" do
       o1 = options.new(**args)
       expect(o1.merge!(options.new(**other_post_json_args))).to eq(options.new(**post_json_merged_hash))
 
-      o2 = options.new(**args)
-      expect(o2.merge!(other_post_json_args)).to eq(options.new(**post_json_merged_hash))
+      o2 = options.new(**post_json_args)
+      expect(o2.merge!(other_options)).to eq(merged_options)
+    end
 
-      o3 = options.new(**post_json_args)
-      expect(o3.merge!(other_args)).to eq(merged_options)
+    it "doesn't unset `post_form` or `post_json` when `other` sets neither" do
+      o1 = options.new(**args)
+      expect(o1.merge!(options.new(user_agent: :curl)))
+        .to eq(options.new(**args, user_agent: :curl))
     end
 
     it "raises an error if `other` sets both `post_form` and `post_json`" do
       o1 = options.new(**args)
-      expect { o1.merge!({ post_form: post_hash, post_json: post_hash }) }
+      expect { o1.merge!(options.new(post_form: post_hash, post_json: post_hash)) }
         .to raise_error(ArgumentError, /both `post_form` and `post_json`/)
       expect(o1).to eq(base_options)
 
-      o2 = options.new(**args)
+      o2 = options.new(post_form: post_hash, post_json: post_hash)
       expect { o2.merge!(options.new(post_form: post_hash, post_json: post_hash)) }
         .to raise_error(ArgumentError, /both `post_form` and `post_json`/)
-      expect(o2).to eq(base_options)
-
-      # o3 = options.new(post_form: post_hash, post_json: post_hash)
-      # expect { o3.merge!(options.new(post_form: post_hash, post_json: post_hash)) }
-      #   .to raise_error(ArgumentError, /both `post_form` and `post_json`/)
     end
   end
 

--- a/Library/Homebrew/test/livecheck/options_spec.rb
+++ b/Library/Homebrew/test/livecheck/options_spec.rb
@@ -117,6 +117,14 @@ RSpec.describe Homebrew::Livecheck::Options do
         .to eq(options.new(**args, user_agent: :curl))
     end
 
+    it "doesn't share a merged collection value with `other`" do
+      o1 = options.new(**args)
+      o1.merge!(other_options)
+      o1.post_form = nil
+
+      expect(other_options.post_form).to eq(other_args[:post_form])
+    end
+
     it "raises an error if `other` sets both `post_form` and `post_json`" do
       o1 = options.new(**args)
       expect { o1.merge!(options.new(post_form: post_hash, post_json: post_hash)) }


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

I implemented this manually and reviewed it using Claude Code (Opus 5, high).

-----

Mike suggested removing support for hash arguments from livecheck's `Options#merge` and `#merge!` methods (https://github.com/Homebrew/brew/pull/23832#discussion_r3943404759), as hash values can't be adequately typed. I agree with this and removing hash support also allows us to simplify the `#merge!` implementation. Hash support is merely a convenience (e.g., to avoid creating an intermediate `Options` object like `options.merge(Options.new(...))` or having to call `#dup` before copying values from `other`). This removes hash support from these methods and updates the tests accordingly.

I updated the related call sites in `latest_version` and `Crate#find_versions` to use `#deep_dup` and a property setter method. It's important that we use `#deep_dup` in these instances, as we don't want to modify the original `livecheck.options` object (which should reflect the options from the `livecheck` block) or the `Options` object that's passed into `find_versions` respectively. `#merge` was calling it for us before but we have to call it explicitly with this setup. `#deep_dup` is also specifically needed here, as `#dup` only does a shallow clone, so nested collection types can still reference another object's values and cause issues.

Besides that, this also updates `Options#merge!` to use property setter methods to modify values in `self`, as these ensure the `other` value adheres to the property's specified type. To be clear, it's technically possible to do something like `other.to_h.each { |prop, value| public_send(:"#{prop}=", value.dup) }` but that would preclude us from being able to remove the nil-guard in the future (i.e., Sorbet's `#to_h` implementation is quirky and filters `nil` values). I'm experimenting with exactly that, as we want a referencing `livecheck` block to be able to unset options it has inherited from a referenced `livecheck` block (which isn't currently possible). This doesn't affect any existing `livecheck` blocks in core/cask but it limits what we can do with `livecheck` block references, so it's something I may have to address in the future.

Lastly, this updates the `#merge!` logic to use `val.deep_dup` when setting a value from `other`, so values in `self` don't reference the original. That was an unintended side effect in the existing implementation and could cause problems for values using a collection type (`cookies`, `post_form`, `post_json`, and sometimes `header`).

[All that said, clearly the most important change here is that I fixed my "unitiailized" typo in the doc comments for these methods 😆]