### PR TITLE
bump: autobump partially disabled packages

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -1334,7 +1334,10 @@ class Tap
     end
 
     autobump = autobump_packages.select do |_, p|
-      next if p["disabled"]
+      next if p["disabled"] && p["variations"].blank?
+      next if p["variations"].present? && p["variations"].each_value.all? do |variation|
+        variation.fetch("disabled", p["disabled"])
+      end
       next if p["skip_livecheck"]
 
       p["autobump"] == true

--- a/Library/Homebrew/test/dev-cmd/bump-cask-pr_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-cask-pr_spec.rb
@@ -88,6 +88,62 @@ RSpec.describe Homebrew::DevCmd::BumpCaskPr do
     expect(Cask::CaskLoader.load("local-caffeine").version.to_s).to eq("1.2.4")
   end
 
+  describe "#run" do
+    it "updates a cask disabled only on the current arch" do
+      cask_path = CoreCaskTap.instance.new_cask_path("test")
+      cask_path.dirname.mkpath
+      cask_path.write <<~RUBY
+        cask "test" do
+          version "1.2.3"
+          sha256 :no_check
+
+          on_#{Hardware::CPU.arm? ? "arm" : "intel"} do
+            disable! date: "2020-01-01", because: :unmaintained
+          end
+        end
+      RUBY
+      cask = Cask::CaskLoader.load(cask_path)
+      command = described_class.new([
+        "--write-only", "--no-audit", "--no-style", "--version=1.2.4", "--sha256=:no_check", "test"
+      ])
+
+      allow(CoreCaskTap.instance).to receive_messages(allow_bump?: true, git?: true,
+                                                      remote_repository: "Homebrew/homebrew-cask", install: nil)
+      allow(command.args.named).to receive(:to_casks).and_return([cask])
+
+      command.run
+
+      expect(Cask::CaskLoader.load(cask_path).version.to_s).to eq("1.2.4")
+    end
+
+    it "updates a cask disabled only on the current OS" do
+      cask_path = CoreCaskTap.instance.new_cask_path("test")
+      cask_path.dirname.mkpath
+      cask_path.write <<~RUBY
+        cask "test" do
+          version "1.2.3"
+          sha256 :no_check
+
+          on_#{OS.mac? ? "macos" : "linux"} do
+            disable! date: "2020-01-01", because: :unmaintained
+          end
+        end
+      RUBY
+      cask = Cask::CaskLoader.load(cask_path)
+      command = described_class.new([
+        "--write-only", "--no-audit", "--no-style", "--version=1.2.4", "--sha256=:no_check", "test"
+      ])
+
+      allow(CoreCaskTap.instance).to receive_messages(allow_bump?: true, git?: true,
+                                                      remote_repository: "Homebrew/homebrew-cask", install: nil)
+      allow(command.args.named).to receive(:to_casks).and_return([cask])
+
+      command.run
+
+      expect(Cask::CaskLoader.load(cask_path).version.to_s).to eq("1.2.4")
+    end
+  end
+
   describe "::generate_system_options" do
     # We simulate a macOS version older than the newest, as the method will use
     # the host macOS version instead of the default (the newest macOS version).

--- a/Library/Homebrew/test/dev-cmd/bump-formula-pr_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-formula-pr_spec.rb
@@ -33,6 +33,38 @@ RSpec.describe Homebrew::DevCmd::BumpFormulaPr do
   end
 
   describe "#run" do
