### PR TITLE
advisory-match: protect reviewed ranges

### DIFF
--- a/Library/Homebrew/dev-cmd/advisory-match.rb
+++ b/Library/Homebrew/dev-cmd/advisory-match.rb
@@ -42,8 +42,8 @@ module Homebrew
                             "boundary; use the current `pkg_version` instead."
         switch "--new-history",
                depends_on:  "--output=",
-               description: "Walk `FormulaVersions` only for records whose " \
-                            "reviewed ranges are not already in <directory>."
+               description: "Skip `FormulaVersions` for existing terminal ranges " \
+                            "unless their matching provenance changes."
         conflicts "--all", "--index"
         conflicts "--all", "--json"
         conflicts "--index", "--json"
@@ -61,8 +61,9 @@ module Homebrew
         Homebrew::API.with_no_api_env do
           latest_macos = MacOSVersion.new((HOMEBREW_MACOS_NEWEST_UNSUPPORTED.to_i - 1).to_s).to_sym
           Homebrew::SimulateSystem.with(os: latest_macos, arch: :arm) do
+            overrides = local_overrides
             matcher = Homebrew::Vulns::Match.new(repology:  local_repology,
-                                                 overrides: local_overrides,
+                                                 overrides:,
                                                  bulk:      args.all? || args.index?)
             next emit_index(matcher) if args.index?
 
@@ -91,9 +92,16 @@ module Homebrew
                   record_id = matcher.record_id(formula, hit)
                   next if emitter.alias_protected?(record_id)
 
+                  candidate = matcher.to_brew_record(formula, hit)
+                  basis_changed = emitter.range_basis_changed?(candidate)
+                  if basis_changed && (args.no_history? || !status&.fixed?)
+                    emitter.emit(candidate)
+                    next
+                  end
+
                   reviewed_state = emitter.reviewed_range_state(record_id)
-                  has_open_range = [:open, :mixed].include?(reviewed_state)
-                  has_terminal_range = [:terminal, :mixed].include?(reviewed_state)
+                  has_open_range = reviewed_state == :open
+                  has_terminal_range = reviewed_state == :terminal
                   transition = (status&.fixed? && has_open_range) ||
                                (status&.affected? && has_terminal_range)
                   if args.no_history? && transition
@@ -102,7 +110,7 @@ module Homebrew
                   end
 
                   walk_history = !args.no_history? && status&.fixed?
-                  walk_history &&= emitter.history_required?(record_id) if args.new_history?
+                  walk_history &&= basis_changed || emitter.history_required?(record_id) if args.new_history?
                   emitter.record_history_walk if walk_history
                   first_fixed = matcher.first_fixed_version(formula, hit) if walk_history
                   fixed_boundary = T.let(nil, T.nilable(String))
@@ -144,8 +152,13 @@ module Homebrew
                     first_reintroduced = reintroduced
                   end
 
-                  emitter << matcher.to_brew_record(formula, hit, first_fixed:        fixed_boundary,
-                                                                  first_reintroduced:)
+                  candidate = matcher.to_brew_record(formula, hit, first_fixed: fixed_boundary, first_reintroduced:)
+                  # A metadata override does not replace the upstream constraints
+                  # used by the history walk. Correct its reviewed ranges and
+                  # provenance together instead of automatically certifying them.
+                  override = overrides&.advisory_override(formula.name, hit.identifiers)
+                  revalidated = !fixed_boundary.nil? && !override&.fixed_in_overridden
+                  emitter.emit(candidate, revalidated:)
                 end
               end
             rescue Homebrew::Vulns::OSV::Error => e
@@ -232,6 +245,9 @@ module Homebrew
         sig { params(_record_id: String).returns(T::Boolean) }
         def alias_protected?(_record_id) = false
 
