### PR TITLE
shellenv: prioritise Homebrew across shells

### DIFF
--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -7,7 +7,7 @@
 # Please do not submit PRs to remove it!
 # shellcheck disable=SC2154
 homebrew-shellenv() {
-  if [[ "${HOMEBREW_PATH%%:"${HOMEBREW_PREFIX}"/sbin*}" == "${HOMEBREW_PREFIX}/bin" ]]
+  if [[ "${HOMEBREW_PATH}:" == "${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin:"* ]]
   then
     return
   fi
@@ -51,8 +51,8 @@ homebrew-shellenv() {
       echo "set --global --export HOMEBREW_CELLAR \"${HOMEBREW_CELLAR}\";"
       echo "set --global --export HOMEBREW_REPOSITORY \"${HOMEBREW_REPOSITORY}\";"
       echo "fish_add_path --global --move --path \"${HOMEBREW_PREFIX}/bin\" \"${HOMEBREW_PREFIX}/sbin\";"
-      echo "if test -n \"\$MANPATH[1]\"; set --global --export MANPATH '' \$MANPATH; end;"
-      echo "if not set --query INFOPATH; set INFOPATH ''; end; if not contains \"${HOMEBREW_PREFIX}/share/info\" \$INFOPATH; set --global --export INFOPATH \"${HOMEBREW_PREFIX}/share/info\" \$INFOPATH; end;"
+      echo "if test -n \"\$MANPATH\"; set --global --export MANPATH (string replace --regex '^:*(.*?):*\$' ':\$1' -- \"\$MANPATH\"); end;"
+      echo "if not set --query INFOPATH; set INFOPATH ''; end; set --global --export INFOPATH \"${HOMEBREW_PREFIX}/share/info\" \$INFOPATH;"
       ;;
     csh | -csh | tcsh | -tcsh)
       echo "setenv HOMEBREW_PREFIX ${HOMEBREW_PREFIX};"
@@ -62,18 +62,19 @@ homebrew-shellenv() {
       then
         echo "eval \`/usr/bin/env PATH_HELPER_ROOT=\"${PATH_HELPER_ROOT}\" /usr/libexec/path_helper -c\`;"
       else
-        echo "setenv PATH ${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin:\$PATH;"
+        echo "setenv PATH \"${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin:\$PATH\";"
       fi
-      echo "test \${?MANPATH} -eq 1 && setenv MANPATH :\${MANPATH};"
-      echo "setenv INFOPATH ${HOMEBREW_PREFIX}/share/info\`test \${?INFOPATH} -eq 1 && echo :\${INFOPATH}\`;"
+      echo "test \${?MANPATH} -eq 1 && test -n \"\${MANPATH}\" && setenv MANPATH :\`printf '%s' \"\${MANPATH}\" | /usr/bin/sed -e 's/^:*//' -e 's/:*\$//'\`;"
+      echo "test \${?INFOPATH} -eq 1 || setenv INFOPATH '';"
+      echo "setenv INFOPATH \"${HOMEBREW_PREFIX}/share/info:\${INFOPATH}\";"
       ;;
     pwsh | -pwsh | pwsh-preview | -pwsh-preview)
       echo "[System.Environment]::SetEnvironmentVariable('HOMEBREW_PREFIX','${HOMEBREW_PREFIX}',[System.EnvironmentVariableTarget]::Process)"
       echo "[System.Environment]::SetEnvironmentVariable('HOMEBREW_CELLAR','${HOMEBREW_CELLAR}',[System.EnvironmentVariableTarget]::Process)"
       echo "[System.Environment]::SetEnvironmentVariable('HOMEBREW_REPOSITORY','${HOMEBREW_REPOSITORY}',[System.EnvironmentVariableTarget]::Process)"
       echo "[System.Environment]::SetEnvironmentVariable('PATH',\$('${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin:'+\$ENV:PATH),[System.EnvironmentVariableTarget]::Process)"
-      echo "[System.Environment]::SetEnvironmentVariable('MANPATH',\$('${HOMEBREW_PREFIX}/share/man'+\$(if(\${ENV:MANPATH}){':'+\${ENV:MANPATH}})+':'),[System.EnvironmentVariableTarget]::Process)"
-      echo "[System.Environment]::SetEnvironmentVariable('INFOPATH',\$('${HOMEBREW_PREFIX}/share/info'+\$(if(\${ENV:INFOPATH}){':'+\${ENV:INFOPATH}})),[System.EnvironmentVariableTarget]::Process)"
+      echo "if (\${ENV:MANPATH}) { [System.Environment]::SetEnvironmentVariable('MANPATH',(':'+\${ENV:MANPATH}.Trim(':')),[System.EnvironmentVariableTarget]::Process) }"
+      echo "[System.Environment]::SetEnvironmentVariable('INFOPATH',('${HOMEBREW_PREFIX}/share/info:'+\${ENV:INFOPATH}),[System.EnvironmentVariableTarget]::Process)"
       ;;
     *)
       echo "export HOMEBREW_PREFIX=\"${HOMEBREW_PREFIX}\";"
