### PR TITLE
Decouple macOS release names from support status

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -329,7 +329,7 @@ HOMEBREW_BOTTLE_DEFAULT_DOMAIN="https://ghcr.io/v2/homebrew/core"
 # - Library/Homebrew/os/mac.rb (latest_sdk_version)
 # - Library/Homebrew/os/mac/xcode.rb (latest_version), (minimum_version)
 # and, if needed:
-# - MacOSVersion::SYMBOLS
+# - MacOSVersion::RELEASES
 HOMEBREW_MACOS_NEWEST_UNSUPPORTED="27"
 # TODO: bump version when new macOS is released
 HOMEBREW_MACOS_NEWEST_SUPPORTED="26"

--- a/Library/Homebrew/dev-cmd/formula-analytics.rb
+++ b/Library/Homebrew/dev-cmd/formula-analytics.rb
@@ -439,9 +439,13 @@ module Homebrew
 
         begin
           macos_version = ::MacOSVersion.new(dimension)
-          if macos_version.pretty_name.presence && macos_version.to_sym != :dunno
-            return "macOS #{macos_version.pretty_name} (#{macos_version.strip_patch})"
+          release_version = macos_version.release_version
+          os_name = (macos_version < "10.12") ? "OS X" : "macOS"
+          if (release_name = macos_version.release_name)
+            return "#{os_name} #{release_name} (#{release_version})"
           end
+
+          return "#{os_name} #{release_version}"
         rescue MacOSVersion::Error
           nil
         end
@@ -450,7 +454,7 @@ module Homebrew
         when /Ubuntu(-Server)? (14|16|18|20|22|24)\.04/ then "Ubuntu #{Regexp.last_match(2)}.04 LTS"
         when /Ubuntu(-Server)? (\d+\.\d+).\d ?(LTS)?/
           "Ubuntu #{Regexp.last_match(2)} #{Regexp.last_match(3)}".strip
-        when %r{Debian GNU/Linux (\d+)\.\d+} then "Debian #{Regexp.last_match(1)} #{Regexp.last_match(2)}"
+        when %r{Debian GNU/Linux (\d+)} then "Debian #{Regexp.last_match(1)}"
         when /CentOS (\w+) (\d+)/ then "CentOS #{Regexp.last_match(1)} #{Regexp.last_match(2)}"
         when /Fedora Linux (\d+)[.\d]*/ then "Fedora Linux #{Regexp.last_match(1)}"
         when /KDE neon .*?([\d.]+)/ then "KDE neon #{Regexp.last_match(1)}"
@@ -461,11 +465,6 @@ module Homebrew
         when /Red Hat Enterprise Linux CoreOS (\d+\.\d+)[-.\d]*/
           "Red Hat Enterprise Linux CoreOS #{Regexp.last_match(1)}"
         when /([A-Za-z ]+)\s+(\d+)\.\d{8}[.\d]*/ then "#{Regexp.last_match(1)} #{Regexp.last_match(2)}"
-        # odisabled: add new entries when removing support, remove entries when no longer in the data
-        when /^10\.14[.\d]*/ then "macOS Mojave (10.14)"
-        when /^10\.13[.\d]*/ then "macOS High Sierra (10.13)"
-        when /^10\.12[.\d]*/ then "macOS Sierra (10.12)"
-        when /^10\.(\d+)/ then "macOS 10.#{Regexp.last_match(1)}"
         else dimension
         end
 

--- a/Library/Homebrew/macos_version.rb
+++ b/Library/Homebrew/macos_version.rb
@@ -17,10 +17,8 @@ class MacOSVersion < Version
     end
   end
 