+        sig { params(_record: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
+        def range_basis_changed?(_record) = false
+
         sig { params(_record_id: String).returns(T::Boolean) }
         def history_required?(_record_id) = true
 
@@ -250,8 +266,8 @@ module Homebrew
         sig { params(_record_id: String, _boundary: String).returns(T::Boolean) }
         def reintroduction_boundary_valid?(_record_id, _boundary) = true
 
-        sig { params(record: T::Hash[Symbol, T.untyped]).void }
-        def <<(record); end
+        sig { params(record: T::Hash[Symbol, T.untyped], revalidated: T::Boolean).void }
+        def emit(record, revalidated: false); end
 
         sig { void }
         def finish; end
@@ -268,6 +284,7 @@ module Homebrew
           @written = T.let(0, Integer)
           @unchanged = T.let(0, Integer)
           @skipped_generated = T.let(0, Integer)
+          @basis_changed = T.let(0, Integer)
           @history_walks = T.let(0, Integer)
           @history_unavailable_by_formula = T.let({}, T::Hash[String, Integer])
           @alias_targets = T.let({}, T::Hash[String, T::Array[String]])
@@ -309,6 +326,7 @@ module Homebrew
             end
 
             writable = T.let([], T::Array[String])
+            generated = T.let([], T::Array[String])
             paths.each do |path|
               existing = alias_record(path)
               if existing == :malformed
@@ -324,10 +342,18 @@ module Homebrew
                 next
               end
 
+              affected = existing["affected"]
+              names = affected_formula_names(existing)
+              if !affected.is_a?(Array) || !affected.one? || names != [formula_name]
+                errors << "#{canonical_id}: #{path} has unsupported affected entries for " \
+                          "#{formula_name}; leaving family unchanged"
+                next
+              end
+
               database_specific = existing["database_specific"]
               source = database_specific["source"] if database_specific.is_a?(Hash)
               if source == "generated"
-                generated_paths << path
+                generated << path
                 next
               end
               if source != "matched"
@@ -336,21 +362,27 @@ module Homebrew
                 next
               end
 
-              affected = existing["affected"]
-              names = affected_formula_names(existing)
-              if !affected.is_a?(Array) || !affected.one? || names != [formula_name]
-                errors << "#{canonical_id}: #{path} has unsupported affected entries for " \
-                          "#{formula_name}; leaving family unchanged"
-                next
-              end
               writable << path
             end
 
+            if generated.any?
+              targets[canonical_id] = []
+              protected[canonical_id] = true
+              generated_paths.concat(generated)
+              next
+            end
+            if writable.length > 1
+              errors << "#{canonical_id}: multiple alias records found; consolidate the family before matching"
+              next
+            end
+
             canonical_path = record_path(canonical_id)
-            writable << canonical_path unless File.file?(canonical_path)
-            writable.uniq!
-            targets[canonical_id] = writable
-            protected[canonical_id] = writable.empty?
+            targets[canonical_id] = if writable.one?
+              writable
+            else
+              [canonical_path]
+            end
+            protected[canonical_id] = false
           end
           return errors.uniq if errors.any?
 
@@ -365,14 +397,47 @@ module Homebrew
           @protected_aliases.fetch(record_id, false)
         end
 
-        sig { override.params(record: T::Hash[Symbol, T.untyped]).void }
-        def <<(record)
-          updates = alias_target_paths(record.fetch(:id)).map do |path|
+        sig { override.params(record: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
+        def range_basis_changed?(record)
+          alias_target_paths(record.fetch(:id)).any? do |path|
+            next false unless File.file?(path)
+
+            existing = alias_record(path)
+            existing.is_a?(Hash) && range_basis(existing) != range_basis(record)
+          end
+        end
+
+        sig { override.params(record: T::Hash[Symbol, T.untyped], revalidated: T::Boolean).void }
+        def emit(record, revalidated: false)
+          updates = alias_target_paths(record.fetch(:id)).filter_map do |path|
             candidate = record.deep_dup
             existing = alias_record(path) if File.file?(path)
             if existing.is_a?(Hash)
               candidate[:id] = existing.fetch("id")
               candidate[:upstream] = (Array(existing["upstream"]) + Array(candidate[:upstream])).uniq
+              existing_basis = range_basis(existing)
+              candidate_basis = range_basis(candidate)
+              if existing_basis != candidate_basis
+                ranges = JSON.parse(JSON.generate(candidate)).dig("affected", 0, "ranges")
+                existing_ranges = existing.dig("affected", 0, "ranges")
+                no_reviewed_ranges = Array(existing_ranges).none? do |range|
+                  Homebrew::Vulns::OsvExport.ranges_open?([range]) ||
+                    Homebrew::Vulns::OsvExport.ranges_terminal?([range])
+                end
+                compatible = ranges == existing_ranges || (@close_open_ranges && no_reviewed_ranges)
+                if !compatible || (!revalidated && !Homebrew::Vulns::OsvExport.ranges_open?(ranges))
+                  fields = (existing_basis.keys | candidate_basis.keys).reject do |key|
+                    existing_basis[key] == candidate_basis[key]
+                  end
+                  Utils::Output.onoe "#{candidate[:id]}: reviewed range basis changed (#{fields.join(", ")}); " \
+                                     "leaving it unchanged.\n" \
+                                     "Run advisory-match for this formula with --json and history enabled,\n" \
+                                     "then review and update its ranges and provenance together."
+                  @basis_changed += 1
+                  Homebrew.failed = true
+                  next
+                end
+              end
             elsif File.file?(path)
               candidate[:id] = File.basename(path, ".json")
             end
@@ -391,6 +456,61 @@ module Homebrew
             puts "  wrote #{path}" if @verbose
             @written += 1
           end
+        end
+
+        # Keep every strategy and runtime subject. Ignore version values and
+        # resource labels, but retain checkability and separate copies of the
+        # same resource package: either can change the aggregate history.
+        sig { params(record: T::Hash[T.untyped, T.untyped]).returns(T::Hash[String, T.untyped]) }
+        def range_basis(record)
+          record = JSON.parse(JSON.generate(record))
+          affected = record["affected"]
+          return {} unless affected.is_a?(Array)
+          return {} unless affected.one?
+
+          entry = affected.fetch(0)
+          return {} unless entry.is_a?(Hash)
+
+          ecosystem_specific = entry["ecosystem_specific"]
+          ecosystem_specific = {} unless ecosystem_specific.is_a?(Hash)
+
+          database_specific = record["database_specific"]
+          evidence = Array(database_specific["upstream_evidence"]) if database_specific.is_a?(Hash)
+          evidence = Array(evidence).grep(Hash)
+          subjects = evidence.group_by { |row| row["resource"] }.map do |resource, rows|
+            identities = rows.filter_map do |row|
+              identity = subject_identity(row)
+              next if identity.empty?
+
+              [row["strategy"].to_s, identity, row["subject_version"].nil? ? "unknown" : "versioned"]
+            end
+            [resource ? "resource" : "primary", identities.uniq.sort]
+          end
+          basis = { "subjects" => subjects.sort }
+          resource_purl = ecosystem_specific["resource_purl"]
+          if resource_purl.is_a?(String)
+            resource = evidence.find { |row| row["resource"] && row["key"] == resource_purl }
+            basis["resource_purl"] = resource ? subject_identity(resource) : [unversioned_key(resource_purl)]
+          end
+          upstream_fixed_in = ecosystem_specific["upstream_fixed_in"]
+          basis["upstream_fixed_in"] = upstream_fixed_in if upstream_fixed_in.is_a?(String)
+          basis
+        end
+
+        sig { params(evidence: T::Hash[String, T.untyped]).returns(T::Array[String]) }
+        def subject_identity(evidence)
+          ecosystem = evidence["ecosystem"]
+          name = evidence["name"]
+          return [ecosystem, name] if ecosystem.is_a?(String) && name.is_a?(String)
+
+          key = evidence["key"]
+          key.is_a?(String) ? [unversioned_key(key)] : []
+        end
+
+        sig { params(key: String).returns(String) }
+        def unversioned_key(key)
+          key = key.delete_prefix("upstream:")
+          key.start_with?("pkg:") ? key.sub(%r{@[^/@]*\z}, "") : key
         end
 
         sig { override.params(record_id: String).returns(T::Boolean) }
@@ -439,10 +559,7 @@ module Homebrew
           states = states_by_path.flatten
           return if states.empty?
 
-          unique = states.uniq
-          return :mixed if unique.include?(:open) && unique.include?(:terminal)
-
-          unique.fetch(0)
+          states.fetch(0)
         end
 
         sig { override.params(record_id: String, boundary: String).returns(T::Boolean) }
@@ -588,7 +705,8 @@ module Homebrew
           history_unavailable = @history_unavailable_by_formula.values.sum
           Utils::Output.ohai "#{@written} records written to #{@dir} " \
                              "(#{@unchanged} unchanged, #{@skipped_generated} generated left as-is, " \
-                             "#{@history_walks} history walks, #{history_unavailable} history-unavailable skips)"
+                             "#{@history_walks} history walks, #{history_unavailable} history-unavailable skips, " \
+                             "#{@basis_changed} range-basis skips)"
           return if @history_unavailable_by_formula.empty?
 
           puts "  Unavailable history by formula:"
@@ -603,8 +721,8 @@ module Homebrew
           @records = T.let([], T::Array[T::Hash[Symbol, T.untyped]])
         end
 
-        sig { override.params(record: T::Hash[Symbol, T.untyped]).void }
-        def <<(record)
+        sig { override.params(record: T::Hash[Symbol, T.untyped], revalidated: T::Boolean).void }
+        def emit(record, revalidated: false)
           @records << record
         end
 
@@ -621,8 +739,8 @@ module Homebrew
           @count = T.let(0, Integer)
         end
 
-        sig { override.params(_record: T::Hash[Symbol, T.untyped]).void }
-        def <<(_record)
+        sig { override.params(_record: T::Hash[Symbol, T.untyped], revalidated: T::Boolean).void }
+        def emit(_record, revalidated: false)
           @count += 1
         end
 

--- a/Library/Homebrew/test/dev-cmd/advisory-match_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/advisory-match_spec.rb
@@ -12,6 +12,15 @@ RSpec.describe Homebrew::DevCmd::AdvisoryMatch do
       head "https://github.com/psf/requests.git"
     end
   end
+  let(:reviewed_git_evidence) do
+    [{
+      "strategy"        => "git",
+      "ecosystem"       => "GIT",
+      "name"            => "https://github.com/psf/requests",
+      "key"             => "https://github.com/psf/requests",
+      "subject_version" => "2.31.0",
+    }]
+  end
 
   before do
     allow(Formulary).to receive(:enable_factory_cache!)
@@ -44,62 +53,65 @@ RSpec.describe Homebrew::DevCmd::AdvisoryMatch do
     )
   end
 
-  it "synchronizes an existing matched alias while preserving its identity and reviewed history" do
+  it "updates one existing matched alias without creating a canonical duplicate" do
     stub_osv_hit("GHSA-old", aliases: ["CVE-2024-1234"], fixed: "2.28.1")
 
     Dir.mktmpdir do |dir|
       alias_path = File.join(dir, "BREW-requests-GHSA-old.json")
-      legacy_path = File.join(dir, "BREW-requests-PYSEC-old.json")
       File.write(alias_path, JSON.generate({
         "id"                => "BREW-requests-GHSA-old",
-        "published"         => "2025-01-01T00:00:00Z",
         "summary"           => "stale",
         "upstream"          => ["GHSA-old"],
         "affected"          => [{
-          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
-          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [
+          "package"            => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"             => [{ "type" => "ECOSYSTEM", "events" => [
             { "introduced" => "0" }, { "fixed" => "2.28.1" }
           ] }],
+          "ecosystem_specific" => { "upstream_fixed_in" => "2.28.1" },
         }],
-        "database_specific" => { "source" => "matched" },
-      }))
-      File.write(legacy_path, JSON.generate({
-        "id"                => "BREW-requests-PYSEC-old",
-        "published"         => "2024-01-01T00:00:00Z",
-        "summary"           => "older",
-        "upstream"          => ["PYSEC-old", "GHSA-old"],
-        "affected"          => [{
-          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
-          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [
-            { "introduced" => "0" }, { "fixed" => "2.27.0" }
-          ] }],
-        }],
-        "database_specific" => { "source" => "matched" },
+        "database_specific" => {
+          "source"            => "matched",
+          "upstream_evidence" => reviewed_git_evidence,
+        },
       }))
 
       cmd_for("requests", "--output", dir, "--no-history").run
 
