### PR TITLE
Support registry package overrides

### DIFF
--- a/Library/Homebrew/test/vulns/advisory_overrides_spec.rb
+++ b/Library/Homebrew/test/vulns/advisory_overrides_spec.rb
@@ -4,6 +4,64 @@
 require "vulns/advisory_overrides"
 
 RSpec.describe Homebrew::Vulns::AdvisoryOverrides do
+  it "loads an explicit primary registry package identity" do
+    overrides = described_class.new({
+      "pnpm" => { "registry_package" => {
+        "ecosystem" => "npm",
+        "name"      => "pnpm",
+      } },
+    })
+
+    expect(overrides.registry_package_override("pnpm"))
+      .to have_attributes(ecosystem: "npm", name: "pnpm")
+  end
+
+  it "rejects unknown registry package fields" do
+    data = { "pnpm" => { "registry_package" => {
+      "ecosystem" => "npm",
+      "name"      => "pnpm",
+      "purl"      => "pkg:npm/pnpm",
+    } } }
+
+    expect { described_class.new(data) }
+      .to raise_error(Homebrew::Vulns::AdvisoryOverrides::Error, /unknown key.*purl/)
+  end
+
+  it "rejects missing registry package fields" do
+    data = { "pnpm" => { "registry_package" => { "ecosystem" => "npm" } } }
+
+    expect { described_class.new(data) }
+      .to raise_error(Homebrew::Vulns::AdvisoryOverrides::Error, /missing key.*name/)
+  end
+
+  it "rejects unsupported registry package ecosystems" do
+    data = { "pnpm" => { "registry_package" => { "ecosystem" => "GIT", "name" => "pnpm" } } }
+
+    expect { described_class.new(data) }
+      .to raise_error(Homebrew::Vulns::AdvisoryOverrides::Error, /supported registry package/)
+  end
+
+  it "rejects blank registry package fields" do
+    data = { "pnpm" => { "registry_package" => { "ecosystem" => "npm", "name" => " \n" } } }
+
+    expect { described_class.new(data) }
+      .to raise_error(Homebrew::Vulns::AdvisoryOverrides::Error, /name must be a non-blank string/)
+  end
+
+  it "rejects non-string registry package fields" do
+    data = { "pnpm" => { "registry_package" => { "ecosystem" => "npm", "name" => 12 } } }
+
+    expect { described_class.new(data) }
+      .to raise_error(Homebrew::Vulns::AdvisoryOverrides::Error, /name must be a non-blank string/)
+  end
+
+  it "rejects a non-mapping registry package" do
+    data = { "pnpm" => { "registry_package" => "npm/pnpm" } }
+
+    expect { described_class.new(data) }
+      .to raise_error(Homebrew::Vulns::AdvisoryOverrides::Error, /registry_package must be a mapping/)
+  end
+
   it "loads formula skips and candidate-specific state and fix corrections" do
     overrides = described_class.new({
       "linux-headers" => { "skip" => true },

--- a/Library/Homebrew/test/vulns/identify_spec.rb
+++ b/Library/Homebrew/test/vulns/identify_spec.rb
@@ -459,4 +459,73 @@ RSpec.describe Homebrew::Vulns::Identify do
       expect(result(nil)).to be_nil
     end
   end
+
+  describe ".registry_package_for" do
+    it "round-trips every source-derived registry ecosystem supported by overrides" do
+      urls = [
+        "https://files.pythonhosted.org/packages/00/2a/e8/jmespath-1.0.1.tar.gz",
+        "https://registry.npmjs.org/@angular/cli/-/cli-22.0.3.tgz",
+        "https://static.crates.io/crates/cargo-llvm-cov/cargo-llvm-cov-0.8.7.crate",
+        "https://rubygems.org/downloads/activesupport-8.1.1.gem",
+        "https://hackage.haskell.org/package/Allure-0.11.0.0/Allure-0.11.0.0.tar.gz",
+        "https://repo.hex.pm/tarballs/phoenix-1.7.0-rc.0.tar",
+        "https://cpan.metacpan.org/authors/id/A/AB/ABIGAIL/Regexp-Common-2024080801.tar.gz",
+        "https://repo.maven.apache.org/maven2/com/github/spotbugs/spotbugs/4.10.2/spotbugs-4.10.2.tgz",
+        "https://cran.r-project.org/src/contrib/data.table_1.15.4.tar.gz",
+        "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/13.0.3/newtonsoft.json.13.0.3.nupkg",
+      ]
+
+      round_tripped = urls.map do |url|
+        package = described_class.registry_package(url)
+        next false if package.nil?
+
+        rebuilt = described_class.registry_package_for(
+          ecosystem: package.ecosystem,
+          name:      package.name,
+          version:   package.version,
+        )
+        # `purl` is excluded because CPAN purls carry the author as a
+        # namespace, which an OSV `ecosystem`/`name` identity cannot supply.
+        rebuilt&.to_h&.slice(:ecosystem, :name, :version) == package.to_h.slice(:ecosystem, :name, :version)
+      end
+
+      expect(round_tripped).to all(be(true))
+    end
+
+    it "builds a canonical scoped npm package from an OSV identity" do
+      package = described_class.registry_package_for(ecosystem: "npm", name: "@babel/core", version: "7.0.0")
+
+      expect(package&.to_h).to eq(
+        ecosystem: "npm",
+        name:      "@babel/core",
+        version:   "7.0.0",
+        purl:      "pkg:npm/%40babel/core@7.0.0",
+      )
+    end
+
+    it "builds a canonical Maven package from an OSV identity" do
+      package = described_class.registry_package_for(
+        ecosystem: "Maven", name: "com.github.spotbugs:spotbugs", version: "4.10.2",
+      )
+
+      expect(package&.purl).to eq "pkg:maven/com.github.spotbugs/spotbugs@4.10.2"
+    end
+
+    it "rejects an unsupported OSV ecosystem" do
+      expect(described_class.registry_package_for(ecosystem: "GIT", name: "example", version: "1.0")).to be_nil
+    end
+
+    it "rejects non-canonical registry package names" do
+      invalid = [
+        { ecosystem: "PyPI", name: "Foo_Bar" },
+        { ecosystem: "Hex", name: "Foo" },
+        { ecosystem: "npm", name: "foo/bar" },
+        { ecosystem: "Maven", name: "spotbugs" },
+      ]
+
+      expect(invalid).to all(satisfy do |package|
+        described_class.registry_package_for(**package, version: "1.0").nil?
+      end)
+    end
+  end
 end

--- a/Library/Homebrew/test/vulns/match_spec.rb
+++ b/Library/Homebrew/test/vulns/match_spec.rb
@@ -36,7 +36,55 @@ RSpec.describe Homebrew::Vulns::Match do
     Homebrew::Vulns::Match::Hit.new(vulnerability:, evidence:)
   end
 
+  def pnpm_overrides
+    Homebrew::Vulns::AdvisoryOverrides.new({
+      "pnpm" => { "registry_package" => {
+        "ecosystem" => "npm",
+        "name"      => "pnpm",
+      } },
+    })
+  end
+
   describe "#identify" do
+    it "uses an explicit registry package when the source URL is not a registry archive" do
+      overridden = described_class.new(repology:, cpan_sec:, overrides: pnpm_overrides)
+      pnpm = formula("pnpm") do
+        T.bind(self, T.class_of(Formula))
+        url "https://github.com/pnpm/pnpm/archive/refs/tags/v12.3.4.tar.gz"
+      end
+
+      expect(overridden.identify(pnpm).primary_package.to_h).to eq(
+        ecosystem: "npm",
+        name:      "pnpm",
+        version:   "12.3.4",
+        purl:      "pkg:npm/pnpm@12.3.4",
+      )
+    end
+
+    it "rejects an explicit registry package that conflicts with the source URL" do
+      overridden = described_class.new(repology:, cpan_sec:, overrides: pnpm_overrides)
+      pnpm = formula("pnpm") do
+        T.bind(self, T.class_of(Formula))
+        url "https://registry.npmjs.org/not-pnpm/-/not-pnpm-12.3.4.tgz"
+      end
+
+      expect { overridden.identify(pnpm) }
+        .to raise_error(Homebrew::Vulns::AdvisoryOverrides::Error, /conflicts with its source URL/)
+    end
+
+    it "keeps the source-derived package when the formula has no stable version" do
+      overridden = described_class.new(repology:, cpan_sec:, overrides: pnpm_overrides)
+      pnpm = formula("pnpm") do
+        T.bind(self, T.class_of(Formula))
+        url "https://registry.npmjs.org/pnpm/-/pnpm-12.3.4.tgz"
+      end
+      stable = pnpm.stable
+      allow(stable).to receive(:version).and_return(nil)
+      allow(pnpm).to receive(:stable).and_return(stable)
+
+      expect(overridden.identify(pnpm).primary_package&.name).to eq "pnpm"
+    end
+
     it "derives git repo/tag, primary registry package, resources and distro packages" do
       f = formula("requests") do
         T.bind(self, T.class_of(Formula))
@@ -851,6 +899,57 @@ RSpec.describe Homebrew::Vulns::Match do
     it "returns the pkg_version at the oldest revision still at or past upstream fixed_in" do
       stub_history(["2.31.0", "2.30.0", "2.28.1", "2.28.0", "2.27.0"])
       expect(matcher.first_fixed_version(requests, hit_fixed_at("2.28.1"))).to eq "2.28.1"
+    end
+
+    def stub_pnpm_history(*formulae)
+      fv = instance_double(FormulaVersions)
+      revisions = formulae.each_index.map { |index| ["r#{index}", "Formula/p/pnpm.rb"] }
+      allow(fv).to receive(:rev_list) { |_, &block| revisions.each { |revision| block.call(*revision) } }
+      formulae.each_with_index do |old, index|
+        allow(fv).to receive(:formula_at_revision).with("r#{index}", anything).and_yield(old)
+      end
+      allow(FormulaVersions).to receive(:new).and_return(fv)
+    end
+
+    def pnpm_hit
+      make_hit(
+        vuln("id" => "CVE-1", "affected" => [
+          { "package" => { "ecosystem" => "npm", "name" => "pnpm" },
+            "ranges"  => [{ "type"   => "ECOSYSTEM",
+                            "events" => [{ "introduced" => "0" }, { "fixed" => "11.11.0" }] }] },
+        ]),
+        ev(:registry, ecosystem: "npm", name: "pnpm", subject_version: "12.3.4"),
+      )
+    end
+
+    it "uses an explicit registry identity across a source transition in history" do
+      overridden = described_class.new(repology:, cpan_sec:, overrides: pnpm_overrides)
+      current = formula("pnpm") do
+        T.bind(self, T.class_of(Formula))
+        url "https://github.com/pnpm/pnpm/archive/refs/tags/v12.3.4.tar.gz"
+      end
+      previous = formula("pnpm") do
+        T.bind(self, T.class_of(Formula))
+        url "https://registry.npmjs.org/pnpm/-/pnpm-11.10.0.tgz"
+      end
+      stub_pnpm_history(current, previous)
+
+      expect(overridden.first_fixed_version(current, pnpm_hit)).to eq "12.3.4"
+    end
+
+    it "fails a history walk closed when the declared registry identity conflicts" do
+      overridden = described_class.new(repology:, cpan_sec:, overrides: pnpm_overrides)
+      current = formula("pnpm") do
+        T.bind(self, T.class_of(Formula))
+        url "https://github.com/pnpm/pnpm/archive/refs/tags/v12.3.4.tar.gz"
+      end
+      conflicting = formula("pnpm") do
+        T.bind(self, T.class_of(Formula))
+        url "https://registry.npmjs.org/not-pnpm/-/not-pnpm-11.10.0.tgz"
+      end
+      stub_pnpm_history(conflicting)
+
+      expect(overridden.first_fixed_version(current, pnpm_hit)).to eq :history_unavailable
     end
 
     it "honours last_affected inclusivity by re-running the range per revision" do

--- a/Library/Homebrew/vulns/advisory_overrides.rb
+++ b/Library/Homebrew/vulns/advisory_overrides.rb
@@ -1,15 +1,22 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "vulns/identify"
 require "yaml"
 
 module Homebrew
   module Vulns
-    # Reviewed, candidate-specific corrections for advisory matching. These are
-    # intentionally keyed by formula and upstream advisory identifier so a bad
-    # upstream range cannot silently change unrelated matches.
+    # Reviewed formula identity and candidate-specific corrections for advisory
+    # matching. These are intentionally keyed by formula, and range corrections
+    # are further keyed by upstream advisory identifier, so a bad upstream range
+    # cannot silently change unrelated matches.
     class AdvisoryOverrides
       class Error < RuntimeError; end
+
+      class RegistryPackageOverride < T::Struct
+        const :ecosystem, String
+        const :name, String
+      end
 
       class Entry < T::Struct
         const :state, T.nilable(Symbol)
@@ -19,6 +26,10 @@ module Homebrew
 
       VALID_STATES = [:affected, :fixed, :not_applicable].freeze
       private_constant :VALID_STATES
+
+      # Mirrored by Homebrew/advisory-database spec/overrides_spec.rb.
+      REGISTRY_PACKAGE_KEYS = %w[ecosystem name].freeze
+      private_constant :REGISTRY_PACKAGE_KEYS
 
       sig { params(path: Pathname).returns(AdvisoryOverrides) }
       def self.from_file(path)
@@ -30,6 +41,7 @@ module Homebrew
       sig { params(data: T.untyped).void }
       def initialize(data)
         @skipped_formulae = T.let({}, T::Hash[String, T::Boolean])
+        @registry_packages = T.let({}, T::Hash[String, RegistryPackageOverride])
         @advisories = T.let({}, T::Hash[String, T::Hash[String, Entry]])
 
         root = hash(data, "top level")
@@ -37,12 +49,28 @@ module Homebrew
           raise Error, "Formula names must be strings" unless formula_name.is_a?(String)
 
           formula = hash(raw_formula, formula_name)
-          reject_unknown_keys(formula, %w[skip advisories], formula_name)
+          reject_unknown_keys(formula, %w[skip advisories registry_package], formula_name)
 
           skip = formula.fetch("skip", false)
           raise Error, "#{formula_name}.skip must be true or false" unless [true, false].include?(skip)
 
           @skipped_formulae[formula_name] = true if skip
+
+          if formula.key?("registry_package")
+            location = "#{formula_name}.registry_package"
+            package = hash(formula.fetch("registry_package"), location)
+            reject_unknown_keys(package, REGISTRY_PACKAGE_KEYS, location)
+            missing = REGISTRY_PACKAGE_KEYS - package.keys
+            raise Error, "#{location} is missing key(s): #{missing.join(", ")}" if missing.any?
+
+            ecosystem = nonblank_string(package.fetch("ecosystem"), "#{location}.ecosystem")
+            name = nonblank_string(package.fetch("name"), "#{location}.name")
+            unless Identify.registry_package_for(ecosystem:, name:)
+              raise Error, "#{location} must identify a supported registry package with a canonical OSV name"
+            end
+
+            @registry_packages[formula_name] = RegistryPackageOverride.new(ecosystem:, name:)
+          end
           next unless formula.key?("advisories")
 
           raw_advisories = hash(formula.fetch("advisories"), "#{formula_name}.advisories")
@@ -78,12 +106,18 @@ module Homebrew
           @advisories[formula_name] = parsed.freeze
         end
         @skipped_formulae.freeze
+        @registry_packages.freeze
         @advisories.freeze
       end
 
       sig { params(formula_name: String).returns(T::Boolean) }
       def skip_formula?(formula_name)
         @skipped_formulae.key?(formula_name)
+      end
+
+      sig { params(formula_name: String).returns(T.nilable(RegistryPackageOverride)) }
+      def registry_package_override(formula_name)
+        @registry_packages[formula_name]
       end
 
       sig { params(formula_name: String, identifiers: T::Array[String]).returns(T.nilable(Entry)) }
@@ -105,6 +139,16 @@ module Homebrew
         return value if value.is_a?(Hash)
 
         raise Error, "#{location} must be a mapping"
+      end
+
+      sig { params(value: T.anything, location: String).returns(String) }
+      def nonblank_string(value, location)
+        case value
+        when String
+          return value if value.match?(/\S/)
+        end
+
+        raise Error, "#{location} must be a non-blank string"
       end
 
       sig {

--- a/Library/Homebrew/vulns/identify.rb
+++ b/Library/Homebrew/vulns/identify.rb
@@ -87,6 +87,23 @@ module Homebrew
       # for CPAN distributions (queried via CPANSA, not OSV).
       RegistryPackage = Struct.new(:ecosystem, :name, :version, :purl, keyword_init: true)
 
+      REGISTRY_PURL_TYPES = T.let(
+        {
+          "CPAN"      => "cpan",
+          "CRAN"      => "cran",
+          "Hackage"   => "hackage",
+          "Hex"       => "hex",
+          "Maven"     => "maven",
+          "NuGet"     => "nuget",
+          "PyPI"      => "pypi",
+          "RubyGems"  => "gem",
+          "crates.io" => "cargo",
+          "npm"       => "npm",
+        }.freeze,
+        T::Hash[String, String],
+      )
+      private_constant :REGISTRY_PURL_TYPES
+
       ARCHIVE_EXTENSIONS = /\.(?:tar\.gz|tar\.bz2|tar\.xz|tgz|zip|gem|crate|tar|nupkg)\z/i
       private_constant :ARCHIVE_EXTENSIONS
 
@@ -118,9 +135,43 @@ module Homebrew
       def self.registry_package(url)
         return if url.nil?
 
-        ecosystem, purl = registry_purl(url)
-        return if purl.nil?
+        result = registry_purl(url)
+        return if result.nil?
 
+        ecosystem, purl = result
+        registry_package_from_purl(ecosystem, purl)
+      end
+
+      # Build a canonical registry package from reviewed OSV package fields.
+      # Returns nil for unsupported ecosystems or non-canonical package names.
+      sig {
+        params(ecosystem: String, name: String, version: T.nilable(String)).returns(T.nilable(RegistryPackage))
+      }
+      def self.registry_package_for(ecosystem:, name:, version: nil)
+        return unless REGISTRY_PURL_TYPES.key?(ecosystem)
+        return if name.empty? || name.match?(/\s/)
+
+        namespace = T.let(nil, T.nilable(String))
+        purl_name = T.let(name, String)
+        case ecosystem
+        when "npm"
+          if name.start_with?("@")
+            namespace, separator, purl_name = name.partition("/")
+            return if namespace == "@" || separator.empty? || purl_name.empty? || purl_name.include?("/")
+          elsif name.include?("/")
+            return
+          end
+        when "Maven"
+          namespace, separator, purl_name = name.rpartition(":")
+          return if separator.empty? || namespace.empty? || purl_name.empty? || namespace.include?(":")
+        end
+
+        package = registry_package_from_purl(ecosystem, purl_for(ecosystem, namespace:, name: purl_name, version:))
+        package if package.name == name
+      end
+
+      sig { params(ecosystem: String, purl: Purl).returns(RegistryPackage) }
+      def self.registry_package_from_purl(ecosystem, purl)
         name = case purl.type
         when "maven" then "#{purl.namespace}:#{purl.name}"
         # OSV keys PyPI packages by their PEP 503 normalised name.
@@ -131,6 +182,16 @@ module Homebrew
         end
         RegistryPackage.new(ecosystem:, name:, version: purl.version, purl: purl.to_s).freeze
       end
+      private_class_method :registry_package_from_purl
+
+      sig {
+        params(ecosystem: String, name: String, namespace: T.nilable(String),
+               version: T.nilable(String)).returns(Purl)
+      }
+      def self.purl_for(ecosystem, name:, namespace: nil, version: nil)
+        Purl.new(type: REGISTRY_PURL_TYPES.fetch(ecosystem), namespace:, name:, version:)
+      end
+      private_class_method :purl_for
 
       sig { params(url: String).returns(T.nilable([String, Purl])) }
       def self.registry_purl(url)
@@ -142,7 +203,7 @@ module Homebrew
           name, _, version = basename.rpartition("-")
           return if name.empty?
 
-          ["PyPI", Purl.new(type: "pypi", name:, version:)]
+          ["PyPI", purl_for("PyPI", name:, version:)]
         when %r{\Ahttps://registry\.npmjs\.org/(?:((?:@|%40)[^/]+)/)?([^/@%][^/]*)/-/}
           namespace = Regexp.last_match(1)
           name = Regexp.last_match(2)
@@ -152,7 +213,7 @@ module Homebrew
           name = decode(name)
           return unless (version = version_after_prefix(basename, name))
 
-          ["npm", Purl.new(type: "npm", namespace:, name:, version:)]
+          ["npm", purl_for("npm", namespace:, name:, version:)]
         when %r{\Ahttps://static\.crates\.io/crates/([^/]+)/}
           name = Regexp.last_match(1)
           return if name.nil?
@@ -160,12 +221,12 @@ module Homebrew
           name = decode(name)
           return unless (version = version_after_prefix(basename, name))
 
-          ["crates.io", Purl.new(type: "cargo", name:, version:)]
+          ["crates.io", purl_for("crates.io", name:, version:)]
         when %r{\Ahttps://rubygems\.org/(?:downloads|gems)/}
           name, version = gem_name_version(basename)
           return if name.nil?
 
-          ["RubyGems", Purl.new(type: "gem", name:, version:)]
+          ["RubyGems", purl_for("RubyGems", name:, version:)]
         when %r{\Ahttps://hackage\.haskell\.org/package/([^/]+)}
           match = Regexp.last_match(1)&.match(HACKAGE_PKGID)
           return if match.nil?
@@ -173,13 +234,13 @@ module Homebrew
           name, version = match.captures
           return if name.nil?
 
-          ["Hackage", Purl.new(type: "hackage", name:, version:)]
+          ["Hackage", purl_for("Hackage", name:, version:)]
         when %r{\Ahttps://repo\.hex\.pm/tarballs/}
           # Hex package names are `[a-z][a-z0-9_]*` so the first hyphen delimits.
           name, sep, version = basename.partition("-")
           return if sep.empty?
 
-          ["Hex", Purl.new(type: "hex", name:, version:)]
+          ["Hex", purl_for("Hex", name:, version:)]
         when %r{/authors/id/[A-Z]/[A-Z]{2}/([A-Z][A-Z0-9-]+)/}
           author = Regexp.last_match(1)
           match = basename.match(CPAN_DISTNAME)
@@ -188,7 +249,7 @@ module Homebrew
           name, version = match.captures
           return if name.nil?
 
-          ["CPAN", Purl.new(type: "cpan", namespace: author, name:, version:)]
+          ["CPAN", purl_for("CPAN", namespace: author, name:, version:)]
         # Maven Central only: OSV's bare `Maven` ecosystem is Central-scoped,
         # so third-party repositories (Google, fabricmc, jfrog, ...) are skipped.
         when %r{\Ahttps://repo1?\.maven\.(?:apache\.)?org/maven2/(.+)/([^/]+)/([^/]+)/\2-\3[.-][^/]+\z},
@@ -198,17 +259,17 @@ module Homebrew
           version = Regexp.last_match(3)
           return if group_id.nil? || artifact_id.nil?
 
-          ["Maven", Purl.new(type: "maven", namespace: group_id.tr("/", "."), name: artifact_id, version:)]
+          ["Maven", purl_for("Maven", namespace: group_id.tr("/", "."), name: artifact_id, version:)]
         when %r{\Ahttps://(?:cran|cloud)\.r-project\.org/src/contrib/(?:Archive/[^/]+/)?([^/_]+)_([^/]+)\.tar\.gz\z}
           name = Regexp.last_match(1)
           return if name.nil?
 
-          ["CRAN", Purl.new(type: "cran", name:, version: Regexp.last_match(2))]
+          ["CRAN", purl_for("CRAN", name:, version: Regexp.last_match(2))]
         when %r{\Ahttps://(?:api|www)\.nuget\.org/(?:v3-flatcontainer|api/v2/package)/([^/]+)/([^/]+)(?:/|\z)}
           name = Regexp.last_match(1)
           return if name.nil?
 
-          ["NuGet", Purl.new(type: "nuget", name:, version: Regexp.last_match(2))]
+          ["NuGet", purl_for("NuGet", name:, version: Regexp.last_match(2))]
         end
       end
 

--- a/Library/Homebrew/vulns/match.rb
+++ b/Library/Homebrew/vulns/match.rb
@@ -149,13 +149,40 @@ module Homebrew
         Identity.new(
           git_repo:          Identify.repo_url(stable_url, formula.head&.url, formula.homepage),
           git_tag:           Identify.tag(stable_url) || stable&.specs&.dig(:tag) || stable&.version&.to_s,
-          primary_package:   Identify.registry_package(stable_url),
+          primary_package:   primary_registry_package(formula),
           resource_packages: formula.resources.filter_map do |r|
             pkg = Identify.registry_package(r.url)
             [r.name, pkg] if pkg
           end.to_h.freeze,
           distro_packages:   distro_packages_for(formula.name),
         ).freeze
+      end
+
+      # Return the formula's source-derived registry package, unless a reviewed
+      # override supplies an identity for formulae built from non-registry URLs.
+      # Historical conflicts are uncheckable so one stale override cannot abort
+      # matching every formula.
+      sig {
+        params(formula: Formula, strict: T::Boolean).returns(T.nilable(Identify::RegistryPackage))
+      }
+      def primary_registry_package(formula, strict: true)
+        derived = Identify.registry_package(formula.stable&.url)
+        override = @overrides&.registry_package_override(formula.name)
+        return derived unless override
+
+        if derived
+          if derived.ecosystem != override.ecosystem || derived.name != override.name
+            raise AdvisoryOverrides::Error, "#{formula.name}.registry_package conflicts with its source URL" if strict
+
+            return
+          end
+          return derived
+        end
+
+        version = formula.stable&.version&.to_s
+        return if version.nil?
+
+        Identify.registry_package_for(ecosystem: override.ecosystem, name: override.name, version:)
       end
 
       # Returns one {Hit} per distinct vulnerability reached by any strategy,
@@ -769,7 +796,7 @@ module Homebrew
             return [true, version]
           end
 
-          primary_package = Identify.registry_package(stable_url)
+          primary_package = primary_registry_package(formula, strict: false)
           return [true, nil] if primary_package.nil?
           if primary_package.ecosystem != evidence.ecosystem || primary_package.name != evidence.name
             return [false, nil]


### PR DESCRIPTION
Ingest fails on the 30 tracked `pnpm` records. homebrew-core acc59bfe7fa moved `pnpm` 12.3.4 from its npm tarball to a GitHub source archive and a Rust build, so `Identify.registry_package` no longer derives `pkg:npm/pnpm` and every OSV npm range became unevaluable. The matcher rewrote each tracked record without a `range_state` and `advisories:filter` raised on all 30. See https://github.com/Homebrew/advisory-database/actions/runs/34156413561.

`registry_package` declares a formula's primary language-registry identity independently of its source URL, for current matching and for formula-history walks across the transition. It is validated through `Identify.registry_package_for`, which rejects unsupported ecosystems and non-canonical OSV names, and which derives the versioned purl rather than accepting one, so `ecosystem`, `name` and the purl cannot disagree. All ten registry purl types now build through a single ecosystem map, so a type added to `registry_purl` without a matching entry fails loudly rather than silently narrowing what an override can declare.

An identity that disagrees with a source-derived one raises on the current formula, where it means the override is stale, but fails closed as `:history_unavailable` during a history walk. `FormulaVersions#formula_at_revision` does not rescue the block it yields to and `advisory-match` only guards `OSV::Error`, so raising there would abort matching for every formula rather than skipping one candidate.

To reproduce on current `main`, from an advisory-database checkout:

```bash
HOMEBREW_NO_INSTALL_FROM_API=1 brew advisory-match pnpm --verbose --repology data/repology.json
```

The 30 candidates report `git`, `medium` and `uncomparable`. Adding `--overrides data/overrides.yml` with Homebrew/advisory-database#291 on top of this change gives each `pkg:npm/pnpm@12.3.4`, evaluates its npm range, and the comparable-only filter passes.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the change and pass with it, and ran `brew lgtm --online` plus a live pnpm advisory-match replay.

-----


