### PR TITLE
test-bot: add padded prefix output

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -445,7 +445,7 @@ jobs:
           - name: test-bot (Linux arm64, padded prefix)
             runs-on: ubuntu-24.04-arm
             container: ghcr.io/homebrew/ubuntu24.04:latest
-            prefix-constant: LINUX_ARM64_BOTTLE_PREFIX
+            padded-prefix: true
             system-tar: true
           - name: test-bot (Linux x86_64)
             runs-on: ubuntu-latest
@@ -453,7 +453,7 @@ jobs:
           - name: test-bot (Linux x86_64, padded prefix)
             runs-on: ubuntu-latest
             container: ghcr.io/homebrew/ubuntu24.04:main
-            prefix-constant: LINUX_X86_64_BOTTLE_PREFIX
+            padded-prefix: true
             system-tar: true
           - name: test-bot (no Sorbet)
             runs-on: ubuntu-latest
@@ -468,7 +468,7 @@ jobs:
             runs-on: macos-26
           - name: test-bot (macOS arm64, padded prefix)
             runs-on: macos-26
-            prefix-constant: MACOS_ARM64_BOTTLE_PREFIX
+            padded-prefix: true
     env:
       HOMEBREW_TEST_BOT_ANALYTICS: 1
     steps:
@@ -515,11 +515,9 @@ jobs:
           cask: false
 
       - name: Set up padded bottle prefix
-        if: matrix.prefix-constant
-        env:
-          PREFIX_CONSTANT: ${{ matrix.prefix-constant }}
+        if: matrix.padded-prefix
         run: |
-          padded_prefix="$(brew ruby -- -e 'puts Homebrew.const_get(ARGV.fetch(0))' "${PREFIX_CONSTANT}")"
+          padded_prefix="$(brew test-bot --print-padded-prefix)"
           test "${#padded_prefix}" -eq 64
           mkdir -p "${padded_prefix}/bin"
           ln -s "$(brew --repository)/bin/brew" "${padded_prefix}/bin/brew"
@@ -545,7 +543,7 @@ jobs:
 
       - run: brew test-bot --only-setup
         env:
-          HOMEBREW_TEST_BOT_IGNORE_DOCTOR_FAILURE: ${{ matrix.prefix-constant && '1' || null }}
+          HOMEBREW_TEST_BOT_IGNORE_DOCTOR_FAILURE: ${{ matrix.padded-prefix && '1' || null }}
 
       - name: Run brew test-bot formulae
         run: |

--- a/Library/Homebrew/dev-cmd/test-bot.rb
+++ b/Library/Homebrew/dev-cmd/test-bot.rb
@@ -3,6 +3,7 @@
 
 require "abstract_command"
 require "test_bot"
+require "utils/bottles"
 
 module Homebrew
   module Cmd
@@ -108,6 +109,9 @@ module Homebrew
                                  "formulae dependents step."
         comma_array "--tested-formulae=",
                     description: "Use these tested formulae from formulae steps for a formulae dependents step."
+        switch "--print-padded-prefix",
+               description: "Print the padded bottle prefix for the current platform.",
+               hidden:      true
         flag   "--formulae-dependents-shard=",
                description: "Only test the formulae dependents in the given <SHARD/TOTAL>.",
                hidden:      true
@@ -122,6 +126,15 @@ module Homebrew
 
       sig { override.void }
       def run
+        if args.print_padded_prefix?
+          tag = Utils::Bottles.tag
+          padded_prefix = tag.padded_prefix
+          odie "No padded bottle prefix is available for #{tag}." if padded_prefix.nil?
+
+          puts padded_prefix
+          return
+        end
+
         if GitHub::Actions.env_set?
           ENV["HOMEBREW_COLOR"] = "1"
           ENV["HOMEBREW_GITHUB_ACTIONS"] = "1"

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/test_bot_cmd.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/test_bot_cmd.rbi
@@ -78,6 +78,9 @@ class Homebrew::Cmd::TestBotCmd::Args < Homebrew::CLI::Args
   def only_tap_syntax?; end
 
   sig { returns(T::Boolean) }
+  def print_padded_prefix?; end
+
+  sig { returns(T::Boolean) }
   def publish?; end
 
   sig { returns(T.nilable(String)) }

--- a/Library/Homebrew/test/dev-cmd/test-bot_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/test-bot_spec.rb
@@ -1,6 +1,27 @@
 # typed: strict
 # frozen_string_literal: true
 
-RSpec.describe "brew test-bot", type: :system do
+require "cmd/shared_examples/args_parse"
+require "dev-cmd/test-bot"
+
+RSpec.describe Homebrew::Cmd::TestBotCmd do
+  it_behaves_like "parseable arguments"
   it_behaves_like "a documented command", "test-bot"
+
+  it "prints the padded prefix for the current bottle tag" do
+    tag = Utils::Bottles::Tag.from_symbol(:arm64_tahoe)
+    allow(Utils::Bottles).to receive(:tag).and_return(tag)
+
+    expect { described_class.new(["--print-padded-prefix"]).run }
+      .to output("#{tag.padded_prefix}\n").to_stdout
+  end
+
+  it "fails when the current bottle tag has no padded prefix" do
+    tag = Utils::Bottles::Tag.from_symbol(:tahoe)
+    allow(Utils::Bottles).to receive(:tag).and_return(tag)
+
+    expect { described_class.new(["--print-padded-prefix"]).run }
+      .to raise_error(SystemExit)
+      .and output(/No padded bottle prefix is available for #{tag}/).to_stderr
+  end
 end


### PR DESCRIPTION
The three padded prefix `test-bot` jobs read a per platform constant out of `Homebrew` through `brew ruby`, which is not a supported extension point and duplicates in the workflow matrix something `brew` already knows.

`brew test-bot` can see the current bottle tag, so this adds a hidden `--print-padded-prefix` switch that prints `Utils::Bottles.tag.padded_prefix` and dies when the current tag has no padded prefix. The matrix entries collapse from three different constant names to a single `padded-prefix: true`, so adding another padded prefix platform no longer means naming a constant in the workflow.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new specs fail without the switch and pass with it, checked `padded_prefix` maps to the same three constants the matrix previously named, and ran `brew lgtm` plus `actionlint` on the changed workflow.

-----