+      files = Dir.glob(File.join(dir, "*.json"))
       refreshed = JSON.parse(File.read(alias_path))
-      expect(refreshed.values_at("id", "published", "summary", "upstream")).to eq([
-        "BREW-requests-GHSA-old",
-        "2025-01-01T00:00:00Z",
-        "s",
-        ["GHSA-old", "CVE-2024-1234"],
-      ])
-      expect(refreshed.dig("affected", 0, "ranges", 0, "events")).to eq([
-        { "introduced" => "0" }, { "fixed" => "2.28.1" }
-      ])
-      legacy = JSON.parse(File.read(legacy_path))
-      expect(legacy.values_at("id", "published", "summary", "upstream")).to eq([
-        "BREW-requests-PYSEC-old",
-        "2024-01-01T00:00:00Z",
-        "s",
-        ["PYSEC-old", "GHSA-old", "CVE-2024-1234"],
-      ])
-      expect(legacy.dig("affected", 0, "ranges", 0, "events")).to eq([
-        { "introduced" => "0" }, { "fixed" => "2.27.0" }
-      ])
-      expect(File).to exist(File.join(dir, "BREW-requests-CVE-2024-1234.json"))
+      expect([files, refreshed.values_at("id", "summary", "upstream")]).to eq [
+        [alias_path],
+        ["BREW-requests-GHSA-old", "s", ["GHSA-old", "CVE-2024-1234"]],
+      ]
+    end
+  end
+
+  it "fails closed when an alias family already has multiple matched records" do
+    stub_osv_hit("GHSA-old", aliases: ["CVE-2024-1234"], fixed: "2.28.1")
+
+    Dir.mktmpdir do |dir|
+      originals = ["GHSA-old", "PYSEC-old"].to_h do |id|
+        path = File.join(dir, "BREW-requests-#{id}.json")
+        record = {
+          "id"                => "BREW-requests-#{id}",
+          "summary"           => id,
+          "upstream"          => [id, "GHSA-old"],
+          "affected"          => [{
+            "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
+            "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [
+              { "introduced" => "0" }, { "fixed" => "2.28.1" }
+            ] }],
+          }],
+          "database_specific" => { "source" => "matched" },
+        }
+        File.write(path, JSON.generate(record))
+        [path, record]
+      end
+
+      expect { cmd_for("requests", "--output", dir, "--no-history").run }
+        .to output(/multiple alias records/).to_stderr
+      actual = originals.to_h { |path, _| [path, JSON.parse(File.read(path))] }
+      expect([actual, Homebrew.failed?]).to eq [originals, true]
     end
   end
 
@@ -115,12 +127,16 @@ RSpec.describe Homebrew::DevCmd::AdvisoryMatch do
         "id"                => "BREW-requests-GHSA-old",
         "upstream"          => ["GHSA-old"],
         "affected"          => [{
-          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
-          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [
+          "package"            => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"             => [{ "type" => "ECOSYSTEM", "events" => [
             { "introduced" => "0" }, { "fixed" => "2.30.0" }
           ] }],
+          "ecosystem_specific" => { "upstream_fixed_in" => "2.32.0" },
         }],
-        "database_specific" => { "source" => "matched" },
+        "database_specific" => {
+          "source"            => "matched",
+          "upstream_evidence" => reviewed_git_evidence,
+        },
       }))
 
       expect { cmd_for("requests", "--output", dir, "--new-history").run }
@@ -131,7 +147,7 @@ RSpec.describe Homebrew::DevCmd::AdvisoryMatch do
     end
   end
 
-  it "protects a generated alias while still emitting the canonical matched record" do
+  it "protects a generated alias without emitting a matched duplicate" do
     stub_osv_hit("GHSA-old", aliases: ["CVE-2024-1234"], fixed: "2.28.1")
 
     Dir.mktmpdir do |dir|
@@ -149,178 +165,10 @@ RSpec.describe Homebrew::DevCmd::AdvisoryMatch do
 
       expect { cmd_for("requests", "--output", dir, "--no-history").run }
         .to output(/1 generated left as-is/).to_stdout
