### PR TITLE
Fix SSH Python resource updates in the sandbox

### DIFF
--- a/Library/Homebrew/test/utils/pypi_spec.rb
+++ b/Library/Homebrew/test/utils/pypi_spec.rb
@@ -165,6 +165,60 @@ RSpec.describe PyPI do
   end
 
   describe ".pip_report" do
+    context "with sandbox execution stubbed" do
+      before do
+        allow(Sandbox).to receive_messages(available?: true, avoid_nested_sandboxing?: false,
+                                           full_write_isolation?: true)
+        sandbox = instance_double(Sandbox, allow_write_path: nil, deny_write_homebrew_repository: nil,
+                                          deny_read_home: nil)
+        allow(Sandbox).to receive(:new).and_return(sandbox)
+        allow(sandbox).to receive(:run) do |*command, **_options|
+          system(*command)
+        end
+      end
+
+      it "runs the Git shim with the configured Git executable" do
+        git = mktmpdir/"custom-git"
+        git.write <<~SH
+          #!/bin/sh
+          printf 'git version 2.50.1'
+        SH
+        git.chmod 0755
+        ENV["HOMEBREW_GIT"] = git.to_s
+
+        expect(described_class.pip_output([HOMEBREW_SHIMS_PATH/"shared/git", "--version"]))
+          .to eq("git version 2.50.1")
+      end
+
+      it "fetches SSH resources with their download settings before inspecting local metadata" do
+        source = mktmpdir
+        source.cd do
+          system "git", "init", "--quiet"
+          (source/"pyproject.toml").write("[project]\nname = 'tool'\n")
+          system "git", "add", "pyproject.toml"
+          system "git", "-c", "commit.gpgsign=false", "commit", "--quiet", "-m", "Initial commit"
+          system "git", "tag", "v0.20.1"
+          (source/"pyproject.toml").write("[project]\nname = 'newer-tool'\n")
+          system "git", "-c", "commit.gpgsign=false", "commit", "--quiet", "-am", "Newer commit"
+        end
+        ssh = mktmpdir/"ssh"
+        ssh.write <<~SH
+          #!/bin/sh
+          exec git-upload-pack #{source.to_s.shellescape}
+        SH
+        ssh.chmod 0755
+        ENV["GIT_SSH_COMMAND"] = ssh.to_s.shellescape
+        ENV["GIT_SSH_VARIANT"] = "ssh"
+        resource = Resource.new("tool")
+        resource.url "ssh://user@gitlab.example/tool", using: :git, tag: "v0.20.1",
+                     revision: Utils.popen_read("git", "-C", source, "rev-parse", "v0.20.1").chomp
+
+        expect(described_class.pip_output(["/bin/sh", "-c", 'cat "$1/pyproject.toml"', "brew-pypi",
+                                           resource]))
+          .to eq("[project]\nname = 'tool'\n")
+      end
+    end
+
     it "captures metadata with a minimal sandbox environment" do
       skip Sandbox.failure_reason unless Sandbox.available?
       skip "Homebrew is running inside another sandbox" if Sandbox.avoid_nested_sandboxing?
@@ -272,6 +326,26 @@ RSpec.describe PyPI do
   end
 
   describe ".update_python_resources!" do
+    it "uses the stable resource for dependency and package metadata resolution" do
+      path = mktmpdir/"foo.rb"
+      path.write <<~RUBY
+        class Foo < Formula
+          url "ssh://git@gitlab.example/foo.git", tag: "v1.0"
+
+          def install
+            bin.install "foo"
+          end
+        end
+      RUBY
+      formula = Formulary.from_contents("foo", path, path.read)
+      allow(Formula).to receive(:[]).with("python").and_return(instance_double(Formula, ensure_installed!: true))
+      allow(described_class).to receive(:pip_output)
+        .with(array_including(formula.resource), any_args)
+        .and_return('{"install":[{"metadata":{"name":"foo","version":"1.0"}}]}')
+
+      expect(described_class.update_python_resources!(formula, quiet: true)).to be true
+    end
+
     it "keeps resources with livecheck blocks" do
       path = mktmpdir/"foo.rb"
       livecheck_resource = <<~RUBY
