### PR TITLE
Reuse macOS release aliases in cask audit

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -267,15 +267,8 @@ module Cask
       return if min_os.nil?
       return if min_os.is_a?(String) && min_os.blank?
 
-      # Big Sur is sometimes identified as 10.16, so normalize it before
-      # stripping the patch version.
-      return MacOSVersion.from_symbol(:big_sur) if /\A10\.16(?:\.\d+)?\z/.match?(min_os.to_s)
-
-      if min_os.is_a?(MacOSVersion)
-        min_os.strip_patch
-      else
-        MacOSVersion.new(min_os).strip_patch
-      end
+      min_os = MacOSVersion.new(min_os) unless min_os.is_a?(MacOSVersion)
+      MacOSVersion.new(min_os.release_version)
     rescue MacOSVersion::Error
       nil
     end


### PR DESCRIPTION
`Cask::Audit#normalize_min_os` carried its own regex for Big Sur's `10.16` compatibility version. #23887 moves that fact into `MacOSVersion::RELEASE_ALIASES`, so the audit can go through `release_version` instead and the two copies cannot drift apart.

No behavior change. `normalize_min_os` returns the same value for every String and `MacOSVersion` input I checked, including blanks, malformed versions and the alias itself, and the existing "normalizes 10.16.0 minimum macOS to Big Sur" spec still passes, so no new test is added.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) did the work; I reviewed the diff, verified the change is behavior-preserving across String and `MacOSVersion` inputs, and ran `brew lgtm` plus targeted specs.

-----