-      expect(JSON.parse(File.read(generated_path))).to eq generated
-      expect(File).to exist(File.join(dir, "BREW-requests-CVE-2024-1234.json"))
-    end
-  end
-
-  it "leaves every alias unchanged with --no-history when one needs a transition" do
-    stub_osv_hit("GHSA-old", aliases: ["CVE-2024-1234"], fixed: "2.28.1")
-
-    Dir.mktmpdir do |dir|
-      canonical_path = File.join(dir, "BREW-requests-CVE-2024-1234.json")
-      alias_path = File.join(dir, "BREW-requests-GHSA-old.json")
-      canonical = {
-        "id"                => "BREW-requests-CVE-2024-1234",
-        "upstream"          => ["CVE-2024-1234", "GHSA-old"],
-        "affected"          => [{
-          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
-          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [
-            { "introduced" => "0" }, { "fixed" => "2.28.1" }
-          ] }],
-        }],
-        "database_specific" => { "source" => "matched" },
-      }
-      alias_record = {
-        "id"                => "BREW-requests-GHSA-old",
-        "upstream"          => ["GHSA-old", "CVE-2024-1234"],
-        "affected"          => [{
-          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
-          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [{ "introduced" => "1.0" }] }],
-        }],
-        "database_specific" => { "source" => "matched" },
-      }
-      File.write(canonical_path, JSON.generate(canonical))
-      File.write(alias_path, JSON.generate(alias_record))
-
-      cmd_for("requests", "--output", dir, "--no-history").run
-
-      expect(JSON.parse(File.read(canonical_path))).to eq canonical
-      expect(JSON.parse(File.read(alias_path))).to eq alias_record
-    end
-  end
-
-  it "closes an open alias without changing a terminal alias in the same family" do
-    stub_osv_hit("GHSA-old", aliases: ["CVE-2024-1234"], fixed: "2.28.1")
-    matcher = Homebrew::Vulns::Match.new
-    expect(matcher).to receive(:first_fixed_version).and_return("2.28.1")
-    allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
-
-    Dir.mktmpdir do |dir|
-      canonical_path = File.join(dir, "BREW-requests-CVE-2024-1234.json")
-      alias_path = File.join(dir, "BREW-requests-GHSA-old.json")
-      common = {
-        "affected"          => [{
-          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
-        }],
-        "database_specific" => { "source" => "matched" },
-      }
-      File.write(canonical_path, JSON.generate(common.merge(
-                                                 "id"       => "BREW-requests-CVE-2024-1234",
-                                                 "upstream" => ["CVE-2024-1234", "GHSA-old"],
-                                                 "affected" => [{
-                                                   "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
-                                                   "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [
-                                                     { "introduced" => "0" }, { "fixed" => "2.27.0" }
-                                                   ] }],
-                                                 }],
-                                               )))
-      File.write(alias_path, JSON.generate(common.merge(
-                                             "id"       => "BREW-requests-GHSA-old",
-                                             "upstream" => ["GHSA-old", "CVE-2024-1234"],
-                                             "affected" => [{
-                                               "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
-                                               "ranges"  => [{ "type"   => "ECOSYSTEM",
-                                                               "events" => [{ "introduced" => "2.27.1" }] }],
-                                             }],
-                                           )))
-
-      expect { cmd_for("requests", "--output", dir, "--new-history").run }
-        .to output(/1 history walks/).to_stdout
-      expect(JSON.parse(File.read(canonical_path)).dig("affected", 0, "ranges", 0, "events")).to eq([
-        { "introduced" => "0" }, { "fixed" => "2.27.0" }
-      ])
-      expect(JSON.parse(File.read(alias_path)).dig("affected", 0, "ranges", 0, "events")).to eq([
-        { "introduced" => "2.27.1" }, { "fixed" => "2.28.1" }
-      ])
-    end
-  end
-
-  it "leaves an alias family unchanged when fixed does not follow every open range" do
-    stub_osv_hit("GHSA-old", aliases: ["CVE-2024-1234"], fixed: "2.28.1")
-    matcher = Homebrew::Vulns::Match.new
-    expect(matcher).to receive(:first_fixed_version).and_return("2.28.1")
-    allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
-
-    Dir.mktmpdir do |dir|
-      canonical_path = File.join(dir, "BREW-requests-CVE-2024-1234.json")
-      alias_path = File.join(dir, "BREW-requests-GHSA-old.json")
-      canonical = {
-        "id"                => "BREW-requests-CVE-2024-1234",
-        "upstream"          => ["CVE-2024-1234", "GHSA-old"],
-        "affected"          => [{
-          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
-          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [{ "introduced" => "2.27.0" }] }],
-        }],
-        "database_specific" => { "source" => "matched" },
-      }
-      alias_record = {
-        "id"                => "BREW-requests-GHSA-old",
-        "upstream"          => ["GHSA-old", "CVE-2024-1234"],
-        "affected"          => [{
-          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
-          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [{ "introduced" => "2.29.0" }] }],
-        }],
-        "database_specific" => { "source" => "matched" },
-      }
-      File.write(canonical_path, JSON.generate(canonical))
-      File.write(alias_path, JSON.generate(alias_record))
-
-      expect { cmd_for("requests", "--output", dir, "--new-history").run }
-        .to output(/fixed 2\.28\.1 does not follow its reviewed range/).to_stderr
       expect([
-        JSON.parse(File.read(canonical_path)),
-        JSON.parse(File.read(alias_path)),
-        Homebrew.failed?,
-      ]).to eq [canonical, alias_record, true]
-    end
-  end
-
-  it "refreshes an open alias while reopening terminal siblings" do
-    stub_osv_hit("GHSA-old", aliases: ["CVE-2024-1234"], fixed: "2.32.0")
-    matcher = Homebrew::Vulns::Match.new
-    expect(matcher).to receive(:first_reintroduced_version).and_return("2.31.0")
-    allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
-
-    Dir.mktmpdir do |dir|
-      canonical_path = File.join(dir, "BREW-requests-CVE-2024-1234.json")
-      alias_path = File.join(dir, "BREW-requests-GHSA-old.json")
-      File.write(canonical_path, JSON.generate({
-        "id"                => "BREW-requests-CVE-2024-1234",
-        "summary"           => "stale",
-        "upstream"          => ["CVE-2024-1234", "GHSA-old"],
-        "affected"          => [{
-          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
-          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [
-            { "introduced" => "0" }, { "fixed" => "2.30.0" }
-          ] }],
-        }],
-        "database_specific" => { "source" => "matched" },
-      }))
-      File.write(alias_path, JSON.generate({
-        "id"                => "BREW-requests-GHSA-old",
-        "summary"           => "stale",
-        "upstream"          => ["GHSA-old"],
-        "affected"          => [{
-          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
-          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [{ "introduced" => "2.31.0" }] }],
-        }],
-        "database_specific" => { "source" => "matched" },
-      }))
-
-      cmd_for("requests", "--output", dir, "--new-history").run
-
-      canonical = JSON.parse(File.read(canonical_path))
-      alias_record = JSON.parse(File.read(alias_path))
-      expect([
-        canonical.dig("affected", 0, "ranges", 0, "events"),
-        alias_record.values_at("summary", "upstream"),
-        alias_record.dig("affected", 0, "ranges", 0, "events"),
-      ]).to eq [
-        [{ "introduced" => "0" }, { "fixed" => "2.30.0" }, { "introduced" => "2.31.0" }],
-        ["s", ["GHSA-old", "CVE-2024-1234"]],
-        [{ "introduced" => "2.31.0" }],
-      ]
+        JSON.parse(File.read(generated_path)),
+        File.exist?(File.join(dir, "BREW-requests-CVE-2024-1234.json")),
+      ]).to eq [generated, false]
     end
   end
 
@@ -477,7 +325,452 @@ RSpec.describe Homebrew::DevCmd::AdvisoryMatch do
     end
   end
 