@@ -90,7 +91,7 @@ homebrew-shellenv() {
       else
         echo "export PATH=\"${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin\${PATH+:\$PATH}\";"
       fi
-      echo "[ -z \"\${MANPATH-}\" ] || export MANPATH=\":\${MANPATH#:}\";"
+      echo "[ -z \"\${MANPATH-}\" ] || { export MANPATH=\"\${MANPATH%\"\${MANPATH##*[!:]}\"}\"; export MANPATH=\":\${MANPATH#\"\${MANPATH%%[!:]*}\"}\"; };"
       echo "export INFOPATH=\"${HOMEBREW_PREFIX}/share/info:\${INFOPATH:-}\";"
       ;;
   esac

--- a/Library/Homebrew/test/cmd/shellenv_spec.rb
+++ b/Library/Homebrew/test/cmd/shellenv_spec.rb
@@ -1,11 +1,144 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "open3"
+
 RSpec.describe "brew shellenv", type: :system do
+  before do
+    ENV["HOMEBREW_PREFIX"] = HOMEBREW_PREFIX.to_s
+    ENV["HOMEBREW_CELLAR"] = HOMEBREW_CELLAR.to_s
+    ENV["HOMEBREW_REPOSITORY"] = HOMEBREW_REPOSITORY.to_s
+    ENV["HOMEBREW_PATH"] = "/usr/bin:/bin"
+    ENV.delete("HOMEBREW_MACOS")
+    ENV.delete("PATH_HELPER_ROOT")
+    ENV.delete("MANPATH")
+    ENV.delete("INFOPATH")
+    ENV["FPATH"] = "/custom/functions"
+    ENV["XDG_CONFIG_HOME"] = (HOMEBREW_TEMP/"config").to_s
+    (HOMEBREW_PREFIX/"bin").mkpath
+    (HOMEBREW_PREFIX/"sbin").mkpath
+  end
+
   it "prints export statements", :integration_test do
     expect { brew_sh "shellenv" }
       .to output(/.*/).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
+  end
+
+  sig { params(shell: String).returns(String) }
+  def shellenv(shell)
+    Utils.safe_popen_read(
+      "/bin/bash", "-c", 'source "$1"; homebrew-shellenv "$2"',
+      "bash", (HOMEBREW_LIBRARY_PATH/"cmd/shellenv.sh").to_s, shell
+    )
+  end
+
+  sig { params(shell: String, shell_args: T::Array[String]).returns(T::Hash[String, String]) }
+  def shellenv_environment(shell, shell_args)
+    stdout, stderr, status = Open3.capture3(
+      (which(shell, ORIGINAL_PATHS) || skip("#{shell} is not installed")).to_s, *shell_args,
+      "#{shellenv(shell)}\n/usr/bin/env"
+    )
+    raise "shellenv failed: #{stderr}" if !status.success? || !stderr.empty?
+
+    stdout.lines.filter_map do |line|
+      name, value = line.chomp.split("=", 2)
+      next if name.nil? || value.nil?
+      next unless %w[HOMEBREW_PREFIX HOMEBREW_CELLAR HOMEBREW_REPOSITORY PATH MANPATH INFOPATH FPATH].include?(name)
+
+      [name, value]
+    end.to_h
+  end
+
+  test_each_hash({
+    "bash" => %w[--noprofile --norc -c],
+    "csh"  => %w[-f -c],
+    "fish" => %w[--no-config -c],
+    "pwsh" => %w[-NoProfile -Command],
+    "sh"   => %w[-c],
+    "tcsh" => %w[-f -c],
+    "zsh"  => %w[-f -c],
+  }) do |shell, shell_args|
+    it "produces no output when Homebrew already leads PATH in #{shell}" do
+      ENV["HOMEBREW_PATH"] = "#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:/usr/bin:/bin"
+
+      expect(shellenv(shell)).to be_empty
+    end
+
+    it "does not mistake an sbin-prefixed directory for Homebrew's sbin in #{shell}" do
+      ENV["HOMEBREW_PATH"] = "#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin-other:/usr/bin:/bin"
+
+      expect(shellenv(shell)).not_to be_empty
+    end
+
+    it "handles login shell names for #{shell}" do
+      expect(shellenv("-#{shell}")).to eq(shellenv(shell))
+    end
+
+    it "exports Homebrew's directories in #{shell}" do
+      expect(shellenv_environment(shell, shell_args)).to include(
+        "HOMEBREW_PREFIX"     => HOMEBREW_PREFIX.to_s,
+        "HOMEBREW_CELLAR"     => HOMEBREW_CELLAR.to_s,
+        "HOMEBREW_REPOSITORY" => HOMEBREW_REPOSITORY.to_s,
+      )
+    end
+
+    it "prioritises Homebrew executables and preserves existing PATH entries in #{shell}" do
+      ENV["PATH"] = "/custom path:/usr/bin:/bin"
+
+      expect(shellenv_environment(shell, shell_args).fetch("PATH"))
+        .to start_with("#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:")
+        .and end_with("/custom path:/usr/bin:/bin")
+    end
+
+    it "preserves existing FPATH entries and adds completions for #{shell}" do
+      expect(shellenv_environment(shell, shell_args).fetch("FPATH").split(":"))
+        .to eq([("#{HOMEBREW_PREFIX}/share/zsh/site-functions" if shell == "zsh"), "/custom/functions"].compact)
+    end
+
+    it "prepends default man directories in #{shell}" do
+      expected = {
+        nil                            => nil,
+        ""                             => "",
+        ":"                            => ":",
+        "/usr/share/man:/ghostty/man:" => ":/usr/share/man:/ghostty/man",
+        ":/usr/share/man:"             => ":/usr/share/man",
+        ":/ghostty/man"                => ":/ghostty/man",
+        "/ghostty/man"                 => ":/ghostty/man",
+        "/custom man:"                 => ":/custom man",
+        "/usr/share/man::"             => ":/usr/share/man",
+        ":::/usr/share/man"            => ":/usr/share/man",
+        ":::/usr/share/man:::"         => ":/usr/share/man",
+        ":::"                          => ":",
+        "::/custom man::/other/man::"  => ":/custom man::/other/man",
+      }
+
+      expect(expected.keys.to_h do |manpath|
+        ENV["MANPATH"] = manpath
+        [manpath, shellenv_environment(shell, shell_args)["MANPATH"]]
+      end).to eq(expected)
+    end
+
+    it "preserves Info directories in #{shell}" do
+      expect([nil, "", ":", "/custom/info", ":/custom/info:", "/custom info:"].to_h do |infopath|
+        ENV["INFOPATH"] = infopath
+        [infopath, shellenv_environment(shell, shell_args).fetch("INFOPATH")]
+      end).to eq(
+        nil              => "#{HOMEBREW_PREFIX}/share/info:",
+        ""               => "#{HOMEBREW_PREFIX}/share/info:",
+        ":"              => "#{HOMEBREW_PREFIX}/share/info::",
+        "/custom/info"   => "#{HOMEBREW_PREFIX}/share/info:/custom/info",
+        ":/custom/info:" => "#{HOMEBREW_PREFIX}/share/info::/custom/info:",
+        "/custom info:"  => "#{HOMEBREW_PREFIX}/share/info:/custom info:",
+      )
+    end
+
+    it "prioritises Homebrew Info directories already present in INFOPATH in #{shell}" do
+      ENV["INFOPATH"] = "/custom/info:#{HOMEBREW_PREFIX}/share/info:"
+
+      expect(shellenv_environment(shell, shell_args).fetch("INFOPATH"))
+        .to start_with("#{HOMEBREW_PREFIX}/share/info:")
+    end
   end
 end


### PR DESCRIPTION
- Normalise `MANPATH` so default man directories lead existing paths.
- Preserve default `INFOPATH` entries and prioritise Homebrew's Info directory in every shell.
- Preserve spaces in csh paths and require an exact `sbin` PATH entry before skipping exports.

Fixes #23899

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Codex with GPT 6 Astra at High effort, with local review and testing.

-----