### PR TITLE
Ignore uv executable entries in Bundle

### DIFF
--- a/Library/Homebrew/bundle/extensions/uv.rb
+++ b/Library/Homebrew/bundle/extensions/uv.rb
@@ -132,7 +132,7 @@ module Homebrew
           entries = T.let([], T::Array[Tool])
 
           output.each_line do |line|
-            match = line.match(/\A(\S+)\s+v\S+/)
+            match = line.match(/\A([A-Za-z0-9]\S*)\s+v\S+/)
             next unless match
 
             name = match[1]

--- a/Library/Homebrew/test/bundle/uv_spec.rb
+++ b/Library/Homebrew/test/bundle/uv_spec.rb
@@ -6,6 +6,10 @@ require "bundle/dsl"
 require "bundle/extensions/uv"
 
 RSpec.describe Homebrew::Bundle::Uv do
+  let(:uv_tool_list_args) do
+    [Pathname("uv"), "tool", "list", "--show-with", "--show-extras", "--show-version-specifiers"]
+  end
+
   describe "entries" do
     it "accepts a source that resolves on another machine" do
       entry = described_class.entry("ruff", source: "git+https://github.com/astral-sh/ruff.git")
@@ -110,10 +114,6 @@ RSpec.describe Homebrew::Bundle::Uv do
   describe "dumping" do
     subject(:dumper) { described_class }
 
-    let(:uv_tool_list_args) do
-      [Pathname("uv"), "tool", "list", "--show-with", "--show-extras", "--show-version-specifiers"]
-    end
-
     context "when uv is not installed" do
       before do
         described_class.reset!
@@ -152,6 +152,44 @@ RSpec.describe Homebrew::Bundle::Uv do
             source: nil,
           },
         ])
+      end
+
+      it "ignores executable entries when dumping packages" do
+        allow(Utils).to receive(:popen_read_text).with(*uv_tool_list_args, err: File::NULL).and_return(<<~OUTPUT)
+          v-example v1.2.3
+          - v-example
+          - v2
+          vulture v2.16
+          - vulture
+        OUTPUT
+
+        expect(dumper.dump).to eql(<<~BREWFILE.chomp)
+          uv "v-example"
+          uv "vulture"
+        BREWFILE
+      end
+
+      it "accepts headings with valid package-name forms and version strings" do
+        allow(Utils).to receive(:popen_read_text).with(*uv_tool_list_args, err: File::NULL).and_return(<<~OUTPUT)
+          a v1.0
+          7zip v1!2.0rc1+local
+          my-tool.name_2 v2.0
+          Vtool v1.0
+        OUTPUT
+
+        expect(dumper.dump).to eql(<<~BREWFILE.chomp)
+          uv "7zip"
+          uv "Vtool"
+          uv "a"
+          uv "my-tool.name_2"
+        BREWFILE
+      end
+
+      it "ignores lines whose first token starts with punctuation" do
+        allow(Utils).to receive(:popen_read_text).with(*uv_tool_list_args, err: File::NULL)
+                                                 .and_return("vulture v2.16\n-\tv2\n• v2\n_vtool v1.0\n")
+
+        expect(dumper.dump).to eql('uv "vulture"')
       end
 
       it "parses a git source from the version specifier and dumps it" do
@@ -452,6 +490,36 @@ RSpec.describe Homebrew::Bundle::Uv do
           expect(described_class.dump).to eql('uv "mkdocs", with: ["mkdocs-material<10"]')
         end
       end
+    end
+  end
+
+  describe "consumers of parsed tool lists" do
+    before do
+      described_class.reset!
+      allow(described_class).to receive(:package_manager_executable).and_return(Pathname.new("uv"))
+      allow(Utils).to receive(:popen_read_text).with(*uv_tool_list_args, err: File::NULL).and_return(<<~OUTPUT)
+        vulture v2.16 [required: git+https://example.com/vulture.git] [extras: cli] [with: httpx>=0.27]
+        - vulture
+        - v2
+        ruff v0.14.14
+        - ruff
+      OUTPUT
+    end
+
+    it "checks installed entries using parsed names and metadata" do
+      entries = [
+        Homebrew::Bundle::Dsl::Entry.new(:uv, "vulture[cli]", with:   ["httpx>=0.27"],
+                                                              source: "git+https://example.com/vulture.git"),
+        Homebrew::Bundle::Dsl::Entry.new(:uv, "-"),
+      ]
+
+      expect(described_class.check(entries)).to eql(["uv Tool - needs to be installed."])
+    end
+
+    it "selects only undeclared packages for cleanup" do
+      entries = [Homebrew::Bundle::Dsl::Entry.new(:uv, "vulture[cli]")]
+
+      expect(described_class.cleanup_items(entries)).to eql(["ruff"])
     end
   end
 


### PR DESCRIPTION
`brew bundle dump --uv` mistakes executable entries such as `- vulture` for package headings, producing bogus `uv "-"` entries.
The parser accepts the bullet as a package name and the command name as a version.

With `vulture` already installed through `uv tool`, reproduce with:

```sh
uv tool list --show-with --show-extras --show-version-specifiers
brew bundle dump --uv --file=-
```

For example, `uv tool list` includes:

```text
vulture v2.16
- vulture
```

The dump should contain `uv "vulture"` but also contains `uv "-"`.

Require package names in headings to start with an ASCII letter or number, as the [Python package-name specification requires](https://packaging.python.org/en/latest/specifications/name-normalization/#name-format).
This excludes executable bullets while leaving the remaining name, version and optional-metadata parsing unchanged.

Regression tests cover executable bullets, package-name boundary cases and metadata preservation in check and cleanup selection.
The synthetic command name `v2`, listed as `- v2`, verifies that a version-looking command is not mistaken for a package heading.

Tests:

- The dump, invalid-heading, check and cleanup-selection tests fail with the original parser and pass with the fix.
- `./bin/brew lgtm --online`: typechecking, style and all 43 uv tests passed.
- `./bin/brew tests --only=bundle --online --no-parallel --seed=14801`: 411 examples, 0 failures.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

I independently determined and verified the fix. OpenAI Codex assisted with diagnosis and applying the regression tests.

-----