-  it "only walks history for records not already present with --new-history" do
+  describe "range basis identities" do
+    let(:dir) { Dir.mktmpdir }
+    let(:emitter) { Homebrew::DevCmd::AdvisoryMatch::DirEmitter.new(dir, verbose: false, close_open_ranges: true) }
+
+    after { FileUtils.remove_entry(dir) }
+
+    def basis_for(evidence, ecosystem_specific = {})
+      emitter.range_basis({
+        affected:          [{ ecosystem_specific: }],
+        database_specific: { upstream_evidence: evidence },
+      })
+    end
+
+    it "detects distro, CPANSA, Git, scoped package and checkability drift alongside registry evidence" do
+      cases = [
+        [{ strategy: :distro, key: "Debian:13/foo" }, { strategy: :distro, key: "Ubuntu:24.04/bar" }],
+        [{ strategy: :cpansa, key: "pkg:cpan/Foo@1" }, { strategy: :cpansa, key: "pkg:cpan/Bar@1" }],
+        [{ strategy: :git, key: "https://github.com/o/old" },
+         { strategy: :git, key: "https://github.com/o/new" }],
+        [{ strategy: :registry, key: "pkg:npm/@scope-a/name@1" },
+         { strategy: :registry, key: "pkg:npm/@scope-b/other@1" }],
+        [{ strategy: :registry, key: "pkg:pypi/x@1", subject_version: nil },
+         { strategy: :registry, key: "pkg:pypi/x@1", subject_version: "1" }],
+      ]
+      outcomes = cases.map do |before, after|
+        primary = { strategy: :registry, key: "pkg:pypi/primary@1" }
+
+        basis_for([primary, before]) != basis_for([primary, after])
+      end
+      expect(outcomes).to eq [true, true, true, true, true]
+    end
+
+    it "detects removal of a secondary resource even when the deciding resource is unchanged" do
+      deciding = { strategy: :registry, key: "pkg:pypi/x@1", resource: "first" }
+      secondary = { strategy: :registry, key: "pkg:pypi/y@1", resource: "second" }
+      eco = { resource_purl: "pkg:pypi/x@1" }
+
+      expect(basis_for([deciding, secondary], eco)).not_to eq basis_for([deciding], eco)
+    end
+
+    it "retains the multiplicity of separate resources shipping the same package" do
+      first = { strategy: :registry, key: "pkg:pypi/x@1", resource: "first" }
+      second = { strategy: :registry, key: "pkg:pypi/x@2", resource: "second" }
+
+      expect(basis_for([first, second])).not_to eq basis_for([first])
+    end
+
+    it "ignores evidence order, duplicate provenance, resource labels and package versions" do
+      first = { strategy: :registry, key: "upstream:pkg:pypi/x@1", subject_version: "1" }
+      second = { strategy: :cpansa, key: "pkg:cpan/Foo@1", subject_version: "1", resource: "old" }
+
+      expect(basis_for([first, second, first])).to eq basis_for([
+        second.merge(key: "pkg:cpan/Foo@2", subject_version: "2", resource: "new"),
+        first.merge(key: "upstream:pkg:pypi/x@2", subject_version: "2"),
+      ])
+    end
+
+    it "detects removal of an upstream fixed threshold" do
+      expect(basis_for([], { upstream_fixed_in: "1" })).not_to eq basis_for([])
+    end
+
+    it "uses runtime identities across CPAN author transfers and equivalent PyPI spellings" do
+      identities = [
+        ["cpansa", "CPAN", "Foo", "pkg:cpan/ABCD/Foo@1.0", "pkg:cpan/EFGH/Foo@1.1"],
+        ["registry", "PyPI", "foo-bar", "pkg:pypi/foo.bar@1.0", "pkg:pypi/foo-bar@1.1"],
+      ]
+      outcomes = identities.map do |strategy, ecosystem, name, previous_key, current_key|
+        row = { strategy:, ecosystem:, name:, resource: "dependency", subject_version: "1.0" }
+        basis_for([row.merge(key: previous_key)], { resource_purl: previous_key }) ==
+          basis_for([row.merge(key: current_key)], { resource_purl: current_key })
+      end
+
+      expect(outcomes).to eq [true, true]
+    end
+  end
+
+  describe "generated alias ownership" do
+    let(:dir) { Dir.mktmpdir }
+    let(:emitter) { Homebrew::DevCmd::AdvisoryMatch::DirEmitter.new(dir, verbose: false, close_open_ranges: true) }
+
+    after { FileUtils.remove_entry(dir) }
+
+    it "protects generated families with one or more generated or matched siblings" do
+      cases = [["generated", "matched"], ["generated", "generated"], ["generated", "matched", "matched"]]
+      outcomes = cases.map do |sources|
+        Dir.mktmpdir do |scenario_dir|
+          owner = Homebrew::DevCmd::AdvisoryMatch::DirEmitter.new(
+            scenario_dir, verbose: false, close_open_ranges: true
+          )
+          paths = sources.each_with_index.map do |source, index|
+            path = File.join(scenario_dir, "BREW-requests-GHSA-#{index}.json")
+            File.write(path, JSON.generate({
+              id:                "BREW-requests-GHSA-#{index}",
+              upstream:          ["CVE-2024-1234"],
+              affected:          [{ package: { ecosystem: "Homebrew", name: "requests" } }],
+              database_specific: { source: },
+            }))
+            path
+          end
+          originals = paths.map { |path| File.read(path) }
+          errors = owner.prepare_aliases("requests", {
+            "BREW-requests-CVE-2024-1234" => ["BREW-requests-CVE-2024-1234"],
+          })
+
+          [errors, owner.alias_protected?("BREW-requests-CVE-2024-1234"),
+           owner.alias_target_paths("BREW-requests-CVE-2024-1234"), paths.map { |path| File.read(path) }] ==
+            [[], true, [], originals]
+        end
+      end
+      expect(outcomes).to eq [true, true, true]
+    end
+
+    it "rejects a generated record affecting another formula before granting ownership" do
+      File.write(File.join(dir, "BREW-requests-CVE-2024-1234.json"), JSON.generate({
+        id:                "BREW-requests-CVE-2024-1234",
+        affected:          [{ package: { ecosystem: "Homebrew", name: "another-formula" } }],
+        database_specific: { source: "generated" },
+      }))
+
+      expect(emitter.prepare_aliases("requests", {
+        "BREW-requests-CVE-2024-1234" => ["BREW-requests-CVE-2024-1234"],
+      })).to include(/unsupported affected entries/)
+    end
+  end
+
+  describe "range basis migration" do
+    let(:dir) { Dir.mktmpdir }
+    let(:path) { File.join(dir, "BREW-requests-CVE-2024-1234.json") }
+    let(:existing) do
+      {
+        id:                "BREW-requests-CVE-2024-1234",
+        affected:          [{
+          package: { ecosystem: "Homebrew", name: "requests" },
+          ranges:  [{ type: "ECOSYSTEM", events: [{ introduced: "0" }, { fixed: "2.28.1" }] }],
+        }],
+        database_specific: { source: "matched" },
+      }
+    end
+
+    before { stub_osv_hit("CVE-2024-1234", fixed: "2.28.1") }
+    after { FileUtils.remove_entry(dir) }
+
+    it "rechecks history for a legacy terminal record and adopts matching provenance" do
+      File.write(path, JSON.generate(existing))
+      matcher = Homebrew::Vulns::Match.new
+      allow(matcher).to receive(:first_fixed_version).and_return("2.28.1")
+      allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
+
+      cmd_for("requests", "--output", dir, "--new-history").run
+
+      refreshed = JSON.parse(File.read(path))
+      expect([refreshed.dig("affected", 0, "ranges"),
+              refreshed.dig("database_specific", "upstream_evidence")&.empty?])
+        .to eq [JSON.parse(JSON.generate(existing.dig(:affected, 0, :ranges))), false]
+    end
+
+    it "repairs legacy missing, empty or invalid ranges after verifying history" do
+      matcher = Homebrew::Vulns::Match.new
+      allow(matcher).to receive(:first_fixed_version).and_return("2.28.1")
+      allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
+      cases = [nil, [], [{ type: "ECOSYSTEM", events: [] }]]
+      outcomes = cases.map do |ranges|
+        record = existing.deep_dup
+        record[:affected].first[:ranges] = ranges
+        File.write(path, JSON.generate(record))
+
+        cmd_for("requests", "--output", dir, "--new-history").run
+
+        JSON.parse(File.read(path)).dig("affected", 0, "ranges") ==
+          JSON.parse(JSON.generate(existing.dig(:affected, 0, :ranges)))
+      end
+
+      expect(outcomes).to eq [true, true, true]
+    end
+
+    it "leaves a legacy terminal record unchanged when recomputed ranges disagree" do
+      File.write(path, JSON.generate(existing))
+      original = File.read(path)
+      matcher = Homebrew::Vulns::Match.new
+      allow(matcher).to receive(:first_fixed_version).and_return("2.29.0")
+      allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
+      output = capture_stdout { cmd_for("requests", "--output", dir, "--new-history").run }
+
+      expect([File.read(path), Homebrew.failed?, output.include?("1 range-basis skips")])
+        .to eq [original, true, true]
+    end
+
+    it "cannot migrate a terminal record using today's version with --no-history" do
+      existing[:affected].first[:ranges].first[:events].last[:fixed] = requests.pkg_version.to_s
+      File.write(path, JSON.generate(existing))
+      original = File.read(path)
+
+      cmd_for("requests", "--output", dir, "--no-history").run
+
+      expect([File.read(path), Homebrew.failed?]).to eq [original, true]
+    end
+
+    it "does not adopt provenance when the forced history walk is unavailable" do
+      File.write(path, JSON.generate(existing))
+      original = File.read(path)
+      matcher = Homebrew::Vulns::Match.new
+      allow(matcher).to receive(:first_fixed_version).and_return(:history_unavailable)
+      allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
+      output = capture_stdout { cmd_for("requests", "--output", dir, "--new-history").run }
+
+      expect([File.read(path), output.include?("1 history-unavailable skips")]).to eq [original, true]
+    end
+
+    it "does not treat a fixed-threshold override as proof of an existing terminal range" do
+      existing[:database_specific][:upstream_evidence] = reviewed_git_evidence
+      existing[:affected].first[:ecosystem_specific] = { upstream_fixed_in: "2.28.1" }
+      File.write(path, JSON.generate(existing))
+      original = File.read(path)
+      overrides_path = File.join(dir, "overrides.yml")
+      File.write(overrides_path, <<~YAML)
+        requests:
+          advisories:
+            CVE-2024-1234:
+              upstream_fixed_in: "2.29.0"
+      YAML
+      overrides = Homebrew::Vulns::AdvisoryOverrides.from_file(Pathname(overrides_path))
+      matcher = Homebrew::Vulns::Match.new(overrides:)
+      allow(matcher).to receive(:first_fixed_version).and_return("2.28.1")
+      allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
+
+      cmd_for("requests", "--output", dir, "--new-history", "--overrides", overrides_path).run
+
+      expect([File.read(path), Homebrew.failed?]).to eq [original, true]
+    end
+
+    it "accepts a fixed-threshold override after the record's ranges and provenance are reviewed together" do
+      existing[:database_specific][:upstream_evidence] = reviewed_git_evidence
+      existing[:affected].first[:ecosystem_specific] = { upstream_fixed_in: "2.29.0" }
+      File.write(path, JSON.generate(existing))
+      overrides_path = File.join(dir, "overrides.yml")
+      File.write(overrides_path, <<~YAML)
+        requests:
+          advisories:
+            CVE-2024-1234:
+              upstream_fixed_in: "2.29.0"
+      YAML
+
+      cmd_for("requests", "--output", dir, "--new-history", "--overrides", overrides_path).run
+
+      refreshed = JSON.parse(File.read(path))
+      expect([refreshed.dig("affected", 0, "ecosystem_specific", "upstream_fixed_in"),
+              refreshed.dig("affected", 0, "ranges", 0, "events").last, Homebrew.failed?])
+        .to eq ["2.29.0", { "fixed" => "2.28.1" }, false]
+    end
+
+    it "adopts a legacy open record when the candidate has exactly the same range" do
+      stub_osv_hit("CVE-2024-1234", fixed: "2.32.0")
+      existing[:affected].first[:ranges].first[:events].pop
+      File.write(path, JSON.generate(existing))
+
+      cmd_for("requests", "--output", dir, "--new-history").run
+
+      expect(JSON.parse(File.read(path)).dig("database_specific", "upstream_evidence")).not_to be_nil
+    end
+
+    it "rejects a fixed boundary preceding a single reviewed open introduction" do
+      existing[:affected].first[:ranges].first[:events] = [{ introduced: "2.29.0" }]
+      File.write(path, JSON.generate(existing))
+      original = File.read(path)
+      matcher = Homebrew::Vulns::Match.new
+      allow(matcher).to receive(:first_fixed_version).and_return("2.28.1")
+      allow(Homebrew::Vulns::Match).to receive(:new).and_return(matcher)
+
+      expect { cmd_for("requests", "--output", dir, "--new-history").run }
+        .to output(/fixed 2\.28\.1 does not follow its reviewed range/).to_stderr
+      expect([File.read(path), Homebrew.failed?]).to eq [original, true]
+    end
+  end
+
+  it "fails closed when a reviewed matched range basis changes" do
+    incompatible = [
+      [
+        { "resource" => "multipart", "resource_purl" => "pkg:pypi/fastapi@0.109.1",
+          "upstream_fixed_in" => "0.109.1" },
+        { resource: "multipart", resource_purl: "pkg:pypi/python-multipart@0.0.20",
+          upstream_fixed_in: "0.0.7" },
+      ],
+      [
+        { "resource" => "marshmallow", "resource_purl" => "pkg:pypi/marshmallow@3.26.2",
+          "upstream_fixed_in" => "3.26.2" },
+        { resource: "marshmallow", resource_purl: "pkg:pypi/marshmallow@4.3.1",
+          upstream_fixed_in: "4.1.2" },
+      ],
+      [
+        {},
+        { resource: "multipart", resource_purl: "pkg:pypi/python-multipart@0.0.20",
+          upstream_fixed_in: "0.0.7" },
+      ],
+    ]
+
+    outcomes = incompatible.map do |existing_basis, incoming_basis|
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "BREW-requests-CVE-2024-1234.json")
+        existing = {
+          "id"                => "BREW-requests-CVE-2024-1234",
+          "summary"           => "reviewed",
+          "upstream"          => ["CVE-2024-1234"],
+          "affected"          => [{
+            "package"            => { "ecosystem" => "Homebrew", "name" => "requests" },
+            "ranges"             => [{ "type" => "ECOSYSTEM", "events" => [
+              { "introduced" => "0" }, { "fixed" => "2.28.1" }
+            ] }],
+            "ecosystem_specific" => existing_basis,
+          }],
+          "database_specific" => { "source" => "matched" },
+        }
+        File.write(path, JSON.generate(existing))
+        emitter = Homebrew::DevCmd::AdvisoryMatch::DirEmitter.new(
+          dir, verbose: false, close_open_ranges: true
+        )
+        errors = emitter.prepare_aliases("requests", {
+          "BREW-requests-CVE-2024-1234" => ["BREW-requests-CVE-2024-1234"],
+        })
+
+        emitter.emit({
+          id:                "BREW-requests-CVE-2024-1234",
+          summary:           "incoming",
+          upstream:          ["CVE-2024-1234"],
+          affected:          [{
+            package:            { ecosystem: "Homebrew", name: "requests" },
+            ranges:             [{ type: "ECOSYSTEM", events: [
+              { introduced: "0" }, { fixed: "3.0" }
+            ] }],
+            ecosystem_specific: incoming_basis,
+          }],
+          database_specific: { source: "matched" },
+        })
+        errors.empty? && JSON.parse(File.read(path)) == existing && Homebrew.failed?
+      end
+    end
+
+    expect(outcomes).to eq [true, true, true]
+  end
+
+  it "fails closed when a reviewed primary package identity changes" do
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "BREW-requests-CVE-2024-1234.json")
+      existing = {
+        "id"                => "BREW-requests-CVE-2024-1234",
+        "summary"           => "reviewed",
+        "upstream"          => ["CVE-2024-1234"],
+        "affected"          => [{
+          "package"            => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"             => [{ "type" => "ECOSYSTEM", "events" => [
+            { "introduced" => "0" }, { "fixed" => "2.28.1" }
+          ] }],
+          "ecosystem_specific" => { "upstream_fixed_in" => "1.0" },
+        }],
+        "database_specific" => {
+          "source"            => "matched",
+          "upstream_evidence" => [{
+            "strategy" => "registry",
+            "key"      => "pkg:pypi/old-package@2.0",
+          }],
+        },
+      }
+      File.write(path, JSON.generate(existing))
+      emitter = Homebrew::DevCmd::AdvisoryMatch::DirEmitter.new(
+        dir, verbose: false, close_open_ranges: true
+      )
+      emitter.prepare_aliases("requests", {
+        "BREW-requests-CVE-2024-1234" => ["BREW-requests-CVE-2024-1234"],
+      })
+
+      expect do
+        emitter.emit({
+          id:                "BREW-requests-CVE-2024-1234",
+          summary:           "incoming",
+          upstream:          ["CVE-2024-1234"],
+          affected:          [{
+            package:            { ecosystem: "Homebrew", name: "requests" },
+            ranges:             [{ type: "ECOSYSTEM", events: [
+              { introduced: "0" }, { fixed: "3.0" }
+            ] }],
+            ecosystem_specific: { upstream_fixed_in: "1.0" },
+          }],
+          database_specific: {
+            source:            "matched",
+            upstream_evidence: [{ strategy: :registry, key: "pkg:pypi/new-package@2.0" }],
+          },
+        })
+      end.to output(/range basis changed/).to_stderr
+      expect([JSON.parse(File.read(path)), Homebrew.failed?]).to eq [existing, true]
+    end
+  end
+
+  it "accepts resource version and label changes for the same reviewed package" do
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "BREW-requests-CVE-2024-1234.json")
+      File.write(path, JSON.generate({
+        "id"                => "BREW-requests-CVE-2024-1234",
+        "summary"           => "reviewed",
+        "upstream"          => ["CVE-2024-1234"],
+        "affected"          => [{
+          "package"            => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"             => [{ "type" => "ECOSYSTEM", "events" => [
+            { "introduced" => "0" }, { "fixed" => "2.28.1" }
+          ] }],
+          "ecosystem_specific" => {
+            "resource"          => "old-label",
+            "resource_purl"     => "pkg:pypi/python-multipart@0.0.7",
+            "upstream_fixed_in" => "0.0.7",
+          },
+        }],
+        "database_specific" => { "source" => "matched" },
+      }))
+      emitter = Homebrew::DevCmd::AdvisoryMatch::DirEmitter.new(
+        dir, verbose: false, close_open_ranges: true
+      )
+      emitter.prepare_aliases("requests", {
+        "BREW-requests-CVE-2024-1234" => ["BREW-requests-CVE-2024-1234"],
+      })
+
+      emitter.emit({
+        id:                "BREW-requests-CVE-2024-1234",
+        summary:           "incoming",
+        upstream:          ["CVE-2024-1234"],
+        affected:          [{
+          package:            { ecosystem: "Homebrew", name: "requests" },
+          ranges:             [{ type: "ECOSYSTEM", events: [
+            { introduced: "0" }, { fixed: "3.0" }
+          ] }],
+          ecosystem_specific: {
+            resource:          "new-label",
+            resource_purl:     "pkg:pypi/python-multipart@0.0.20",
+            upstream_fixed_in: "0.0.7",
+          },
+        }],
+        database_specific: { source: "matched" },
+      })
+
+      refreshed = JSON.parse(File.read(path))
+      expect([
+        refreshed["summary"],
+        refreshed.dig("affected", 0, "ecosystem_specific", "resource"),
+        refreshed.dig("affected", 0, "ranges", 0, "events").last,
+      ]).to eq ["incoming", "new-label", { "fixed" => "2.28.1" }]
+    end
+  end
+
+  it "skips history for existing terminal records with unchanged provenance under --new-history" do
     stub_osv_hit("CVE-2024-1234", fixed: "2.28.1")
 
     Dir.mktmpdir do |dir|
