### PR TITLE
Allow limiting total build-from-source dependents

### DIFF
--- a/Library/Homebrew/dev-cmd/test-bot.rb
+++ b/Library/Homebrew/dev-cmd/test-bot.rb
@@ -25,7 +25,8 @@ module Homebrew
         switch "--build-from-source",
                description: "Build from source rather than building bottles."
         switch "--build-dependents-from-source",
-               description: "Build dependents from source rather than testing bottles."
+               description: "Build a limited set of dependents from source in addition to testing bottles. " \
+                            "Up to 10 per formula per shard, prioritising popular dependents in a sharded group."
         switch "--junit",
                description: "generate a JUnit XML test results file."
         switch "--keep-old",

--- a/Library/Homebrew/test/test_bot/formulae_dependents_spec.rb
+++ b/Library/Homebrew/test/test_bot/formulae_dependents_spec.rb
@@ -54,4 +54,74 @@ RSpec.describe Homebrew::TestBot::FormulaeDependents do
       expect(formulae_dependents.dependents_for_shard([[dependent, dependent.deps.to_a]], "2/2")).to be_empty
     end
   end
+
+  describe "#split_source_dependents" do
+    let(:dependents) { dependents_hash.values }
+    let(:dependents_hash) do
+      14.downto(6).to_h do |i|
+        f = formula "dependent-#{i}" do
+          T.bind(self, T.class_of(Formula))
+          url "https://brew.sh/dependent-#{i}/1.0.tar.gz"
+          depends_on "dependency"
+        end
+        [i, [f, f.deps.to_a]]
+      end
+    end
+
+    before do
+      stub_formula_loader(
+        formula("dependency") do
+          T.bind(self, T.class_of(Formula))
+          url "https://brew.sh/dependency/1.0.tar.gz"
+        end,
+      )
+      allow(Homebrew::API::Analytics).to receive(:fetch).with("install", 90).and_return({
+        "items" => 1.upto(20).map { |i| { "number" => i, "formula" => "dependent-#{i}" } },
+      })
+      allow(formulae_dependents).to receive_messages(
+        build_dependent_from_source?: true,
+        bottled_or_built?:            true,
+      )
+    end
+
+    it "does not source build dependents with unbottled dependency" do
+      unbottled_dependency = formula "unbottled-dependency" do
+        T.bind(self, T.class_of(Formula))
+        url "https://brew.sh/unbottled-dependency/1.0.tar.gz"
+        depends_on "dependency"
+      end
+      stub_formula_loader unbottled_dependency
+      allow(formulae_dependents).to receive(:bottled_or_built?).with(unbottled_dependency, []).and_return(false)
+
+      source_dependents = dependents_hash.values
+      dependent_with_unbottled_dep = formula "dependent-5" do
+        T.bind(self, T.class_of(Formula))
+        url "https://brew.sh/dependent-5/1.0.tar.gz"
+        depends_on "dependency"
+        depends_on "unbottled-dependency"
+      end
+      not_source_dependent = [dependent_with_unbottled_dep, dependent_with_unbottled_dep.deps.to_a]
+      dependents_hash[5] = not_source_dependent
+
+      expect(formulae_dependents.split_source_dependents(dependents)).to eq [
+        source_dependents,
+        [not_source_dependent],
+      ]
+    end
+
+    it "limits total source build dependents to upper bound and orders on analytics" do
+      expect(formulae_dependents.split_source_dependents(dependents, 1)).to eq [
+        [dependents_hash.fetch(6)],
+        7.upto(14).map { dependents_hash.fetch(it) },
+      ]
+      expect(formulae_dependents.split_source_dependents(dependents, 5)).to eq [
+        6.upto(10).map { dependents_hash.fetch(it) },
+        11.upto(14).map { dependents_hash.fetch(it) },
+      ]
+      expect(formulae_dependents.split_source_dependents(dependents, 7)).to eq [
+        6.upto(12).map { dependents_hash.fetch(it) },
+        13.upto(14).map { dependents_hash.fetch(it) },
+      ]
+    end
+  end
 end

--- a/Library/Homebrew/test_bot/formulae_dependents.rb
+++ b/Library/Homebrew/test_bot/formulae_dependents.rb
@@ -184,20 +184,6 @@ module Homebrew
 
         ohai "Only source building #{max} of #{source_dependents.count} dependents"
 
