### PR TITLE
Use setup-ruby in vendor version workflow

### DIFF
--- a/.github/workflows/vendor-version.yml
+++ b/.github/workflows/vendor-version.yml
@@ -24,12 +24,17 @@ jobs:
           core: false
           cask: false
 
+      - name: Set up Ruby
+        uses: Homebrew/actions/setup-ruby@3cdb78d0f62ad29dd32de765782654f4eedea607 # 2026.08.31.1
+        with:
+          portable-ruby: true
+
       - name: Install Bundler RubyGems
         run: brew install-bundler-gems --groups=all
 
       - name: Get Ruby ABI version
         id: ruby-abi
-        run: echo "version=$(brew ruby -e "puts Gem.ruby_api_version")" >> "${GITHUB_OUTPUT}"
+        run: echo "version=$(ruby -e 'puts Gem.ruby_api_version')" >> "${GITHUB_OUTPUT}"
 
       - name: Get gem info
         id: gem-info
@@ -52,7 +57,8 @@ jobs:
           git checkout "origin/${GITHUB_BASE_REF}"
           rm .homebrew_vendor_version
           brew install-bundler-gems --groups=all
-          if [[ "$(brew ruby -e "puts Gem.ruby_api_version")" == "${ABI_VERSION}" && \
+          # The install above re-points portable-ruby/current to the base ref's Ruby.
+          if [[ "$(ruby -e 'puts Gem.ruby_api_version')" == "${ABI_VERSION}" && \
                 "$(<.homebrew_vendor_version)" == "${VENDOR_VERSION}" ]]
           then
             while IFS= read -r gem; do


### PR DESCRIPTION
The vendor version check reads the Ruby ABI through `brew ruby`, which is not a supported extension point. `Homebrew/actions/setup-ruby` with `portable-ruby: true` puts the same interpreter `brew` itself uses on `PATH`, so a plain `ruby -e` gets the same answer without reaching into `brew`.

The second call still reports the base ref's ABI, which is the whole point of that comparison. `setup-ruby` adds `vendor/portable-ruby/current/bin` to `PATH`, and the `brew install-bundler-gems` on the line above re-points `current` at whichever Ruby the base ref pins, so the symlink resolves to the base ref's interpreter at exec time. A comment records that, since it is not obvious from the diff.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the change; I reviewed the diff, confirmed `setup-ruby` puts the same interpreter on `PATH` that `brew` resolves via `utils/ruby.sh`, traced the `portable-ruby/current` re-point that keeps the base ref comparison honest, and ran `brew lgtm` plus `actionlint` on the changed workflow. This workflow has no Ruby changes, so there is nothing to add tests for.

-----