@@ -487,12 +780,13 @@ RSpec.describe Homebrew::DevCmd::AdvisoryMatch do
         "id"                => "BREW-requests-CVE-2024-1234",
         "modified"          => "2026-01-01T00:00:00Z",
         "affected"          => [{
-          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
-          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [
+          "package"            => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"             => [{ "type" => "ECOSYSTEM", "events" => [
             { "introduced" => "0" }, { "fixed" => "2.28.1" }
           ] }],
+          "ecosystem_specific" => { "upstream_fixed_in" => "2.28.1" },
         }],
-        "database_specific" => { "source" => "matched" },
+        "database_specific" => { "source" => "matched", "upstream_evidence" => reviewed_git_evidence },
       }
       File.write(path, JSON.generate(record))
 
@@ -596,8 +890,14 @@ RSpec.describe Homebrew::DevCmd::AdvisoryMatch do
       path = File.join(dir, "BREW-requests-CVE-2024-1234.json")
       File.write(path, JSON.generate({
         "id"                => "BREW-requests-CVE-2024-1234",
-        "affected"          => [{ "package" => { "ecosystem" => "Homebrew", "name" => "requests" } }],
-        "database_specific" => { "source" => "matched" },
+        "affected"          => [{
+          "package"            => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ecosystem_specific" => { "upstream_fixed_in" => "2.28.1" },
+        }],
+        "database_specific" => {
+          "source"            => "matched",
+          "upstream_evidence" => reviewed_git_evidence,
+        },
       }))
 
       cmd_for("requests", "--output", dir, "--new-history").run
