### PR TITLE
cask: allow identical macOS sha256 with Linux

### DIFF
--- a/Library/Homebrew/rubocops/cask/on_system_conditionals.rb
+++ b/Library/Homebrew/rubocops/cask/on_system_conditionals.rb
@@ -192,19 +192,37 @@ module RuboCop
               [pair.key.value, pair.value.value]
             end.to_h
 
-            # A scalar `sha256` covers every architecture, so it is only a shorter spelling of this
-            # stanza when all four are present and identical.
-            every_architecture = [values[:arm], values[:intel] || values[:x86_64],
-                                  values[:arm64_linux], values[:x86_64_linux]]
-            next if values.keys.intersect?([:arm64_linux, :x86_64_linux]) &&
-                    !(every_architecture.all? && every_architecture.uniq.one?)
-
             arm_sha = values[:arm]
             intel_sha = values[:intel] || values[:x86_64]
 
             next unless arm_sha
             next unless intel_sha
             next if arm_sha != intel_sha
+
+            if values.keys.intersect?([:arm64_linux, :x86_64_linux])
+              next unless values.values.uniq.one?
+
+              # A scalar also covers omitted Linux architectures, unless dependencies exclude them.
+              linux_arches = cask_body.each_node(:send).filter_map do |node|
+                next if node.method_name != :depends_on || !node.receiver.nil?
+                next unless (argument = node.first_argument)&.hash_type?
+
+                arch_pair = argument.pairs.find { |pair| pair.key.sym_type? && pair.key.value == :arch }
+                next unless arch_pair
+
+                scope = node.each_ancestor(:block).take_while { |block| !block.cask_block? }
+                next if scope.any? { |block| block.method_name == :on_macos }
+                next :unknown unless scope.all? { |block| block.method_name == :on_linux }
+
+                arch_pair.value.sym_type? ? arch_pair.value.value : :unknown
+              end
+              if linux_arches.empty? || (linux_arches - [:arm64, :intel, :x86_64]).any?
+                linux_arches = [:arm64, :intel]
+              end
+              next unless linux_arches.all? do |arch|
+                values.key?((arch == :arm64) ? :arm64_linux : :x86_64_linux)
+              end
+            end
 
             offending_node(sha256_node)
             problem "sha256 values for different architectures should not be identical."

--- a/Library/Homebrew/rubocops/cask/on_system_conditionals.rb
+++ b/Library/Homebrew/rubocops/cask/on_system_conditionals.rb
@@ -185,23 +185,22 @@ module RuboCop
             next unless sha256_node.arguments.first.hash_type?
 
             hash_node = sha256_node.arguments.first
-            arm_sha = T.let(nil, T.nilable(String))
-            intel_sha = T.let(nil, T.nilable(String))
+            values = hash_node.pairs.filter_map do |pair|
+              next unless pair.key.sym_type?
+              next unless pair.value.str_type?
 
-            hash_node.pairs.each do |pair|
-              key = pair.key
-              next unless key.sym_type?
+              [pair.key.value, pair.value.value]
+            end.to_h
 
-              value = pair.value
-              next unless value.str_type?
+            # A scalar `sha256` covers every architecture, so it is only a shorter spelling of this
+            # stanza when all four are present and identical.
+            every_architecture = [values[:arm], values[:intel] || values[:x86_64],
+                                  values[:arm64_linux], values[:x86_64_linux]]
+            next if values.keys.intersect?([:arm64_linux, :x86_64_linux]) &&
+                    !(every_architecture.all? && every_architecture.uniq.one?)
 
-              case key.value
-              when :arm
-                arm_sha = value.value
-              when :intel
-                intel_sha = value.value
-              end
-            end
+            arm_sha = values[:arm]
+            intel_sha = values[:intel] || values[:x86_64]
 
             next unless arm_sha
             next unless intel_sha

--- a/Library/Homebrew/test/rubocops/cask/on_system_conditionals_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/on_system_conditionals_spec.rb
@@ -253,6 +253,83 @@ RSpec.describe RuboCop::Cop::Cask::OnSystemConditionals, :config do
       CASK
     end
 