-  # NOTE: When removing symbols here, ensure that they are added
-  #       to `DISABLED_MACOS_VERSIONS` in `MacOSRequirement`.
-  # NOTE: Changes to this list must match `macos_version_name` in `cmd/update.sh`.
-  SYMBOLS = T.let({
+  # Retain named releases after support ends so historical data can still be labelled.
+  RELEASES = T.let({
     golden_gate: "27",
     tahoe:       "26",
     sequoia:     "15",
@@ -29,7 +27,28 @@ class MacOSVersion < Version
     monterey:    "12",
     # odisabled: remove support for Big Sur and macOS x86_64 September (or later) 2027
     big_sur:     "11",
+    catalina:    "10.15",
+    mojave:      "10.14",
+    high_sierra: "10.13",
+    sierra:      "10.12",
+    el_capitan:  "10.11",
   }.freeze, T::Hash[Symbol, String])
+
+  # Big Sur reports 10.16 under SYSTEM_VERSION_COMPAT.
+  RELEASE_ALIASES = T.let({
+    "10.16" => "11",
+  }.freeze, T::Hash[String, String])
+
+  # NOTE: When removing support, exclude the symbol here and add it to
+  #       `DISABLED_MACOS_VERSIONS` in `MacOSRequirement`.
+  # NOTE: Active symbols must match `macos_version_name` in `cmd/update.sh`.
+  SYMBOLS = T.let(RELEASES.except(
+    :catalina,
+    :mojave,
+    :high_sierra,
+    :sierra,
+    :el_capitan,
+  ).freeze, T::Hash[Symbol, String])
 
   sig { params(macos_version: MacOSVersion).returns(Version) }
   def self.kernel_major_version(macos_version)
@@ -91,13 +110,33 @@ class MacOSVersion < Version
   def strip_patch
     return self if null?
 
-    self.class.new(major.to_s)
+    # Releases before Big Sur are all 10.x.
+    if major.to_i >= 11
+      self.class.new(major.to_s)
+    else
+      major_minor
+    end
+  end
+
+  sig { returns(String) }
+  def release_version
+    version = strip_patch.to_s
+    RELEASE_ALIASES.fetch(version, version)
+  end
+
+  sig { returns(T.nilable(String)) }
+  def release_name
+    symbol = RELEASES.key(release_version)
+    return if symbol.nil?
+
+    symbol.to_s.split("_").map(&:capitalize).join(" ")
   end
 
   sig { returns(Symbol) }
   def to_sym
     return @sym if @sym
 
+    # Compatibility aliases are display-only and must not become supported bottle tags.
     sym = SYMBOLS.invert.fetch(strip_patch.to_s, :dunno)
 
     @sym = sym unless frozen?
@@ -109,7 +148,7 @@ class MacOSVersion < Version
   def pretty_name
     return @pretty_name if @pretty_name
 
-    pretty_name = to_sym.to_s.split("_").map(&:capitalize).join(" ").freeze
+    pretty_name = (release_name || "Dunno").freeze
 
     @pretty_name = pretty_name unless frozen?
 

--- a/Library/Homebrew/test/dev-cmd/formula-analytics_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/formula-analytics_spec.rb
@@ -10,6 +10,41 @@ RSpec.describe Homebrew::DevCmd::FormulaAnalytics do
   it_behaves_like "parseable arguments"
 
   describe "#format_os_version_dimension" do
+    it "formats retired macOS versions" do
+      expect(described_class.new([]).format_os_version_dimension("10.15.7"))
+        .to eq("macOS Catalina (10.15)")
+    end
+
+    it "normalizes Big Sur compatibility versions" do
+      expect(described_class.new([]).format_os_version_dimension("10.16.0"))
+        .to eq("macOS Big Sur (11)")
+    end
+
+    it "formats retired OS X versions" do
+      expect(described_class.new([]).format_os_version_dimension("10.11.6"))
+        .to eq("OS X El Capitan (10.11)")
+    end
+
+    it "formats unknown legacy macOS versions" do
+      expect(described_class.new([]).format_os_version_dimension("10.10.5")).to eq("OS X 10.10")
+    end
+
+    it "formats unknown future macOS versions" do
+      expect(described_class.new([]).format_os_version_dimension("28.0")).to eq("macOS 28")
+    end
+
+    it "does not format malformed macOS versions" do
+      expect(described_class.new([]).format_os_version_dimension("10.15.invalid")).to eq("10.15.invalid")
+    end
+
+    it "formats Debian point releases as major releases" do
+      expect(described_class.new([]).format_os_version_dimension("Debian GNU/Linux 12.11")).to eq("Debian 12")
+    end
+
+    it "formats Debian major releases" do
+      expect(described_class.new([]).format_os_version_dimension("Debian GNU/Linux 12")).to eq("Debian 12")
+    end
+
     it "preserves WSL in formatted Linux versions" do
       expect(described_class.new([]).format_os_version_dimension(
                "Ubuntu 24.04.3 LTS#{Utils::Analytics::WSL_SUFFIX}",

--- a/Library/Homebrew/test/macos_version_spec.rb
+++ b/Library/Homebrew/test/macos_version_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe MacOSVersion do
       end.to raise_error(MacOSVersion::Error, "unknown or unsupported macOS version: :foo")
     end
 
+    it "raises an error if the macOS release is retired" do
+      expect do
+        described_class.from_symbol(:catalina)
+      end.to raise_error(MacOSVersion::Error, "unknown or unsupported macOS version: :catalina")
+    end
+
     it "creates a new version from a valid macOS version" do
       symbol_version = described_class.from_symbol(:big_sur)
       expect(symbol_version).to eq(version)
@@ -99,9 +105,62 @@ RSpec.describe MacOSVersion do
   end
 
   describe "#strip_patch" do
-    specify do
-      expect(big_sur_update.strip_patch).to eq(described_class.new("11"))
-      expect(MacOSVersion::NULL.strip_patch).to be MacOSVersion::NULL
+    context "when the release is before Big Sur" do
+      it "preserves the minor version" do
+        expect(described_class.new("10.15.7").strip_patch).to eq(described_class.new("10.15"))
+      end
+    end
+
+    context "when the release is Big Sur or newer" do
+      it "returns the major version" do
+        expect(big_sur_update.strip_patch).to eq(described_class.new("11"))
+      end
+    end
+
+    context "when the version is null" do
+      it "returns itself" do
+        expect(MacOSVersion::NULL.strip_patch).to be MacOSVersion::NULL
+      end
+    end
+  end
+
+  describe "#release_name" do
+    context "when the release is known" do
+      it "returns the name of a retired release" do
+        expect(described_class.new("10.15.7").release_name).to eq("Catalina")
+      end
+    end
+
+    context "when the release is unknown" do
+      it "returns nil" do
+        expect(described_class.new("10.10").release_name).to be_nil
+      end
+    end
+  end
+
+  describe "#release_version" do
+    context "when the release has a compatibility version" do
+      it "returns the canonical release version" do
+        expect(described_class.new("10.16.0").release_version).to eq("11")
+      end
+    end
+
+    context "when the release has no compatibility version" do
+      it "returns the version without the patch" do
+        expect(described_class.new("10.15.7").release_version).to eq("10.15")
+      end
+    end
+  end
+
+  describe "#to_sym with a retired release" do
+    it "returns dunno" do
+      expect(described_class.new("10.15").to_sym).to eq(:dunno)
+    end
+  end
+
+  describe "#to_sym with a compatibility version" do
+    it "returns dunno" do
+      expect(described_class.new("10.16").to_sym).to eq(:dunno)
     end
   end
 
@@ -136,6 +195,12 @@ RSpec.describe MacOSVersion do
     # rubocop:disable Homebrew/NoInstanceVariableAccessInTests
     expect(frozen_version.instance_variable_get(:@pretty_name)).to be_nil
     # rubocop:enable Homebrew/NoInstanceVariableAccessInTests
+  end
+
+  describe "#pretty_name with a retired release" do
+    it "returns the release name" do
+      expect(described_class.new("10.15").pretty_name).to eq("Catalina")
+    end
   end
 
   describe "#requires_nehalem_cpu?", :needs_macos do

--- a/Library/Homebrew/test/requirements/macos_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/macos_requirement_spec.rb
@@ -20,6 +20,13 @@ RSpec.describe MacOSRequirement do
       .to raise_error(MethodDeprecatedError, /`depends_on macos: :catalina`.*disabled/)
   end
 
+  it "tracks every retired macOS release" do
+    expect(MacOSVersion::RELEASES.keys - MacOSVersion::SYMBOLS.keys).to contain_exactly(
+      *MacOSRequirement::DISABLED_MACOS_VERSIONS,
+      *MacOSRequirement::DEPRECATED_MACOS_VERSIONS,
+    )
+  end
+
   describe "#satisfied?" do
     context "when running on macOS", :needs_macos do
       it "returns true" do


### PR DESCRIPTION
Removing Catalina from `MacOSVersion::SYMBOLS` silently changed how `brew formula-analytics` labels historical data, because release names were coupled to support status. Catalina's 560,348 events in the last 365 days went from "macOS Catalina (10.15)" to "macOS 10.15", and El Capitan's 749 from "OS X El Capitan (10.11)" to "macOS 10.11". The old workaround was a hand-maintained regex ladder in `formula-analytics.rb` with an `odisabled` note telling maintainers to keep adding entries by hand.

`MacOSVersion::RELEASES` now keeps every named release and `SYMBOLS` derives from it with `except`, so a release stays nameable for display once it stops being supported. `from_symbol`, `to_sym`, bottle tags and `depends_on macos:` are unchanged. Analytics formats through `MacOSVersion` rather than macOS regexes, restores "OS X" branding for pre-Sierra releases, maps Big Sur's `10.16` compatibility version, and no longer mislabels malformed version strings.

Adding a release is now one line in `RELEASES`, and dropping support is one line in the `except` list with a new spec that fails if it does not match `MacOSRequirement::DISABLED_MACOS_VERSIONS`. Big Sur's scheduled September 2027 removal becomes a two-line change.

Also compresses Debian dimensions to the major release. `Debian GNU/Linux 12` and `Debian GNU/Linux 12.11` were landing in separate buckets, and the point-release branch emitted a trailing space from a capture group that does not exist.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the change and pass with it, and ran `brew lgtm` plus targeted specs.

-----