-        if (ranks = formula_install_ranks).present?
-          last = ranks.each_value.max.to_i + 1
-          source_dependents.sort_by! do |dependent, _|
-            [ranks.fetch(dependent.full_name, last), dependent.full_name]
-          end
-        end
-        dependents.concat(source_dependents.slice!(max..).to_a)
-        [source_dependents, dependents]
-      end
-
-      private
-
-      sig { returns(T::Hash[String, Integer]) }
-      def formula_install_ranks
         @formula_install_ranks ||= T.let(begin
           analytics = begin
             require "api/analytics"
@@ -213,7 +199,18 @@ module Homebrew
             hash[formula.to_s] = number.to_i
           end
         end, T.nilable(T::Hash[String, Integer]))
+
+        if @formula_install_ranks.present?
+          last = @formula_install_ranks.each_value.max.to_i + 1
+          source_dependents.sort_by! do |dependent, _|
+            [@formula_install_ranks.fetch(dependent.full_name, last), dependent.full_name]
+          end
+        end
+        dependents.concat(source_dependents.slice!(max..).to_a)
+        [source_dependents, dependents]
       end
+
+      private
 
       sig { params(installable_bottles: T::Array[String], args: Homebrew::Cmd::TestBotCmd::Args).void }
       def install_formulae_if_needed_from_bottles!(installable_bottles, args:)

--- a/Library/Homebrew/test_bot/formulae_dependents.rb
+++ b/Library/Homebrew/test_bot/formulae_dependents.rb
@@ -33,7 +33,6 @@ module Homebrew
         @tested_dependents = T.let([], T::Array[String])
         @formulae_dependents_filter = T.let(nil, T.nilable(T::Array[String]))
         @dependent_pairs_by_formula = T.let({}, T::Hash[String, T::Array[DependentWithDependencies]])
-        @tested_source_dependents_count = T.let(0, Integer)
       end
 
       sig { params(args: Homebrew::Cmd::TestBotCmd::Args).void }
@@ -53,7 +52,6 @@ module Homebrew
 
         @testing_formulae_with_tested_dependents = []
         @tested_dependents_list = Pathname("tested-dependents-#{Utils::Bottles.tag}.txt")
-        @tested_source_dependents_count = 0
 
         @dependent_testing_formulae = sorted_formulae - skipped_or_failed_formulae
 
@@ -277,7 +275,6 @@ module Homebrew
         source_dependents.each do |dependent|
           install_dependent(dependent, testable_dependents, build_from_source: true, args:)
           install_dependent(dependent, testable_dependents, args:) if bottled?(dependent)
-          @tested_source_dependents_count += 1
         end
 
         bottled_dependents.each do |dependent|
@@ -304,11 +301,11 @@ module Homebrew
 
         # Split into dependents that we could potentially be building from source and those
         # we should not. The criteria is that a dependent must have bottled dependencies and
-        # the `--build-dependents-from-source` flag was passed
-        max = MAX_DEPENDENTS_FROM_SOURCE - @tested_source_dependents_count
+        # the `--build-dependents-from-source` flag was passed. Total source build dependents
+        # are limited per formula to avoid overly long CI runtime.
         source_dependents = []
-        if args.build_dependents_from_source? && max.positive?
-          source_dependents, dependents = split_source_dependents(dependents, max)
+        if args.build_dependents_from_source?
+          source_dependents, dependents = split_source_dependents(dependents)
         end
 
         # From the non-source list, get rid of any dependents we are only a build dependency to

--- a/Library/Homebrew/test_bot/formulae_dependents.rb
+++ b/Library/Homebrew/test_bot/formulae_dependents.rb
@@ -302,7 +302,7 @@ module Homebrew
         # Split into dependents that we could potentially be building from source and those
         # we should not. The criteria is that a dependent must have bottled dependencies and
         # the `--build-dependents-from-source` flag was passed. Total source build dependents
-        # are limited per formula to avoid overly long CI runtime.
+        # are limited per formula per shard to avoid overly long CI runtime.
         source_dependents = []
         if args.build_dependents_from_source?
           source_dependents, dependents = split_source_dependents(dependents)

--- a/Library/Homebrew/test_bot/formulae_dependents.rb
+++ b/Library/Homebrew/test_bot/formulae_dependents.rb
@@ -4,6 +4,9 @@
 module Homebrew
   module TestBot
     class FormulaeDependents < TestFormulae
+      MAX_DEPENDENTS_FROM_SOURCE = 10
+      private_constant :MAX_DEPENDENTS_FROM_SOURCE
+
       DependentWithDependencies = T.type_alias { [Formula, T::Array[Dependency]] }
       private_constant :DependentWithDependencies
 
@@ -30,6 +33,7 @@ module Homebrew
         @tested_dependents = T.let([], T::Array[String])
         @formulae_dependents_filter = T.let(nil, T.nilable(T::Array[String]))
         @dependent_pairs_by_formula = T.let({}, T::Hash[String, T::Array[DependentWithDependencies]])