+    it "updates a formula disabled only on the current arch" do
+      formula_path = CoreTap.instance.new_formula_path("test")
+      formula_path.dirname.mkpath
+      formula_path.write <<~RUBY
+        class Test < Formula
+          url "https://brew.sh/test-1.2.3.tgz"
+          sha256 "#{"a" * 64}"
+
+          on_#{Hardware::CPU.arm? ? "arm" : "intel"} do
+            disable! date: "2020-01-01", because: :unmaintained
+          end
+        end
+      RUBY
+      formula = Formulary.factory(formula_path)
+      command = described_class.new([
+        "--write-only", "--no-audit", "--url=https://brew.sh/test-1.2.4.tgz", "--sha256=#{"b" * 64}", "test"
+      ])
+
+      allow(Utils::GemSetup).to receive(:install_bundler_gems!)
+      allow(CoreTap.instance).to receive_messages(allow_bump?: true, git?: true,
+                                                  remote_repository: "Homebrew/homebrew-core", install: nil)
+      allow(command).to receive_messages(check_new_version: nil, run_audit: false,
+                                         update_matching_version_resources!: {})
+      allow(PyPI).to receive(:update_python_resources!)
+      allow(command.args.named).to receive(:to_formulae).and_return([formula])
+      allow(Formula).to receive(:[]).with("test").and_return(formula)
+
+      command.run
+
+      expect(formula_path.read).to include('url "https://brew.sh/test-1.2.4.tgz"')
+    end
+
     it "updates a formula disabled only on the current OS" do
       formula_path = CoreTap.instance.new_formula_path("test")
       formula_path.dirname.mkpath

--- a/Library/Homebrew/test/dev-cmd/bump_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump_spec.rb
@@ -24,6 +24,36 @@ RSpec.describe Homebrew::DevCmd::Bump do
       disable! date: "2020-01-01", because: "Testing"
     end
   end
+  let(:f_partially_disabled_arch) do
+    path = mktmpdir/"partially_disabled_arch_formula.rb"
+    path.write <<~RUBY
+      class PartiallyDisabledArchFormula < Formula
+        desc "Partially disabled (arch) formula"
+        url "https://brew.sh/test-1.2.3.tgz"
+
+        on_#{Hardware::CPU.arm? ? "arm" : "intel"} do
+          disable! date: "2020-01-01", because: "Testing"
+        end
+      end
+    RUBY
+
+    Formulary.factory(path)
+  end
+  let(:f_partially_disabled_os) do
+    path = mktmpdir/"partially_disabled_os_formula.rb"
+    path.write <<~RUBY
+      class PartiallyDisabledOsFormula < Formula
+        desc "Partially disabled (OS) formula"
+        url "https://brew.sh/test-1.2.3.tgz"
+
+        on_#{OS.mac? ? "macos" : "linux"} do
+          disable! date: "2020-01-01", because: "Testing"
+        end
+      end
+    RUBY
+
+    Formulary.factory(path)
+  end
   let(:f_head_only) do
     formula("head_only_formula") do
       T.bind(self, T.class_of(Formula))
@@ -51,6 +81,34 @@ RSpec.describe Homebrew::DevCmd::Bump do
         desc "Disabled cask"
 
         disable! date: "2020-01-01", because: "Testing"
+      end
+    RUBY
+  end
+  let(:c_partially_disabled_arch) do
+    Cask::CaskLoader.load(<<~RUBY)
+      cask "partially_disabled_arch_cask" do
+        version "1.2.3"
+
+        name "Partially Disabled Arch Cask"
+        desc "Partially disabled (arch) cask"
+
+        on_#{Hardware::CPU.arm? ? "arm" : "intel"} do
+          disable! date: "2020-01-01", because: "Testing"
+        end
+      end
+    RUBY
+  end
+  let(:c_partially_disabled_os) do
+    Cask::CaskLoader.load(<<~RUBY)
+      cask "partially_disabled_os_cask" do
+        version "1.2.3"
+
+        name "Partially Disabled OS Cask"
+        desc "Partially disabled (OS) cask"
+
+        on_#{OS.mac? ? "macos" : "linux"} do
+          disable! date: "2020-01-01", because: "Testing"
+        end
       end
     RUBY
   end
@@ -94,21 +152,6 @@ RSpec.describe Homebrew::DevCmd::Bump do
   end
 
   describe "::skip_ineligible_package!" do
-    it "does not skip a cask disabled only on the current OS" do
-      cask = Cask::CaskLoader.load(<<~RUBY)
-        cask "partially-disabled" do
-          version "1.2.3"
-          url "https://brew.sh/test-1.2.3.tgz"
-
-          on_#{OS.mac? ? "macos" : "linux"} do
-            disable! date: "2020-01-01", because: :unmaintained
-          end
-        end
-      RUBY
-
-      expect(bump.skip_ineligible_package!(cask)).to be(false)
-    end
-
     it "prints a message for disabled formulae" do
       expect { expect(bump.skip_ineligible_package!(f_disabled)).to be(true) }
         .to output(/Formula is disabled so not accepting updates\./).to_stdout