@@ -617,10 +917,14 @@ RSpec.describe Homebrew::DevCmd::AdvisoryMatch do
       File.write(path, JSON.generate({
         "id"                => "BREW-requests-CVE-2024-1234",
         "affected"          => [{
-          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
-          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [{ "introduced" => "1.0" }] }],
+          "package"            => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"             => [{ "type" => "ECOSYSTEM", "events" => [{ "introduced" => "1.0" }] }],
+          "ecosystem_specific" => { "upstream_fixed_in" => "2.28.1" },
         }],
-        "database_specific" => { "source" => "matched" },
+        "database_specific" => {
+          "source"            => "matched",
+          "upstream_evidence" => reviewed_git_evidence,
+        },
       }))
 
       expect { cmd_for("requests", "--output", dir, "--new-history").run }
@@ -645,9 +949,12 @@ RSpec.describe Homebrew::DevCmd::AdvisoryMatch do
           "ranges"             => [{ "type" => "ECOSYSTEM", "events" => [
             { "introduced" => "0" }, { "fixed" => "2.30.0" }
           ] }],
-          "ecosystem_specific" => { "range_state" => "fixed" },
+          "ecosystem_specific" => { "range_state" => "fixed", "upstream_fixed_in" => "2.32.0" },
         }],
-        "database_specific" => { "source" => "matched" },
+        "database_specific" => {
+          "source"            => "matched",
+          "upstream_evidence" => reviewed_git_evidence,
+        },
       }))
 
       expect { cmd_for("requests", "--output", dir, "--new-history").run }
@@ -668,12 +975,16 @@ RSpec.describe Homebrew::DevCmd::AdvisoryMatch do
       existing = {
         "id"                => "BREW-requests-CVE-2024-1234",
         "affected"          => [{
-          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
-          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [
+          "package"            => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"             => [{ "type" => "ECOSYSTEM", "events" => [
             { "introduced" => "0" }, { "fixed" => "2.30.0" }
           ] }],
+          "ecosystem_specific" => { "upstream_fixed_in" => "2.32.0" },
         }],
-        "database_specific" => { "source" => "matched" },
+        "database_specific" => {
+          "source"            => "matched",
+          "upstream_evidence" => reviewed_git_evidence,
+        },
       }
       File.write(path, JSON.generate(existing))
 
@@ -695,12 +1006,13 @@ RSpec.describe Homebrew::DevCmd::AdvisoryMatch do
       existing = {
         "id"                => "BREW-requests-CVE-2024-1234",
         "affected"          => [{
-          "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
-          "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [
+          "package"            => { "ecosystem" => "Homebrew", "name" => "requests" },
+          "ranges"             => [{ "type" => "ECOSYSTEM", "events" => [
             { "introduced" => "0" }, { "fixed" => "2.30.0" }
           ] }],
+          "ecosystem_specific" => { "upstream_fixed_in" => "2.32.0" },
         }],
-        "database_specific" => { "source" => "matched" },
+        "database_specific" => { "source" => "matched", "upstream_evidence" => reviewed_git_evidence },
       }
       File.write(path, JSON.generate(existing))
 