+        @tested_source_dependents_count = T.let(0, Integer)
       end
 
       sig { params(args: Homebrew::Cmd::TestBotCmd::Args).void }
@@ -49,6 +53,7 @@ module Homebrew
 
         @testing_formulae_with_tested_dependents = []
         @tested_dependents_list = Pathname("tested-dependents-#{Utils::Bottles.tag}.txt")
+        @tested_source_dependents_count = 0
 
         @dependent_testing_formulae = sorted_formulae - skipped_or_failed_formulae
 
@@ -162,7 +167,55 @@ module Homebrew
         shards.fetch(shard_index - 1).sort_by { |dependent, _| dependent.full_name }
       end
 
+      sig {
+        params(
+          dependents: T::Array[DependentWithDependencies],
+          max:        Integer,
+        ).returns([T::Array[DependentWithDependencies], T::Array[DependentWithDependencies]])
+      }
+      def split_source_dependents(dependents, max = MAX_DEPENDENTS_FROM_SOURCE)
+        source_dependents, dependents = dependents.partition do |dependent, deps|
+          next false unless build_dependent_from_source?(dependent)
+
+          deps.all? do |d|
+            bottled_or_built?(d.to_formula, @dependent_testing_formulae)
+          end
+        end
+
+        return [source_dependents, dependents] if source_dependents.count <= max
+
+        ohai "Only source building #{max} of #{source_dependents.count} dependents"
+
+        if (ranks = formula_install_ranks).present?
+          last = ranks.each_value.max.to_i + 1
+          source_dependents.sort_by! do |dependent, _|
+            [ranks.fetch(dependent.full_name, last), dependent.full_name]
+          end
+        end
+        dependents.concat(source_dependents.slice!(max..).to_a)
+        [source_dependents, dependents]
+      end
+
       private
+
+      sig { returns(T::Hash[String, Integer]) }
+      def formula_install_ranks
+        @formula_install_ranks ||= T.let(begin
+          analytics = begin
+            require "api/analytics"
+            Homebrew::API::Analytics.fetch "install", 90
+          rescue ArgumentError
+            {}
+          end
+          analytics["items"].to_a.each_with_object({}) do |item, hash|
+            formula = item["formula"]
+            number = item["number"]
+            next if formula.blank? || number.blank?
+
+            hash[formula.to_s] = number.to_i
+          end
+        end, T.nilable(T::Hash[String, Integer]))
+      end
 
       sig { params(installable_bottles: T::Array[String], args: Homebrew::Cmd::TestBotCmd::Args).void }
       def install_formulae_if_needed_from_bottles!(installable_bottles, args:)
@@ -224,6 +277,7 @@ module Homebrew
         source_dependents.each do |dependent|
           install_dependent(dependent, testable_dependents, build_from_source: true, args:)
           install_dependent(dependent, testable_dependents, args:) if bottled?(dependent)
+          @tested_source_dependents_count += 1
         end
 
         bottled_dependents.each do |dependent|
@@ -249,16 +303,12 @@ module Homebrew
         dependents.reject! { |dependent, _| @tested_dependents.include?(dependent.full_name) }
 
         # Split into dependents that we could potentially be building from source and those
-        # we should not. The criteria is that a dependent must have bottled dependencies, and
-        # either the `--build-dependents-from-source` flag was passed or a dependent has no
-        # bottle on the current OS.
-        source_dependents, dependents = dependents.partition do |dependent, deps|
-          next false unless build_dependent_from_source?(dependent)
-
-          all_deps_bottled_or_built = deps.all? do |d|
-            bottled_or_built?(d.to_formula, @dependent_testing_formulae)
-          end
-          args.build_dependents_from_source? && all_deps_bottled_or_built
+        # we should not. The criteria is that a dependent must have bottled dependencies and
+        # the `--build-dependents-from-source` flag was passed
+        max = MAX_DEPENDENTS_FROM_SOURCE - @tested_source_dependents_count
+        source_dependents = []
+        if args.build_dependents_from_source? && max.positive?
+          source_dependents, dependents = split_source_dependents(dependents, max)
         end
 
         # From the non-source list, get rid of any dependents we are only a build dependency to

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -1943,7 +1943,7 @@ __fish_brew_complete_arg 'test' -a '(__fish_brew_suggest_formulae_installed)'
 
 __fish_brew_complete_cmd 'test-bot' 'Tests the full lifecycle of a Homebrew change to a tap (Git repository)'
 __fish_brew_complete_arg 'test-bot' -l added-formulae -d 'Use these added formulae rather than running the formulae detection steps'