@@ -371,6 +445,31 @@ RSpec.describe PyPI do
                                                ignore_main_package_cooldown: true)
 
       expect(exempted&.name).to eq "foo"
+    end
+  end
+
+  describe "resolver failures" do
+    let(:resource) do
+      Resource.new("foo") do
+        url "ssh://git@gitlab.example/foo.git", tag: "v1.0"
+      end
+    end
+    let(:package) { PyPI::Package.new(resource.url, is_url: true, resource:) }
+
+    before do
+      allow(Formula).to receive(:[]).with("python").and_return(instance_double(Formula, ensure_installed!: true))
+      allow(described_class).to receive(:pip_output).and_raise(ErrorDuringExecution.new(["pip"], status: 1))
+    end
+
+    it "renders resource URLs in failed metadata commands" do
+      expect { package.name }
+        .to raise_error(ArgumentError, %r{--report /dev/stdout ssh://git@gitlab\.example/foo\.git`})
+    end
+
+    it "renders resource URLs in failed dependency commands" do
+      expect { described_class.pip_report([package]) }
+        .to output(%r{--report=/dev/stdout ssh://git@gitlab\.example/foo\.git`}).to_stderr
+        .and raise_error(SystemExit)
     end
   end
 

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "release_cooldown"
+require "resource"
 require "utils/output"
 require "utils/ast"
 require "utils/path"
@@ -21,13 +22,14 @@ module PyPI
   class Package
     include Utils::Output::Mixin
 
-    sig { params(package_string: String, is_url: T::Boolean, python_name: String).void }
-    def initialize(package_string, is_url: false, python_name: "python")
+    sig { params(package_string: String, is_url: T::Boolean, python_name: String, resource: T.nilable(Resource)).void }
+    def initialize(package_string, is_url: false, python_name: "python", resource: nil)
       @pypi_info = T.let(nil, T.nilable(T::Array[String]))
       @package_string = package_string
       @is_url = is_url
       @is_pypi_url = T.let(package_string.start_with?(PYTHONHOSTED_URL_PREFIX), T::Boolean)
       @python_name = python_name
+      @resource = resource
     end
 
     sig { returns(T.nilable(String)) }
@@ -124,6 +126,14 @@ module PyPI
       end
     end
 
+    # The source resource or package requirement to inspect with pip.
+    sig { returns(T.any(String, Resource)) }
+    def requirement
+      return to_s if valid_pypi_package?
+
+      @resource || @package_string
+    end
+
     sig { params(other: Package).returns(T::Boolean) }
     def same_package?(other)
       # These names are pre-normalized, so we can compare them directly.
@@ -179,13 +189,13 @@ module PyPI
         # this specific URL's project metadata.
         command =
           [Utils::Path.formula_opt_libexec(@python_name)/"bin/python", "-m", "pip", "install", "-q", "--no-deps",
-           "--dry-run", "--ignore-installed", "--report", "/dev/stdout", @package_string]
+           "--dry-run", "--ignore-installed", "--report", "/dev/stdout", requirement]
         pip_output = begin
           PyPI.pip_output(command)
         rescue ErrorDuringExecution
           raise ArgumentError, <<~EOS
             Unable to determine metadata for "#{@package_string}" because of a failure when running
-            `#{command.join(" ")}`.
+            `#{PyPI.format_pip_command(command)}`.
           EOS
         end
 
@@ -287,12 +297,8 @@ module PyPI
         odie "#{formula.full_name} has no stable URL to determine the main Python package from."
       end
 
-      url = if stable.specs[:tag].present?
-        "git+#{stable_url}@#{stable.specs[:tag]}"
-      else
-        stable_url
-      end
-      Package.new(url, is_url: true, python_name:)
+      Package.new(stable_url, is_url: true, python_name:,
+                  resource: (stable.resource if stable.downloader.is_a?(VCSDownloadStrategy)))
     end
 
     if main_package.nil?
@@ -488,7 +494,13 @@ module PyPI
     name.gsub(/[-_.]+/, "-").downcase
   end
 
-  sig { params(command: T::Array[T.any(String, Pathname)], print_stderr: T::Boolean).returns(String) }
+  # Render source resources as URLs in pip command diagnostics.
+  sig { params(command: T::Array[T.any(String, Pathname, Resource)]).returns(String) }
+  def self.format_pip_command(command)
+    command.map { |argument| argument.is_a?(Resource) ? argument.url : argument }.join(" ")
+  end
+
+  sig { params(command: T::Array[T.any(String, Pathname, Resource)], print_stderr: T::Boolean).returns(String) }
   def self.pip_output(command, print_stderr: false)
     Sandbox.ensure_sandbox_available!
     if Sandbox.avoid_nested_sandboxing?
@@ -503,15 +515,25 @@ module PyPI
     end
 
     Dir.mktmpdir("homebrew-pypi", HOMEBREW_TEMP) do |directory|
+      command = command.each_with_index.map do |argument, index|
+        next argument unless argument.is_a?(Resource)
+
+        argument.fetch(quiet: !print_stderr, skip_patches: true)
+        source = Pathname(directory)/"source-#{index}"
+        source.mkpath
+        source.cd { argument.downloader.stage { source = Pathname.pwd } }
+        source
+      end
+
       sandbox = Sandbox.new
       sandbox.allow_write_path(directory)
       sandbox.deny_write_homebrew_repository
       sandbox.deny_read_home
       Tempfile.create("report", directory) do |report|
-        proxy_env = ENV.to_h.filter_map do |key, value|
-          "#{key}=#{value}" if key.match?(/\A(?:https?|all|no)_proxy\z/i)
+        sandbox_env = ENV.to_h.filter_map do |key, value|
+          "#{key}=#{value}" if key.match?(/\A(?:HOMEBREW_(?:LIBRARY|PREFIX|GIT)|(?:https?|all|no)_proxy)\z/i)
         end
-        sandbox.run "/usr/bin/env", "-i", "PATH=#{ENV.fetch("PATH")}", *proxy_env, "HOME=#{directory}",
+        sandbox.run "/usr/bin/env", "-i", "PATH=#{ENV.fetch("PATH")}", *sandbox_env, "HOME=#{directory}",
                     "TMPDIR=#{directory}", "PIP_CACHE_DIR=#{directory}/cache", "PIP_CONFIG_FILE=#{File::NULL}",
                     "PIP_REQUIRE_VIRTUALENV=false", "/bin/sh", "-c",
                     "report=$1; shift; exec \"$@\" > \"$report\"#{" 2>/dev/null" unless print_stderr}",
@@ -538,7 +560,7 @@ module PyPI
     # dependencies stay index-resolved and cooled.
     requirements = packages.map do |package|
       exempt = ignore_cooldown_package && package == ignore_cooldown_package && package.valid_pypi_package?
-      next package.to_s unless exempt
+      next package.requirement unless exempt
 
       name, sdist_url = package.pypi_info
       next package.to_s if sdist_url.blank?
@@ -563,7 +585,7 @@ module PyPI
     rescue ErrorDuringExecution
       odie <<~EOS
         Unable to determine dependencies for "#{packages.join(" ")}" because of a failure when running
-        `#{command.join(" ")}`.
+        `#{format_pip_command(command)}`.
         Please update the resources manually.
       EOS
     end


### PR DESCRIPTION
- Fetch tagged Git sources with the caller's SSH configuration before inspecting their local metadata in the sandbox.
- Preserve the environment required by Homebrew's Git shim without exposing SSH credentials to Python build backends.

Fixes #23894

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Codex with GPT 6 Astra at High effort, with local review and testing.

-----