@@ -818,7 +1130,10 @@ RSpec.describe Homebrew::DevCmd::AdvisoryMatch do
       path = File.join(dir, "BREW-requests-CVE-2024-1234.json")
       File.write(path, JSON.generate({ "id"                => "BREW-requests-CVE-2024-1234",
                                        "database_specific" => { "source" => "generated" },
-                                       "affected"          => [{ "ecosystem_specific" => { "fix" => "patch" } }] }))
+                                       "affected"          => [{
+                                         "package"            => { "ecosystem" => "Homebrew", "name" => "requests" },
+                                         "ecosystem_specific" => { "fix" => "patch" },
+                                       }] }))
 
       matcher = Homebrew::Vulns::Match.new
       expect(matcher).not_to receive(:first_fixed_version)
@@ -905,7 +1220,10 @@ RSpec.describe Homebrew::DevCmd::AdvisoryMatch do
           "package" => { "ecosystem" => "Homebrew", "name" => "requests" },
           "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [{ "introduced" => "0" }] }],
         }],
-        "database_specific" => { "source" => "matched" },
+        "database_specific" => {
+          "source"            => "matched",
+          "upstream_evidence" => reviewed_git_evidence,
+        },
       }))
 
       expect do

--- a/Library/Homebrew/test/vulns/match_spec.rb
+++ b/Library/Homebrew/test/vulns/match_spec.rb
@@ -753,6 +753,47 @@ RSpec.describe Homebrew::Vulns::Match do
       expect(record.dig(:database_specific, :confidence)).to eq "high"
     end
 
+    it "deduplicates exported evidence after removing internal provenance" do
+      records = ["CVE-2024-1234", "GHSA-abcd"].map do |id|
+        vulnerability = vuln(
+          "id"       => id,
+          "aliases"  => [(id == "CVE-2024-1234") ? "GHSA-abcd" : "CVE-2024-1234"],
+          "affected" => [{
+            "package" => { "ecosystem" => "PyPI", "name" => "requests" },
+            "ranges"  => [{ "type" => "ECOSYSTEM", "events" => [
+              { "introduced" => "0" }, { "fixed" => "2.28.1" }
+            ] }],
+          }],
+        )
+        make_hit(vulnerability, ev(:registry, ecosystem: "PyPI", name: "requests",
+                                              subject_version: "2.31.0", key: "pkg:pypi/requests@2.31.0"))
+      end
+      hit = matcher.dedup_by_aliases(records).fetch(0)
+
+      evidence = matcher.to_brew_record(requests, hit, now:)
+                        .dig(:database_specific, :upstream_evidence)
+      expect(evidence).to eq [{
+        strategy:        :registry,
+        ecosystem:       "PyPI",
+        name:            "requests",
+        subject_version: "2.31.0",
+        key:             "pkg:pypi/requests@2.31.0",
+      }]
+    end
+
+    it "keeps exported evidence for separate resources of the same package" do
+      vulnerability = vuln("id" => "CVE-2024-1234")
+      evidence = ["first", "second"].map do |resource|
+        ev(:registry, ecosystem: "PyPI", name: "requests", subject_version: "2.31.0",
+                      key: "pkg:pypi/requests@2.31.0", resource:)
+      end
+      hit = make_hit(vulnerability, *evidence)
+
+      expect(matcher.to_brew_record(requests, hit, now:)
+                    .dig(:database_specific, :upstream_evidence).map { |row| row[:resource] })
+        .to eq ["first", "second"]
+    end
+
     it "emits no fixed event and fix: nil when the range says the shipped version is still affected" do
       hit = registry_hit(affected_events: [{ "introduced" => "0" }, { "fixed" => "2.32.0" }])
 

--- a/Library/Homebrew/vulns/match.rb
+++ b/Library/Homebrew/vulns/match.rb
@@ -602,7 +602,7 @@ module Homebrew
             source:            "matched",
             strategy:          hit.strategy.to_s,
             confidence:        confidence_for(hit, status),
-            upstream_evidence: hit.evidence.map { |e| e.to_h.except(:advisory, :source_record).compact },
+            upstream_evidence: hit.evidence.map { |e| e.to_h.except(:advisory, :source_record).compact }.uniq,
           },
         }, T::Hash[Symbol, T.untyped])
 

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -339,7 +339,7 @@ __fish_brew_complete_arg 'advisory-match' -l debug -d 'Display any debugging inf
 __fish_brew_complete_arg 'advisory-match' -l help -d 'Show this message'
 __fish_brew_complete_arg 'advisory-match' -l index -d 'Emit the formula-identity index as JSON and exit'
 __fish_brew_complete_arg 'advisory-match' -l json -d 'Output candidate records as a JSON array'
-__fish_brew_complete_arg 'advisory-match' -l new-history -d 'Walk `FormulaVersions` only for records whose reviewed ranges are not already in directory'
+__fish_brew_complete_arg 'advisory-match' -l new-history -d 'Skip `FormulaVersions` for existing terminal ranges unless their matching provenance changes'
 __fish_brew_complete_arg 'advisory-match' -l no-history -d 'Skip the `FormulaVersions` walk for the `fixed` boundary; use the current `pkg_version` instead'
 __fish_brew_complete_arg 'advisory-match' -l output -d 'Write each record to directory as `BREW-formula-id.json`, preserving existing `published`/`ranges` fields'
 __fish_brew_complete_arg 'advisory-match' -l overrides -d 'Load reviewed formula and advisory matching overrides from file'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -448,7 +448,7 @@ _brew_advisory_match() {
     '--help[Show this message]' \
     '(--all --json --output)--index[Emit the formula-identity index as JSON and exit]' \
     '(--all --index)--json[Output candidate records as a JSON array]' \
-    '(--no-history)--new-history[Walk `FormulaVersions` only for records whose reviewed ranges are not already in directory]' \
+    '(--no-history)--new-history[Skip `FormulaVersions` for existing terminal ranges unless their matching provenance changes]' \
     '(--new-history)--no-history[Skip the `FormulaVersions` walk for the `fixed` boundary; use the current `pkg_version` instead]' \
     '(--index)--output[Write each record to directory as `BREW-formula-id.json`, preserving existing `published`/`ranges` fields]' \
     '--overrides[Load reviewed formula and advisory matching overrides from file]' \


### PR DESCRIPTION
`advisory-match` preserves reviewed ranges when refreshing existing records, but replaced the evidence and upstream fixed version without checking whether they still described the same package. A changed resource or fixed threshold could therefore leave old ranges attached to new provenance, and `--new-history` skipped the history walk that could expose it.

This compares the runtime subjects and upstream fix threshold before reusing those ranges. Changed terminal-range provenance triggers history validation even with `--new-history`, and is accepted only when the newly computed ranges agree with the reviewed ones. Otherwise the record stays unchanged with a diagnostic explaining what needs review. Version bumps, resource renames and equivalent package spellings do not count as identity changes.

Alias handling now updates the sole existing matched record instead of also creating a canonical copy. Generated records retain ownership of their family, and multiple matched aliases require consolidation before matching proceeds.

Exported evidence is deduplicated after removing internal provenance, which could make previously distinct rows identical. Internal provenance and separate resource packages are preserved.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Codex drafted the implementation and tests, with Claude reviewing an earlier patch. Verification included focused red/green regressions and `brew lgtm --online`.

-----