@@ -153,6 +196,30 @@ RSpec.describe Homebrew::DevCmd::Bump do
       allow(f_basic).to receive(:tap).and_return(instance_double(Tap, allow_bump?: true))
 
       expect { expect(bump.skip_ineligible_package!(f_basic)).to be(false) }
+        .to not_to_output.to_stdout
+        .and not_to_output.to_stderr
+    end
+
+    it "returns false for a formula disabled only on the current arch" do
+      expect { expect(bump.skip_ineligible_package!(f_partially_disabled_arch)).to be(false) }
+        .to not_to_output.to_stdout
+        .and not_to_output.to_stderr
+    end
+
+    it "returns false for a formula disabled only on the current os" do
+      expect { expect(bump.skip_ineligible_package!(f_partially_disabled_os)).to be(false) }
+        .to not_to_output.to_stdout
+        .and not_to_output.to_stderr
+    end
+
+    it "returns false for a cask disabled only on the current arch" do
+      expect { expect(bump.skip_ineligible_package!(c_partially_disabled_arch)).to be(false) }
+        .to not_to_output.to_stdout
+        .and not_to_output.to_stderr
+    end
+
+    it "returns false for a cask disabled only on the current os" do
+      expect { expect(bump.skip_ineligible_package!(c_partially_disabled_os)).to be(false) }
         .to not_to_output.to_stdout
         .and not_to_output.to_stderr
     end

