### PR TITLE
cask: hoist OS sha256 and sort depends_on

### DIFF
--- a/Library/Homebrew/rubocops/cask/constants/stanza.rb
+++ b/Library/Homebrew/rubocops/cask/constants/stanza.rb
@@ -19,6 +19,7 @@ module RuboCop
         ].map { |option, _| :"on_#{option}" }.freeze,
         T::Array[Symbol],
       )
+      SHA256_ARCH_ORDER = [:arm, :intel, :x86_64, :arm64_linux, :x86_64_linux].freeze
 
       STANZA_GROUPS = T.let(
         [

--- a/Library/Homebrew/rubocops/cask/on_system_conditionals.rb
+++ b/Library/Homebrew/rubocops/cask/on_system_conditionals.rb
@@ -37,6 +37,14 @@ module RuboCop
           [*RuboCop::Cask::Constants::ON_SYSTEM_METHODS, :on_system].freeze,
           T::Array[Symbol],
         )
+        SHA256_KEYS = T.let(
+          {
+            macos: { arm64: :arm, intel: :intel, x86_64: :intel },
+            linux: { arm64: :arm64_linux, intel: :x86_64_linux, x86_64: :x86_64_linux },
+          }.freeze,
+          T::Hash[Symbol, T::Hash[Symbol, Symbol]],
+        )
+        OS_SHA256_MESSAGE = "Don't nest `sha256` stanzas in `on_macos` and `on_linux` blocks"
 
         sig { override.params(cask_block: RuboCop::Cask::AST::CaskBlock).void }
         def on_cask(cask_block)
@@ -52,6 +60,7 @@ module RuboCop
           audit_arch_conditionals(cask_body, allowed_blocks: FLIGHT_STANZA_NAMES)
           audit_macos_version_conditionals(cask_body, recommend_on_system: false, allowed_blocks: FLIGHT_STANZA_NAMES)
           simplify_sha256_stanzas
+          simplify_os_sha256_stanzas
           simplify_arch_version_stanzas
           audit_identical_sha256_across_architectures
         end
@@ -115,6 +124,132 @@ module RuboCop
         end
 
         sig { void }
+        def simplify_os_sha256_stanzas
+          return if toplevel_stanzas.any? { |stanza| stanza.stanza_name == :sha256 }
+
+          macos_blocks = toplevel_os_blocks(:on_macos)
+          linux_blocks = toplevel_os_blocks(:on_linux)
+          return if macos_blocks.count != 1 || linux_blocks.count != 1
+
+          macos_block = macos_blocks.fetch(0)
+          linux_block = linux_blocks.fetch(0)
+
+          macos_sha256_nodes = direct_send_nodes(macos_block).select { |node| node.method_name == :sha256 }
+          linux_sha256_nodes = direct_send_nodes(linux_block).select { |node| node.method_name == :sha256 }
+          return if macos_sha256_nodes.count != 1 || linux_sha256_nodes.count != 1
+
+          macos_sha256 = macos_sha256_nodes.fetch(0)
+          linux_sha256 = linux_sha256_nodes.fetch(0)
+
+          version_node = toplevel_stanzas.find { |stanza| stanza.stanza_name == :version }&.stanza_node
+          return unless version_node.is_a?(RuboCop::AST::SendNode)
+
+          offending_node(linux_block)
+          stanza_sequences = [
+            toplevel_stanzas,
+            RuboCop::Cask::AST::StanzaBlock.new(macos_block, processed_source.comments).stanzas,
+            RuboCop::Cask::AST::StanzaBlock.new(linux_block, processed_source.comments).stanzas,
+          ]
+          stanzas_need_reordering = stanza_sequences.any? do |stanzas|
+            stanzas.each_cons(2).any? do |previous, current|
+              previous_index = previous.stanza_index
+              current_index = current.stanza_index
+              previous_index && current_index && previous_index > current_index
+            end
+          end
+          stanza_grouping_will_edit = [[macos_block, macos_sha256], [linux_block, linux_sha256]].any? do |block, node|
+            stanzas = inner_stanzas(block, processed_source.comments)
+            stanza_index = stanzas.index { |stanza| stanza.stanza_node == node }
+            next false unless stanza_index
+
+            stanza = stanzas.fetch(stanza_index)
+            next_stanza = stanzas[stanza_index + 1]
+            next false unless next_stanza
+
+            stanza.same_group?(next_stanza) == processed_source[stanza.source_range.last_line].empty?
+          end
+          comments_would_be_lost = [macos_sha256, linux_sha256].any? do |node|
+            processed_source.comments.any? do |comment|
+              comment_range = comment.loc.expression
+              comment_range.line.between?(node.first_line, node.last_line) ||
+                comment_range.last_line == node.first_line - 1
+            end
+          end
+          comments_would_be_lost ||= [[macos_block, macos_sha256], [linux_block, linux_sha256]].any? do |block, node|
+            block.block_body == node &&
+              (comments_in_node_ranges?(block) ||
+                processed_source.comments.any? do |comment|
+                  comment_range = comment.loc.expression
+                  comment_range.line == block.last_line || comment_range.last_line == block.first_line - 1
+                end)
+          end
+          if stanzas_need_reordering || stanza_grouping_will_edit || comments_would_be_lost
+            problem OS_SHA256_MESSAGE
+            return
+          end
+
+          macos_argument = macos_sha256.first_argument
+          linux_argument = linux_sha256.first_argument
+          identical_sha256_source = if macos_argument && linux_argument &&
+                                       macos_argument.source == linux_argument.source &&
+                                       (macos_argument.str_type? ||
+                                         (macos_argument.sym_type? && macos_argument.value == :no_check))
+            macos_argument.source
+          end
+
+          replacement = if identical_sha256_source
+            "sha256 #{identical_sha256_source}"
+          else
+            macos_pairs = sha256_pairs(macos_sha256, macos_block, :macos)
+            linux_pairs = sha256_pairs(linux_sha256, linux_block, :linux)
+            if macos_pairs.nil? || linux_pairs.nil?
+              problem OS_SHA256_MESSAGE
+              return
+            end
+
+            pairs = (macos_pairs + linux_pairs).sort_by do |key, _value|
+              RuboCop::Cask::Constants::SHA256_ARCH_ORDER.index(key) || raise("unexpected sha256 key: #{key}")
+            end
+            width = pairs.map { |key, _value| key.length }.max.to_i
+            prefix = "sha256 "
+            continuation = " " * (version_node.source_range.column + prefix.length)
+            pairs.each_with_index.map do |(key, value), index|
+              key_with_padding = "#{key}:".ljust(width + 2)
+              "#{index.zero? ? prefix : continuation}#{key_with_padding}#{value}"
+            end.join(",\n")
+          end
+
+          problem OS_SHA256_MESSAGE do |corrector|
+            corrector.insert_after(range_by_whole_lines(version_node.source_range, include_final_newline: false),
+                                   "\n#{" " * version_node.source_range.column}#{replacement}")
+            os_blocks_and_sha256 = [[macos_block, macos_sha256], [linux_block, linux_sha256]]
+            remove_both_os_blocks = os_blocks_and_sha256.all? { |block, node| block.block_body == node }
+            os_blocks_and_sha256.each_with_index do |(block, node), index|
+              removal_node = (block.block_body == node) ? block : node
+              range = range_by_whole_lines(removal_node.source_range, include_final_newline: true)
+              if remove_both_os_blocks && index.zero? &&
+                 (preceding_blank_line = processed_source.buffer.source[...range.begin_pos].to_s[/\n[ \t]*\n\z/])
+                range = range.adjust(begin_pos: -(preceding_blank_line.length - 1))
+              end
+              stanzas = inner_stanzas(block, processed_source.comments)
+              preserve_following_blank_line = if (stanza_index = stanzas.index do |stanza|
+                stanza.stanza_node == node
+              end) && stanza_index.positive?
+                previous_stanza = stanzas.fetch(stanza_index - 1)
+                next_stanza = stanzas[stanza_index + 1]
+                next_stanza && !previous_stanza.same_group?(next_stanza)
+              end
+              following_blank_line = if preserve_following_blank_line
+                ""
+              else
+                processed_source.buffer.source[range.end_pos..].to_s[/\A[ \t]*\n/].to_s
+              end
+              corrector.remove(range.adjust(end_pos: following_blank_line.length))
+            end
+          end
+        end
+
+        sig { void }
         def simplify_arch_version_stanzas
           grouped_nodes = Hash.new { |hash, key| hash[key] = {} }
 
@@ -173,6 +308,81 @@ module RuboCop
               node_range.begin_pos <= comment_range.begin_pos && comment_range.end_pos <= node_range.end_pos
             end
           end
+        end
+
+        sig { params(method: Symbol).returns(T::Array[RuboCop::AST::BlockNode]) }
+        def toplevel_os_blocks(method)
+          toplevel_stanzas.filter_map do |stanza|
+            node = stanza.stanza_node
+            node if stanza.stanza_name == method && node.is_a?(RuboCop::AST::BlockNode)
+          end
+        end
+
+        sig { params(block: RuboCop::AST::BlockNode).returns(T::Array[RuboCop::AST::SendNode]) }
+        def direct_send_nodes(block)
+          body = block.block_body
+          return [] unless body
+
+          (body.begin_type? ? body.child_nodes : [body]).select do |node|
+            node.is_a?(RuboCop::AST::SendNode) && node.receiver.nil?
+          end
+        end
+
+        sig {
+          params(
+            sha256_node: RuboCop::AST::SendNode,
+            block:       RuboCop::AST::BlockNode,
+            os:          Symbol,
+          ).returns(T.nilable(T::Array[[Symbol, String]]))
+        }
+        def sha256_pairs(sha256_node, block, os)
+          argument = sha256_node.first_argument
+          return unless argument
+
+          if argument.hash_type?
+            allowed_keys = SHA256_KEYS.fetch(os).values.uniq
+            allowed_keys << :x86_64 if os == :macos
+            return if argument.pairs.any? do |pair|
+              !pair.key.sym_type? || !pair.value.str_type? || !allowed_keys.include?(pair.key.value)
+            end
+
+            return argument.pairs.map { |pair| [pair.key.value, pair.value.source] }
+          end
+          return unless argument.str_type?
+
+          toplevel_depends_on_nodes = toplevel_stanzas.filter_map do |stanza|
+            node = stanza.stanza_node
+            node if stanza.stanza_name == :depends_on && node.is_a?(RuboCop::AST::SendNode)
+          end
+          arch_values = (toplevel_depends_on_nodes + direct_send_nodes(block)).filter_map do |node|
+            next if node.method_name != :depends_on
+
+            node.arguments.filter_map do |node_argument|
+              next unless node_argument.hash_type?
+
+              pair = node_argument.pairs.find { |candidate| candidate.key.sym_type? && candidate.key.value == :arch }
+              next unless pair
+
+              if pair.value.sym_type?
+                pair.value.value
+              elsif pair.value.array_type? && pair.value.values.all?(&:sym_type?)
+                pair.value.values.map(&:value)
+              else
+                false
+              end
+            end
+          end.flatten
+          return if arch_values.any? { |value| !value.is_a?(Symbol) }
+
+          keys = if arch_values.empty?
+            SHA256_KEYS.fetch(os).values.uniq
+          else
+            symbol_arch_values = arch_values.grep(Symbol)
+            return if symbol_arch_values.any? { |arch| !SHA256_KEYS.fetch(os).key?(arch) }
+
+            symbol_arch_values.filter_map { |arch| SHA256_KEYS.fetch(os)[arch] }.uniq
+          end
+          keys.map { |key| [key, argument.source] }
         end
 
         sig { void }

--- a/Library/Homebrew/rubocops/cask/sha256_arch_order.rb
+++ b/Library/Homebrew/rubocops/cask/sha256_arch_order.rb
@@ -22,7 +22,7 @@ module RuboCop
         extend AutoCorrector
         include CaskHelp
 
-        ARCH_ORDER = [:arm, :intel, :x86_64, :arm64_linux, :x86_64_linux].freeze
+        ARCH_ORDER = RuboCop::Cask::Constants::SHA256_ARCH_ORDER
 
         MESSAGE = "`sha256` architecture keys should be ordered: arm, intel (or x86_64), arm64_linux, x86_64_linux"
 

--- a/Library/Homebrew/rubocops/cask/stanza_order.rb
+++ b/Library/Homebrew/rubocops/cask/stanza_order.rb
@@ -54,19 +54,48 @@ module RuboCop
 
         sig { params(stanzas: T::Array[RuboCop::Cask::AST::Stanza]).returns(T::Array[RuboCop::Cask::AST::Stanza]) }
         def sort_stanzas(stanzas)
-          stanzas.sort do |stanza1, stanza2|
-            i1 = stanza1.stanza_index
-            i2 = stanza2.stanza_index
-
-            if i1 == i2
-              i1 = stanzas.index(stanza1)
-              i2 = stanzas.index(stanza2)
-            end
-            raise "unexpected nil value for i1" unless i1
-            raise "unexpected nil value for i2" unless i2
-
-            i1 - i2
+          sort_depends_on_stanzas = stanzas.all? do |stanza|
+            stanza.stanza_name != :depends_on || !depends_on_sort_key(stanza).nil?
           end
+          stanzas.each_with_index.sort_by do |stanza, index|
+            [
+              stanza.stanza_index || raise("unexpected nil stanza index"),
+              if sort_depends_on_stanzas && stanza.stanza_name == :depends_on
+                depends_on_sort_key(stanza)
+              else
+                ""
+              end,
+              index,
+            ]
+          end.map(&:first)
+        end
+
+        sig { params(stanza: RuboCop::Cask::AST::Stanza).returns(T.nilable(String)) }
+        def depends_on_sort_key(stanza)
+          node = stanza.stanza_node
+          return unless node.is_a?(RuboCop::AST::SendNode)
+
+          argument = node.first_argument
+          return unless argument
+          return argument.value.to_s.downcase if argument.sym_type?
+          return unless argument.hash_type?
+
+          return unless argument.pairs.all? do |pair|
+            next false unless pair.key.sym_type?
+
+            values = pair.value.array_type? ? pair.value.values : [pair.value]
+            values.all? { |value| value.sym_type? || value.str_type? }
+          end
+
+          sort_key = []
+          argument.pairs.each do |pair|
+            sort_key << pair.key.value.to_s.downcase
+            values = pair.value.array_type? ? pair.value.values : [pair.value]
+            values.each do |value|
+              sort_key << value.value.to_s.downcase
+            end
+          end
+          sort_key.join("\0")
         end
       end
     end

--- a/Library/Homebrew/test/rubocops/cask/on_system_conditionals_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/on_system_conditionals_spec.rb
@@ -330,6 +330,609 @@ RSpec.describe RuboCop::Cop::Cask::OnSystemConditionals, :config do
     end
   end
 
+  context "when auditing `sha256` stanzas inside `on_os` blocks" do
+    it "moves architecture-specific checksums to the top level" do
+      expect_offense <<~CASK
+        cask "foo" do
+          version "1.2.3"
+
+          on_macos do
+            sha256 arm:   "arm",
+                   intel: "intel"
+
+            app "Foo.app"
+          end
+          on_linux do
+          ^^^^^^^^^^^ Don't nest `sha256` stanzas in `on_macos` and `on_linux` blocks
+            sha256 "linux"
+
+            depends_on arch: :x86_64
+
+            app_image "Foo.AppImage"
+          end
+        end
+      CASK
+
+      expect_correction <<~CASK
+        cask "foo" do
+          version "1.2.3"
+          sha256 arm:          "arm",
+                 intel:        "intel",
+                 x86_64_linux: "linux"
+
+          on_macos do
+            app "Foo.app"
+          end
+          on_linux do
+            depends_on arch: :x86_64
+
+            app_image "Foo.AppImage"
+          end
+        end
+      CASK
+    end
+
+    it "duplicates a universal macOS checksum across macOS architectures" do
+      expect_offense <<~CASK
+        cask "foo" do
+          version "1.2.3"
+
+          on_macos do
+            sha256 "macos"
+
+            app "Foo.app"
+          end
+          on_linux do
+          ^^^^^^^^^^^ Don't nest `sha256` stanzas in `on_macos` and `on_linux` blocks
+            sha256 arm64_linux:  "arm-linux",
+                   x86_64_linux: "intel-linux"
+
+            app_image "Foo.AppImage"
+          end
+        end
+      CASK
+
+      expect_correction <<~CASK
+        cask "foo" do
+          version "1.2.3"
+          sha256 arm:          "macos",
+                 intel:        "macos",
+                 arm64_linux:  "arm-linux",
+                 x86_64_linux: "intel-linux"
+
+          on_macos do
+            app "Foo.app"
+          end
+          on_linux do
+            app_image "Foo.AppImage"
+          end
+        end
+      CASK
+    end
+
+    it "combines every architecture dependency in an OS block" do
+      expect_offense <<~CASK
+        cask "foo" do
+          version "1.2.3"
+
+          on_macos do
+            sha256 "macos"
+
+            depends_on arch: :x86_64
+            depends_on arch: :arm64
+          end
+          on_linux do
+          ^^^^^^^^^^^ Don't nest `sha256` stanzas in `on_macos` and `on_linux` blocks
+            sha256 "linux"
+
+            depends_on arch: [:intel, :arm64]
+          end
+        end
+      CASK
+
+      expect_correction <<~CASK
+        cask "foo" do
+          version "1.2.3"
+          sha256 arm:          "macos",
+                 intel:        "macos",
+                 arm64_linux:  "linux",
+                 x86_64_linux: "linux"
+
+          on_macos do
+            depends_on arch: :x86_64
+            depends_on arch: :arm64
+          end
+          on_linux do
+            depends_on arch: [:intel, :arm64]
+          end
+        end
+      CASK
+    end
+
+    it "combines top-level and OS-scoped architecture dependencies" do
+      expect_offense <<~CASK
+        cask "foo" do
+          version "1.2.3"
+
+          on_macos do
+            sha256 "macos"
+
+            depends_on arch: :x86_64
+
+            app "Foo.app"
+          end
+          on_linux do
+          ^^^^^^^^^^^ Don't nest `sha256` stanzas in `on_macos` and `on_linux` blocks
+            sha256 "linux"
+
+            app_image "Foo.AppImage"
+          end
+
+          depends_on arch: :arm64
+        end
+      CASK
+
+      expect_correction <<~CASK
+        cask "foo" do
+          version "1.2.3"
+          sha256 arm:         "macos",
+                 intel:       "macos",
+                 arm64_linux: "linux"
+
+          on_macos do
+            depends_on arch: :x86_64
+
+            app "Foo.app"
+          end
+          on_linux do
+            app_image "Foo.AppImage"
+          end
+
+          depends_on arch: :arm64
+        end
+      CASK
+    end
+
+    it "handles bare Intel dependencies and the macOS x86_64 checksum alias" do
+      expect_offense <<~CASK
+        cask "foo" do
+          version "1.2.3"
+
+          on_macos do
+            sha256 x86_64: "macos"
+          end
+          on_linux do
+          ^^^^^^^^^^^ Don't nest `sha256` stanzas in `on_macos` and `on_linux` blocks
+            sha256 "linux"
+
+            depends_on arch: :intel
+          end
+        end
+      CASK
+
+      expect_correction <<~CASK
+        cask "foo" do
+          version "1.2.3"
+          sha256 x86_64:       "macos",
+                 x86_64_linux: "linux"
+
+          on_linux do
+            depends_on arch: :intel
+          end
+        end
+      CASK
+    end
+
+    it "uses one checksum when the OS checksums are identical" do
+      expect_offense <<~CASK
+        cask "foo" do
+          version "1.2.3"
+
+          on_macos do
+            sha256 "checksum"
+
+            app "Foo.app"
+          end
+          on_linux do
+          ^^^^^^^^^^^ Don't nest `sha256` stanzas in `on_macos` and `on_linux` blocks
+            sha256 "checksum"
+
+            app_image "Foo.AppImage"
+          end
+        end
+      CASK
+
+      expect_correction <<~CASK
+        cask "foo" do
+          version "1.2.3"
+          sha256 "checksum"
+
+          on_macos do
+            app "Foo.app"
+          end
+          on_linux do
+            app_image "Foo.AppImage"
+          end
+        end
+      CASK
+    end
+
+    it "uses one `no_check` checksum when both OS blocks skip verification" do
+      expect_offense <<~CASK
+        cask "foo" do
+          version :latest
+
+          on_macos do
+            sha256 :no_check
+
+            app "Foo.app"
+          end
+          on_linux do
+          ^^^^^^^^^^^ Don't nest `sha256` stanzas in `on_macos` and `on_linux` blocks
+            sha256 :no_check
+
+            app_image "Foo.AppImage"
+          end
+        end
+      CASK
+
+      expect_correction <<~CASK
+        cask "foo" do
+          version :latest
+          sha256 :no_check
+
+          on_macos do
+            app "Foo.app"
+          end
+          on_linux do
+            app_image "Foo.AppImage"
+          end
+        end
+      CASK
+    end
+
+    it "does not add a second top-level `sha256` stanza" do
+      expect_no_offenses <<~CASK
+        cask "foo" do
+          version "1.2.3"
+          sha256 "top-level"
+
+          on_macos do
+            sha256 "macos"
+          end
+          on_linux do
+            sha256 "linux"
+          end
+        end
+      CASK
+    end
+
+    it "removes OS blocks that contain only a checksum" do
+      expect_offense <<~CASK
+        cask "foo" do
+          version "1.2.3"
+
+          on_macos do
+            sha256 "macos"
+          end
+          on_linux do
+          ^^^^^^^^^^^ Don't nest `sha256` stanzas in `on_macos` and `on_linux` blocks
+            sha256 "linux"
+          end
+        end
+      CASK
+
+      expect_correction <<~CASK
+        cask "foo" do
+          version "1.2.3"
+          sha256 arm:          "macos",
+                 intel:        "macos",
+                 arm64_linux:  "linux",
+                 x86_64_linux: "linux"
+        end
+      CASK
+    end
+
+    it "preserves a trailing comment on the `version` stanza" do
+      expect_offense <<~CASK
+        cask "foo" do
+          version "1.2.3" # Keep this version note.
+
+          on_macos do
+            sha256 "macos"
+
+            app "Foo.app"
+          end
+          on_linux do
+          ^^^^^^^^^^^ Don't nest `sha256` stanzas in `on_macos` and `on_linux` blocks
+            sha256 "linux"
+
+            app_image "Foo.AppImage"
+          end
+        end
+      CASK
+
+      expect_correction <<~CASK
+        cask "foo" do
+          version "1.2.3" # Keep this version note.
+          sha256 arm:          "macos",
+                 intel:        "macos",
+                 arm64_linux:  "linux",
+                 x86_64_linux: "linux"
+
+          on_macos do
+            app "Foo.app"
+          end
+          on_linux do
+            app_image "Foo.AppImage"
+          end
+        end
+      CASK
+    end
+
+    it "reports but does not correct when the OS blocks need reordering" do
+      expect_offense <<~CASK
+        cask "foo" do
+          version "1.2.3"
+
+          on_linux do
+          ^^^^^^^^^^^ Don't nest `sha256` stanzas in `on_macos` and `on_linux` blocks
+            sha256 "linux"
+          end
+          on_macos do
+            sha256 "macos"
+          end
+        end
+      CASK
+
+      expect_no_corrections
+    end
+
+    it "reports but does not correct when an OS block's stanzas need reordering" do
+      expect_offense <<~CASK
+        cask "foo" do
+          version "1.2.3"
+
+          on_macos do
+            app "Foo.app"
+
+            sha256 "macos"
+          end
+          on_linux do
+          ^^^^^^^^^^^ Don't nest `sha256` stanzas in `on_macos` and `on_linux` blocks
+            sha256 "linux"
+
+            app_image "Foo.AppImage"
+          end
+        end
+      CASK
+
+      expect_no_corrections
+    end
+
+    it "reports but does not correct when the `version` stanza needs reordering" do
+      expect_offense <<~CASK
+        cask "foo" do
+          on_macos do
+            sha256 "macos"
+          end
+          on_linux do
+          ^^^^^^^^^^^ Don't nest `sha256` stanzas in `on_macos` and `on_linux` blocks
+            sha256 "linux"
+          end
+
+          version "1.2.3"
+        end
+      CASK
+
+      expect_no_corrections
+    end
+
+    it "reports but does not correct when stanza grouping must edit after a nested checksum" do
+      expect_offense <<~CASK
+        cask "foo" do
+          version "1.2.3"
+
+          on_macos do
+            sha256 "macos"
+            app "Foo.app"
+          end
+          on_linux do
+          ^^^^^^^^^^^ Don't nest `sha256` stanzas in `on_macos` and `on_linux` blocks
+            sha256 "linux"
+            app_image "Foo.AppImage"
+          end
+        end
+      CASK
+
+      expect_no_corrections
+    end
+
+    it "preserves grouping after removing a non-leading nested checksum" do
+      expect_offense <<~CASK
+        cask "foo" do
+          version "1.2.3"
+
+          on_macos do
+            version "1.2.3-macos"
+            sha256 "macos"
+
+            app "Foo.app"
+          end
+          on_linux do
+          ^^^^^^^^^^^ Don't nest `sha256` stanzas in `on_macos` and `on_linux` blocks
+            sha256 "linux"
+
+            app_image "Foo.AppImage"
+          end
+        end
+      CASK
+
+      expect_correction <<~CASK
+        cask "foo" do
+          version "1.2.3"
+          sha256 arm:          "macos",
+                 intel:        "macos",
+                 arm64_linux:  "linux",
+                 x86_64_linux: "linux"
+
+          on_macos do
+            version "1.2.3-macos"
+
+            app "Foo.app"
+          end
+          on_linux do
+            app_image "Foo.AppImage"
+          end
+        end
+      CASK
+    end
+
+    it "accepts OS blocks with different versions" do
+      expect_no_offenses <<~CASK
+        cask "foo" do
+          on_macos do
+            version "1.2.3"
+            sha256 "macos"
+
+            app "Foo.app"
+          end
+          on_linux do
+            version "1.2.4"
+            sha256 "linux"
+
+            app_image "Foo.AppImage"
+          end
+        end
+      CASK
+    end
+
+    it "does not remove comments within a `sha256` stanza" do
+      expect_offense <<~CASK
+        cask "foo" do
+          version "1.2.3"
+
+          on_macos do
+            sha256 arm: "arm", # Keep this architecture note.
+                   intel: "intel"
+
+            app "Foo.app"
+          end
+          on_linux do
+          ^^^^^^^^^^^ Don't nest `sha256` stanzas in `on_macos` and `on_linux` blocks
+            sha256 "linux"
+
+            depends_on arch: :x86_64
+
+            app_image "Foo.AppImage"
+          end
+        end
+      CASK
+
+      expect_no_corrections
+    end
+
+    it "does not remove a trailing comment on a `sha256` stanza" do
+      expect_offense <<~CASK
+        cask "foo" do
+          version "1.2.3"
+
+          on_macos do
+            sha256 "macos" # Keep this checksum note.
+
+            app "Foo.app"
+          end
+          on_linux do
+          ^^^^^^^^^^^ Don't nest `sha256` stanzas in `on_macos` and `on_linux` blocks
+            sha256 "linux"
+
+            app_image "Foo.AppImage"
+          end
+        end
+      CASK
+
+      expect_no_corrections
+    end
+
+    it "does not detach a comment immediately above a `sha256` stanza" do
+      expect_offense <<~CASK
+        cask "foo" do
+          version "1.2.3"
+
+          on_macos do
+            # Keep this checksum note.
+            sha256 "macos"
+
+            app "Foo.app"
+          end
+          on_linux do
+          ^^^^^^^^^^^ Don't nest `sha256` stanzas in `on_macos` and `on_linux` blocks
+            sha256 "linux"
+
+            app_image "Foo.AppImage"
+          end
+        end
+      CASK
+
+      expect_no_corrections
+    end
+
+    it "does not detach a comment immediately above a removable OS block" do
+      expect_offense <<~CASK
+        cask "foo" do
+          version "1.2.3"
+
+          # macOS ships a universal build.
+          on_macos do
+            sha256 "macos"
+          end
+          on_linux do
+          ^^^^^^^^^^^ Don't nest `sha256` stanzas in `on_macos` and `on_linux` blocks
+            sha256 "linux"
+          end
+        end
+      CASK
+
+      expect_no_corrections
+    end
+
+    it "does not remove a trailing comment on an OS block" do
+      expect_offense <<~CASK
+        cask "foo" do
+          version "1.2.3"
+
+          on_macos do
+            sha256 "macos"
+          end # macOS ships a universal build.
+          on_linux do
+          ^^^^^^^^^^^ Don't nest `sha256` stanzas in `on_macos` and `on_linux` blocks
+            sha256 "linux"
+          end
+        end
+      CASK
+
+      expect_no_corrections
+    end
+
+    it "ignores repeated OS blocks" do
+      expect_no_offenses <<~CASK
+        cask "foo" do
+          version "1.2.3"
+
+          on_macos do
+            sha256 "first"
+          end
+          on_macos do
+            sha256 "second"
+          end
+          on_linux do
+            sha256 "linux"
+          end
+        end
+      CASK
+    end
+  end
+
   context "when auditing identical `version` stanzas inside `on_arch` blocks" do
     it "reports an offense when `version` is identical in both arch blocks but `sha256` differs" do
       expect_offense <<~CASK

--- a/Library/Homebrew/test/rubocops/cask/stanza_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/stanza_order_spec.rb
@@ -303,6 +303,150 @@ RSpec.describe RuboCop::Cop::Cask::StanzaOrder, :config do
     CASK
   end
 
+  it "alphabetizes `depends_on` stanzas" do
+    expect_offense <<~CASK
+      cask "foo" do
+        depends_on macos: :ventura
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ `depends_on` stanza out of order
+        depends_on arch: :arm64
+        ^^^^^^^^^^^^^^^^^^^^^^^ `depends_on` stanza out of order
+      end
+    CASK
+
+    expect_correction <<~CASK
+      cask "foo" do
+        depends_on arch: :arm64
+        depends_on macos: :ventura
+      end
+    CASK
+  end
+
+  it "alphabetizes `depends_on` stanzas with the same key by value" do
+    expect_offense <<~CASK
+      cask "foo" do
+        depends_on formula: "zlib"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ `depends_on` stanza out of order
+        depends_on formula: "foo"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^ `depends_on` stanza out of order
+      end
+    CASK
+
+    expect_correction <<~CASK
+      cask "foo" do
+        depends_on formula: "foo"
+        depends_on formula: "zlib"
+      end
+    CASK
+  end
+
+  it "alphabetizes scalar and array-valued `depends_on` stanzas by value" do
+    expect_offense <<~CASK
+      cask "foo" do
+        depends_on formula: "zebra"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `depends_on` stanza out of order
+        depends_on formula: ["alpha"]
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `depends_on` stanza out of order
+      end
+    CASK
+
+    expect_correction <<~CASK
+      cask "foo" do
+        depends_on formula: ["alpha"]
+        depends_on formula: "zebra"
+      end
+    CASK
+  end
+
+  it "does not sort `depends_on` stanzas that reference local variables" do
+    expect_no_offenses <<~CASK
+      cask "foo" do
+        depends_on macos: :ventura
+        formula_name = "foo"
+        depends_on formula: formula_name
+      end
+    CASK
+  end
+
+  it "alphabetizes `depends_on` stanzas inside an OS block" do
+    expect_offense <<~CASK
+      cask "foo" do
+        on_macos do
+          depends_on macos: :ventura
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^ `depends_on` stanza out of order
+          depends_on arch: :arm64
+          ^^^^^^^^^^^^^^^^^^^^^^^ `depends_on` stanza out of order
+        end
+      end
+    CASK
+
+    expect_correction <<~CASK
+      cask "foo" do
+        on_macos do
+          depends_on arch: :arm64
+          depends_on macos: :ventura
+        end
+      end
+    CASK
+  end
+
+  it "keeps comments with alphabetized `depends_on` stanzas" do
+    expect_offense <<~CASK
+      cask "foo" do
+        # macOS requirement
+        depends_on macos: :ventura
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ `depends_on` stanza out of order
+        # architecture requirement
+        depends_on arch: :arm64
+        ^^^^^^^^^^^^^^^^^^^^^^^ `depends_on` stanza out of order
+      end
+    CASK
+
+    expect_correction <<~CASK
+      cask "foo" do
+        # architecture requirement
+        depends_on arch: :arm64
+        # macOS requirement
+        depends_on macos: :ventura
+      end
+    CASK
+  end
+
+  it "alphabetizes parenthesized `depends_on` stanzas" do
+    expect_offense <<~CASK
+      cask "foo" do
+        depends_on(macos: :ventura)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `depends_on` stanza out of order
+        depends_on(arch: :arm64)
+        ^^^^^^^^^^^^^^^^^^^^^^^^ `depends_on` stanza out of order
+      end
+    CASK
+
+    expect_correction <<~CASK
+      cask "foo" do
+        depends_on(arch: :arm64)
+        depends_on(macos: :ventura)
+      end
+    CASK
+  end
+
+  it "alphabetizes mixed parenthesized and bare `depends_on` stanzas" do
+    expect_offense <<~CASK
+      cask "foo" do
+        depends_on(macos: :ventura)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `depends_on` stanza out of order
+        depends_on formula: "foo"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^ `depends_on` stanza out of order
+      end
+    CASK
+
+    expect_correction <<~CASK
+      cask "foo" do
+        depends_on formula: "foo"
+        depends_on(macos: :ventura)
+      end
+    CASK
+  end
+
   it "keeps associated comments when auto-correcting" do
     expect_offense <<~CASK
       cask 'foo' do

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/on-linux-blocks.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/on-linux-blocks.rb
@@ -2,18 +2,17 @@
 
 cask "on-linux-blocks" do
   version "1.2.3"
+  sha256 arm:          "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94",
+         intel:        "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94",
+         arm64_linux:  "9a1c0967baa46828930ccbbc88668d1b0db07e6edf778800ed4da073c00054f8",
+         x86_64_linux: "244d413861cecb3707cfbcc5c4346d5367daa827da5ea08fb3f3bc2b6276d239"
 
   on_macos do
-    sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
-
     url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
 
     app "Caffeine.app"
   end
   on_linux do
-    sha256 arm64_linux:  "9a1c0967baa46828930ccbbc88668d1b0db07e6edf778800ed4da073c00054f8",
-           x86_64_linux: "244d413861cecb3707cfbcc5c4346d5367daa827da5ea08fb3f3bc2b6276d239"
-
     url "file://#{TEST_FIXTURE_DIR}/cask/caffeine-linux.zip"
 
     app_image "Caffeine.AppImage"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-formula-multiple.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-formula-multiple.rb
@@ -7,8 +7,8 @@ cask "with-depends-on-formula-multiple" do
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
   homepage "https://brew.sh/with-depends-on-formula-multiple"
 
-  depends_on formula: "unar"
   depends_on formula: "fileutils"
+  depends_on formula: "unar"
 
   app "Caffeine.app"
 end

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -41,6 +41,8 @@ The [token reference](#token-reference) describes the current naming rules and e
 
 Having a common order for stanzas makes casks easier to update and parse. Below is the complete stanza sequence (no cask will have all stanzas). The empty lines shown here are also important, as they help to visually delimit information.
 
+When multiple `depends_on` stanzas are present, order them alphabetically by dependency type and then value.
+
     arch
     on_arch_conditional # additional custom-defined substitutions
     os


### PR DESCRIPTION
Two related cask cop improvements.

`Cask/OnSystemConditionals` now hoists `sha256` stanzas out of paired `on_macos` and `on_linux` blocks into a single top-level stanza keyed by architecture, reproducing Homebrew/homebrew-cask#285811. Scalar checksums map to both architectures for that OS, `depends_on arch:` narrows them, identical checksums collapse to one scalar, and blocks left holding nothing else are removed. The rule declines to autocorrect whenever the result would be wrong: adjacent comments, unmappable values, repeated OS blocks, or stanzas that `Cask/StanzaOrder` or `Cask/StanzaGrouping` still need to move. A normal `brew style --fix` run repairs order and grouping first, then hoists the checksums on the next iteration.

`Cask/StanzaOrder` now sorts repeated `depends_on` stanzas alphabetically by dependency type and then value, while leaving every other repeated stanza in source order. `SHA256_ARCH_ORDER` moves into `RuboCop::Cask::Constants` so `Cask/Sha256ArchOrder` and the new rule share one list.

Verified against the whole cask tap read-only: 84 casks get checksum corrections and around 220 get `depends_on` reorderings, all autocorrectable. Loading each cask before and after across macOS and Linux on both architectures shows no checksum, URL, version, artifact or dependency changes, other than checksums dropping on architectures the cask already excludes with `depends_on arch:`. Running the four cask cops together over those casks converges in one pass with no duplicate stanzas, stray blank lines, empty blocks or lost comments.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the change and pass with it, checked the autocorrection against the full cask tap for behavior changes, and ran `brew lgtm --online` plus targeted specs.

-----
