### PR TITLE
Document remove-disabled window mirror

### DIFF
--- a/Library/Homebrew/deprecate_disable.rb
+++ b/Library/Homebrew/deprecate_disable.rb
@@ -33,6 +33,8 @@ module DeprecateDisable
   }.freeze, T::Hash[Symbol, String])
 
   # One year when << or >> to Date.today.
+  # Keep in sync with RemoveDisabledPackages::REMOVE_DISABLED_MONTHS in
+  # Homebrew/actions/remove-disabled-packages/main.rb.
   REMOVE_DISABLED_TIME_WINDOW = 12
   REMOVE_DISABLED_BEFORE = T.let((Date.today << REMOVE_DISABLED_TIME_WINDOW).freeze, Date)
 


### PR DESCRIPTION
`Homebrew/actions/remove-disabled-packages` no longer loads `DeprecateDisable`, so it carries its own copy of the twelve month window. This is the brew side of the two way sync comment; the other half is in Homebrew/actions#924.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the comment; I reviewed it and ran `brew lgtm`.

-----