--- a/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
+++ b/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
 
   let(:formulae) do
     {
-      basic:               formula("test") do
+      basic:                   formula("test") do
         T.bind(self, T.class_of(Formula))
         desc "Test formula"
         homepage "https://brew.sh"
@@ -21,45 +21,75 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
           regex(/"stable":"(\d+(?:\.\d+)+)"/i)
         end
       end,
-      deprecated:          formula("test_deprecated") do
+      deprecated:              formula("test_deprecated") do
         T.bind(self, T.class_of(Formula))
         desc "Deprecated test formula"
         homepage "https://brew.sh"
         url "https://brew.sh/test-0.0.1.tgz"
         deprecate! date: "2020-06-25", because: :unmaintained
       end,
-      disabled:            formula("test_disabled") do
+      disabled:                formula("test_disabled") do
         T.bind(self, T.class_of(Formula))
         desc "Disabled test formula"
         homepage "https://brew.sh"
         url "https://brew.sh/test-0.0.1.tgz"
         disable! date: "2020-06-25", because: :unmaintained
       end,
-      head_only:           formula("test_head_only") do
+      partially_disabled_arch: lambda do
+        path = mktmpdir/"test_partially_disabled_arch.rb"
+        path.write <<~RUBY
+          class TestPartiallyDisabledArch < Formula
+            desc "Partially disabled (arch) test formula"
+            homepage "https://brew.sh"
+            url "https://brew.sh/test-0.0.1.tgz"
+            on_#{Hardware::CPU.arm? ? "arm" : "intel"} do
+              disable! date: "2020-06-25", because: :unmaintained
+            end
+          end
+        RUBY
+
+        Formulary.factory(path)
+      end.call,
+      partially_disabled_os:   lambda do
+        path = mktmpdir/"test_partially_disabled_os.rb"
+        path.write <<~RUBY
+          class TestPartiallyDisabledOs < Formula
+            desc "Partially disabled (OS) test formula"
+            homepage "https://brew.sh"
+            url "https://brew.sh/test-0.0.1.tgz"
+            on_#{OS.mac? ? "macos" : "linux"} do
+              disable! date: "2020-06-25", because: :unmaintained
+            end
+          end
+        RUBY
+
+        Formulary.factory(path)
+      end.call,
+      head_only:               formula("test_head_only") do
         T.bind(self, T.class_of(Formula))
         desc "HEAD-only test formula"
         homepage "https://brew.sh"
         head "https://github.com/Homebrew/brew.git", branch: "main"
       end,
-      gist:                formula("test_gist") do
+      gist:                    formula("test_gist") do
         T.bind(self, T.class_of(Formula))
         desc "Gist test formula"
         homepage "https://brew.sh"
         url "https://gist.github.com/Homebrew/0000000000"
       end,
-      google_code_archive: formula("test_google_code_archive") do
+      google_code_archive:     formula("test_google_code_archive") do
         T.bind(self, T.class_of(Formula))
         desc "Google Code Archive test formula"
         homepage "https://brew.sh"
         url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/brew/brew-1.0.0.tar.gz"
       end,
-      internet_archive:    formula("test_internet_archive") do
+      internet_archive:        formula("test_internet_archive") do
         T.bind(self, T.class_of(Formula))
         desc "Internet Archive test formula"
         homepage "https://brew.sh"
         url "https://web.archive.org/web/20200101000000/https://brew.sh/test-0.0.1.tgz"
       end,
-      skip:                formula("test_skip") do
+      skip:                    formula("test_skip") do
         T.bind(self, T.class_of(Formula))
         desc "Skipped test formula"
         homepage "https://brew.sh"
@@ -69,7 +99,7 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
           skip
         end
       end,
-      skip_with_message:   formula("test_skip_with_message") do
+      skip_with_message:       formula("test_skip_with_message") do
         T.bind(self, T.class_of(Formula))
         desc "Skipped test formula"
         homepage "https://brew.sh"
@@ -79,7 +109,7 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
           skip "Not maintained"
         end
       end,
-      versioned:           formula("test@0.0.1") do
+      versioned:               formula("test@0.0.1") do
         T.bind(self, T.class_of(Formula))
         desc "Versioned test formula"
         homepage "https://brew.sh"
@@ -124,6 +154,36 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
 
         disable! date: "2020-06-25", because: :discontinued
       end,
+      partially_disabled_arch:               Cask::CaskLoader.load(<<~RUBY),
+        cask "test_partially_disabled_arch" do
+          version "0.0.1"
+          sha256 :no_check
+
+          url "https://brew.sh/test-0.0.1.tgz"
+          name "Test Partially Disable Arch"
+          desc "Partially disabled (arch) test cask"
+          homepage "https://brew.sh"
+
+          on_#{Hardware::CPU.arm? ? "arm" : "intel"} do
+            disable! date: "2020-06-25", because: :unmaintained
+          end
+        end
+      RUBY
+      partially_disabled_os:                 Cask::CaskLoader.load(<<~RUBY),
+        cask "test_partially_disabled_os" do
+          version "0.0.1"
+          sha256 :no_check
+
+          url "https://brew.sh/test-0.0.1.tgz"
+          name "Test Partially Disable OS"
+          desc "Partially disabled (OS) test cask"
+          homepage "https://brew.sh"
+
+          on_#{OS.mac? ? "macos" : "linux"} do
+            disable! date: "2020-06-25", because: :unmaintained
+          end
+        end
+      RUBY
       future_disable_fails_gatekeeper_check: Cask::Cask.new("test_future_disable_fails_gatekeeper_check") do
         version "0.0.1"
 
@@ -352,21 +412,6 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
   end
 
   describe "::skip_information" do
-    it "does not skip a cask disabled only on the current OS" do
-      cask = Cask::CaskLoader.load(<<~RUBY)
-        cask "partially-disabled" do
-          version "1.2.3"
-          url "https://brew.sh/test-1.2.3.tgz"
-
-          on_#{OS.mac? ? "macos" : "linux"} do
-            disable! date: "2020-01-01", because: :unmaintained
-          end
-        end
-      RUBY
-
-      expect(skip_conditions.skip_information(cask)).to eq({})
-    end
-
     context "when a formula without a `livecheck` block is deprecated" do
       it "skips" do
         expect(skip_conditions.skip_information(formulae[:deprecated]))
@@ -378,6 +423,18 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
       it "skips" do
         expect(skip_conditions.skip_information(formulae[:disabled]))
           .to eq(status_hashes[:formula][:disabled])
+      end
+    end
+
+    context "when a formula is only disabled on the current arch" do
+      it "does not skip" do
+        expect(skip_conditions.skip_information(formulae[:partially_disabled_arch])).to eq({})
+      end
+    end
+
+    context "when a formula is only disabled on the current OS" do
+      it "does not skip" do
+        expect(skip_conditions.skip_information(formulae[:partially_disabled_os])).to eq({})
       end
     end
 
@@ -437,6 +494,18 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
       it "skips" do
         expect(skip_conditions.skip_information(casks[:disabled]))
           .to eq(status_hashes[:cask][:disabled])
+      end
+    end
+
+    context "when a cask is only disabled on the current arch" do
+      it "does not skip" do
+        expect(skip_conditions.skip_information(casks[:partially_disabled_arch])).to eq({})
+      end
+    end
+
+    context "when a cask is only disabled on the current OS" do
+      it "does not skip" do
+        expect(skip_conditions.skip_information(casks[:partially_disabled_os])).to eq({})
       end
     end
 

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -1432,12 +1432,26 @@ RSpec.describe Tap do
       core_tap.remove_instance_variable(:@autobump) if core_tap.instance_variable_defined?(:@autobump)
       expect(Homebrew::API::Internal).not_to receive(:formula_hashes)
       allow(Homebrew::API::Formula).to receive(:all_formulae).and_return({
-        "autobumped" => { "autobump" => true, "skip_livecheck" => false },
-        "disabled"   => { "autobump" => true, "disabled" => true },
-        "skipped"    => { "autobump" => true, "skip_livecheck" => true },
+        "autobumped"         => { "autobump" => true, "skip_livecheck" => false },
+        "disabled"           => { "autobump" => true, "disabled" => true },
+        "partially-disabled" => {
+          "autobump"   => true, "disabled" => true,
+          "variations" => {
+            "arm64_tahoe"  => { "conflicts_with" => ["skipped"] },
+            "x86_64_linux" => { "disabled" => false },
+          }
+        },
+        "skipped"            => { "autobump" => true, "skip_livecheck" => true },
+        "variations"         => {
+          "autobump"   => true, "skip_livecheck" => false, "disabled" => false,
+          "variations" => {
+            "arm64_tahoe"  => { "dependencies" => ["autobumped"] },
+            "x86_64_linux" => { "dependencies" => ["skipped"] },
+          }
+        },
       })
 
-      expect(core_tap.autobump).to eq(["autobumped"])
+      expect(core_tap.autobump).to eq(["autobumped", "partially-disabled", "variations"])
     end
 
     specify "#autobump reads public cask API metadata" do
@@ -1446,12 +1460,27 @@ RSpec.describe Tap do
       expect(Homebrew::API::Formula).not_to receive(:all_formulae)
       expect(Homebrew::API::Internal).not_to receive(:cask_hashes)
       allow(Homebrew::API::Cask).to receive(:all_casks).and_return({
-        "autobumped" => { "autobump" => true, "skip_livecheck" => false },
-        "disabled"   => { "autobump" => true, "disabled" => true },
-        "skipped"    => { "autobump" => true, "skip_livecheck" => true },
+        "autobumped"         => { "autobump" => true, "skip_livecheck" => false },
+        "disabled"           => { "autobump" => true, "disabled" => true },
+        "partially-disabled" => {
+          "autobump"   => true, "disabled" => true,
+          "variations" => {
+            "tahoe"        => { "conflicts_with" => ["skipped"] },
+            "x86_64_linux" => { "disabled" => false },
+          }
+        },
+        "skipped"            => { "autobump" => true, "skip_livecheck" => true },
+        "variations"         => {
+          "autobump"   => true, "skip_livecheck" => false, "disabled" => false,
+          "url"        => "https://brew.sh/aarch64.dmg", "sha256" => "abc",
+          "variations" => {
+            "tahoe"        => { "url" => "https://brew.sh/x86_64.dmg", "sha256" => "def" },
+            "x86_64_linux" => { "sha256" => nil },
+          }
+        },
       })
 
-      expect(cask_tap.autobump).to eq(["autobumped"])
+      expect(cask_tap.autobump).to eq(["autobumped", "partially-disabled", "variations"])
     end
 
     specify "files", :no_api do


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

This is an additional fix for #23846

While #23847 made it so that `brew bump` and `brew livecheck` could be used by the user against these packages, this was not enough for autobump CI to work.