### PR TITLE
tar: validate tarballs named with a compound extension

### DIFF
--- a/Library/Homebrew/test/dev-cmd/bump-formula-pr_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-formula-pr_spec.rb
@@ -413,6 +413,7 @@ RSpec.describe Homebrew::DevCmd::BumpFormulaPr do
       resource_path = mktmpdir/"foo-2.0.0.tar.gz"
       resource_path.write "test"
       allow(bump_formula_pr).to receive(:fetch_resource_and_forced_version).and_return([resource_path, false])
+      allow(Utils::Tar).to receive(:validate_file).with(resource_path)
 
       resource_versions = { "foo" => { current_version: "1.2.3", latest_version: "2.0.0" } }
 

--- a/Library/Homebrew/test/utils/tar_spec.rb
+++ b/Library/Homebrew/test/utils/tar_spec.rb
@@ -51,6 +51,15 @@ RSpec.describe Utils::Tar do
         expect { described_class.validate_file invalid_resource }.to raise_error SystemExit
         FileUtils.rm_f invalid_resource
       end
+
+      it "raises an error if a file with a compound extension is an invalid tar file" do
+        %w[.tar.bz2 .tar.gz .tar.lz .tar.xz .tar.Z].each do |extension|
+          invalid_compound_resource = "#{TEST_TMPDIR}/invalid#{extension}"
+          FileUtils.touch invalid_compound_resource
+          expect { described_class.validate_file invalid_compound_resource }.to raise_error SystemExit
+          FileUtils.rm_f invalid_compound_resource
+        end
+      end
     end
   end
 end

--- a/Library/Homebrew/utils/tar.rb
+++ b/Library/Homebrew/utils/tar.rb
@@ -11,7 +11,10 @@ module Utils
       include SystemCommand::Mixin
       include Utils::Output::Mixin
 
-      TAR_FILE_EXTENSIONS = %w[.tar .tb2 .tbz .tbz2 .tgz .tlz .txz .tZ].freeze
+      TAR_FILE_EXTENSIONS = %w[
+        .tar .tb2 .tbz .tbz2 .tgz .tlz .txz .tZ
+        .tar.bz2 .tar.gz .tar.lz .tar.xz .tar.Z
+      ].freeze
 
       sig { returns(T::Boolean) }
       def available?


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

### What and why

`Utils::Tar::TAR_FILE_EXTENSIONS` lists only the abbreviated spellings, and `validate_file` compares them with `include?` against `Pathname#extname`, which Homebrew extends to return compound archive extensions. So `.tgz` is validated and `.tar.gz` is not, though they are the same format.

That matters because `validate_file` is what stops a 404 page or a truncated download being hashed into a formula, and the next line at `dev-cmd/bump-formula-pr.rb:265` is `resource_path.sha256`. Cached downloads really do carry the compound name, e.g. `<sha>--typos-cli--1.50.1...bottle.tar.gz`.

This dates to 15af7189eb, "utils: add `tar`", which moved the check into this module and changed the predicate from a substring test on the URL, where `"foo.tar.gz".include? ".tar"` was true, to exact equality on `extname`.

### Reproduction

```
$ brew ruby -e 'require "utils/tar"
exts = Utils::Tar.singleton_class.const_get(:TAR_FILE_EXTENSIONS)
%w[foo-1.2.3.tar.gz foo-1.2.3.tgz].each { |n| e = Pathname.new("/tmp/#{n}").extname
  puts format("%-18s extname=%-9s validated=%s", n, e, exts.include?(e)) }'
foo-1.2.3.tar.gz   extname=.tar.gz  validated=false
foo-1.2.3.tgz      extname=.tgz     validated=true
```

### Scope

Adds the compound spellings of the formats already listed. `.tar.zst` is deliberately left out: no zstd spelling is validated today, so adding one would newly reject archives that pass now, and that is a separate decision rather than a regression fix. Happy to add it if you would rather.

`.tar.lz` is included because `.tlz` is already listed, so lzip tarballs are already validated and this adds no new class of risk.

### Verification

`brew lgtm` passes (style, typecheck, tests). `brew tests --only=utils/tar` is 6 examples, 0 failures. Reverting only `utils/tar.rb` and keeping the spec fails exactly the one new example. `tar --list` was confirmed to read real `.tar.gz`, `.tar.bz2`, `.tar.xz` and `.tar.Z` archives with the `tar` this machine selects (bsdtar 3.5.3), so widening the list makes the check run rather than fail. lzip is not installed here, so `.tar.lz` was not exercised end to end.

### AI disclosure

The audit, the diff, the tests and this description were written by Claude Opus 5 running in Claude Code, on my machine and under my direction. No commit is attributed to AI and there is no `Assisted-by` trailer, per your policy. I will answer maintainer questions and review comments myself, without AI.

The final checkbox is left unticked for one reason only: it also asserts that I reviewed the output, and I have not yet read the diff line by line. It is a 13-line change and I will confirm here before you spend review time on it. I would rather leave the box empty than tick a statement that is not yet true.