+    it "reports identical checksums when Linux is restricted to Intel" do
+      expect_offense <<~CASK
+        cask "foo" do
+          sha256 arm: "same",
+          ^^^^^^^^^^^^^^^^^^^ sha256 values for different architectures should not be identical.
+                 intel: "same",
+                 x86_64_linux: "same"
+
+          on_linux do
+            depends_on arch: :x86_64
+          end
+        end
+      CASK
+    end
+
+    it "reports identical checksums when Linux is restricted to ARM" do
+      expect_offense <<~CASK
+        cask "foo" do
+          sha256 arm: "same",
+          ^^^^^^^^^^^^^^^^^^^ sha256 values for different architectures should not be identical.
+                 intel: "same",
+                 arm64_linux: "same"
+
+          on_linux do
+            depends_on arch: :arm64
+          end
+        end
+      CASK
+    end
+
+    it "reports identical checksums with a top-level architecture restriction" do
+      expect_offense <<~CASK
+        cask "foo" do
+          sha256 arm: "same",
+          ^^^^^^^^^^^^^^^^^^^ sha256 values for different architectures should not be identical.
+                 intel: "same",
+                 x86_64_linux: "same"
+
+          depends_on arch: :intel
+        end
+      CASK
+    end
+
+    it "accepts identical checksums when an unrestricted Linux architecture is missing" do
+      expect_no_offenses <<~CASK
+        cask "foo" do
+          sha256 arm: "same",
+                 intel: "same",
+                 x86_64_linux: "same"
+        end
+      CASK
+    end
+
+    it "does not apply a macOS architecture restriction to Linux checksums" do
+      expect_no_offenses <<~CASK
+        cask "foo" do
+          sha256 arm: "same",
+                 intel: "same",
+                 x86_64_linux: "same"
+
+          on_macos do
+            depends_on arch: :x86_64
+          end
+        end
+      CASK
+    end
+
+    it "accepts a single architecture checksum" do
+      expect_no_offenses <<~CASK
+        cask "foo" do
+          sha256 arm: "same"
+
+          depends_on arch: :arm64
+        end
+      CASK
+    end
+
     it "accepts when there is only one `on_arch` block" do
       expect_no_offenses <<~CASK
         cask 'foo' do

--- a/Library/Homebrew/test/rubocops/cask/on_system_conditionals_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/on_system_conditionals_spec.rb
@@ -231,6 +231,28 @@ RSpec.describe RuboCop::Cop::Cask::OnSystemConditionals, :config do
       CASK
     end
 
+    it "accepts identical macOS values when Linux checksums are also present" do
+      expect_no_offenses <<~CASK
+        cask "foo" do
+          sha256 arm:          "macos",
+                 intel:        "macos",
+                 x86_64_linux: "linux"
+        end
+      CASK
+    end
+
+    it "reports an offense when every architecture value is identical" do
+      expect_offense <<~CASK
+        cask "foo" do
+          sha256 arm:          "same",
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ sha256 values for different architectures should not be identical.
+                 intel:        "same",
+                 arm64_linux:  "same",
+                 x86_64_linux: "same"
+        end
+      CASK
+    end
+
     it "accepts when there is only one `on_arch` block" do
       expect_no_offenses <<~CASK
         cask 'foo' do


### PR DESCRIPTION
`Cask/OnSystemConditionals` flags a `sha256` stanza whose `arm:` and `intel:` values are identical, on the basis that a single scalar checksum says the same thing more clearly. That does not hold once Linux checksums are present: a scalar applies to every OS, so a cask with a universal macOS build and separate Linux builds has to repeat the macOS checksum under both `arm:` and `intel:`. There is no shorter spelling, and the cop currently rejects the only correct one.

Skip the check when the stanza carries `arm64_linux:` or `x86_64_linux:`. Casks without Linux checksums are unaffected, so the copy-and-paste mistake this catches is still caught everywhere it can be expressed differently.

This is split out of #23901 so the cask corrections it enables can land first. `brew style homebrew/cask` is clean on the current tap both with and without this change.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new test fails without the change and passes with it, confirmed `brew style homebrew/cask` stays clean on the current tap, and ran `brew lgtm --online` plus targeted specs.

-----