-__fish_brew_complete_arg 'test-bot' -l build-dependents-from-source -d 'Build dependents from source rather than testing bottles'
+__fish_brew_complete_arg 'test-bot' -l build-dependents-from-source -d 'Build a limited set of dependents from source in addition to testing bottles. Up to 10 per formula per shard, prioritising popular dependents in a sharded group'
 __fish_brew_complete_arg 'test-bot' -l build-from-source -d 'Build from source rather than building bottles'
 __fish_brew_complete_arg 'test-bot' -l cleanup -d 'Clean all state from the Homebrew directory. Use with care!'
 __fish_brew_complete_arg 'test-bot' -l debug -d 'Display any debugging information'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -2511,7 +2511,7 @@ _brew_test() {
 _brew_test_bot() {
   _arguments \
     '(--only-formulae-detect)--added-formulae[Use these added formulae rather than running the formulae detection steps]' \
-    '--build-dependents-from-source[Build dependents from source rather than testing bottles]' \
+    '--build-dependents-from-source[Build a limited set of dependents from source in addition to testing bottles. Up to 10 per formula per shard, prioritising popular dependents in a sharded group]' \
     '--build-from-source[Build from source rather than building bottles]' \
     '--cleanup[Clean all state from the Homebrew directory. Use with care!]' \
     '--debug[Display any debugging information]' \

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -3750,7 +3750,9 @@ and Linux workers.
 
 `--build-dependents-from-source`
 
-: Build dependents from source rather than testing bottles.
+: Build a limited set of dependents from source in addition to testing bottles.
+  Up to 10 per formula per shard, prioritising popular dependents in a sharded
+  group.
 
 `--junit`
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2360,7 +2360,7 @@ Don\[u2019]t check if the local system is set up correctly\.
 Build from source rather than building bottles\.
 .TP
 \fB\-\-build\-dependents\-from\-source\fP
-Build dependents from source rather than testing bottles\.
+Build a limited set of dependents from source in addition to testing bottles\. Up to 10 per formula per shard, prioritising popular dependents in a sharded group\.
 .TP
 \fB\-\-junit\fP
 generate a JUnit XML test results file\.


### PR DESCRIPTION
One possible idea for issue we have been discussing with overly long CI times.

This PR uses a limit ranked by analytics data. Other ideas mentioned were testing dependents with dependents, no longer source building dependents, etc.

---

Rust and Go PRs run for over 1 day and continue to grow in total dependents. To make these more reasonable, allow limiting the maximum number of build-from-source dependents per formula under test.

Selected based on analytics data as more popular formulae are more likely to be built from source by users so identifying these earlier would allow reporting issues or opening PRs upstream.

---

Examples:

<details>
<summary><tt>brew test-bot '--testing-formulae=rust' '--tested-formulae=rust' --only-formulae-dependents --junit --build-dependents-from-source</tt></summary>

```
==> Running FormulaeDependents#dependent_formulae!(rust)
==> Determining dependents...
==> Only source building 10 of 1084 dependents
==> Source dependents:
uv
ripgrep
mise
pnpm
deno
just
ruby
usage
librsvg
azure-cli
==> Bottled dependents:
maturin
pake
hk
corrosion
anchor
diesel
helix-db
rust-wasm
cbfmt
rust-script
==> Testable dependents:
...
```
</details>

<details>
<summary><tt>brew test-bot '--testing-formulae=go' '--tested-formulae=go' --only-formulae-dependents --junit --build-dependents-from-source</tt></summary>

```
==> Running FormulaeDependents#dependent_formulae!(go)
==> Determining dependents...
==> Only source building 10 of 1418 dependents
==> Source dependents:
gh
docker
fzf
ollama
yq
kubernetes-cli
helm
mole
glab
cloudflared
==> Bottled dependents:
golangci-lint
osv-scanner
akamai
govulncheck
staticcheck
bitrise
gotestsum
gosec
goimports
operator-sdk
gofumpt
kubebuilder
go-air
ibazel
gup
mage
wails
xk6
go-bindata
go-size-analyzer
vet
llgo
ignite
go-critic
pkgsite
cyclonedx-gomod
revive
cloudformation-cli
gf
xgo
gotests
ifacemaker
errcheck
go-blueprint
cobra-cli
solod
kitex
hz
terramaid
gops
richgo
goproxy
counterfeiter
kubehound
bunster
go-rice
naml
vgt
tygo
stuffbin
tscriptify
spdx-sbom-generator
==> Testable dependents:
...
```
</details>

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

n/a

-----
