### PR TITLE
Adjust macOS subprocess policy

### DIFF
--- a/Library/Homebrew/extend/os/mac/sandbox.rb
+++ b/Library/Homebrew/extend/os/mac/sandbox.rb
@@ -34,6 +34,8 @@ module OS
         (deny file-write*) ; deny non-allowlist file write operations
         (deny file-write-setugid) ; deny non-allowlist file write SUID/SGID operations
         (deny file-write-mode) ; deny non-allowlist file write mode operations
+        (deny lsopen)
+        (deny appleevent-send)
         (allow process-exec
             (literal "/bin/ps")
             (with no-sandbox)

--- a/Library/Homebrew/test/sandbox_spec.rb
+++ b/Library/Homebrew/test/sandbox_spec.rb
@@ -13,12 +13,25 @@ RSpec.describe Sandbox, :needs_macos do
 
   before do
     skip "Sandbox not implemented." unless described_class.available?
-    if described_class.nested_sandbox? && !RSpec.current_example&.metadata&.key?(:tests_nested_sandbox_detection)
+    if described_class.nested_sandbox? && !RSpec.current_example&.metadata&.key?(:no_sandbox_run)
       skip "Nested sandboxing is not supported."
     end
   end
 
-  describe ".avoid_nested_sandboxing?", :tests_nested_sandbox_detection do
+  describe "#seatbelt_profile", :no_sandbox_run do
+    subject(:sandbox) do
+      Class.new(described_class) do
+        T.bind(self, T.class_of(Sandbox))
+        public :seatbelt_profile
+      end.new
+    end
+
+    it "denies LaunchServices and Apple Events even when network access is allowed" do
+      expect(sandbox.seatbelt_profile).to include("(deny lsopen)", "(deny appleevent-send)")
+    end
+  end
+
+  describe ".avoid_nested_sandboxing?", :no_sandbox_run do
     before do
       allow(Homebrew::EnvConfig).to receive(:avoid_nested_sandboxing?).and_return(true)
       allow(described_class).to receive(:nested_sandbox?).and_return(true)
@@ -69,6 +82,15 @@ RSpec.describe Sandbox, :needs_macos do
   end
 
   describe "#run" do
+    it "prevents LaunchServices from launching an application outside the sandbox" do
+      app = dir/"SandboxTest.app"
+      SystemCommand.run!("/usr/bin/osacompile", args: ["-o", app, "-e", "return"])
+      SystemCommand.run!("/usr/bin/open", args: ["-W", "-n", app])
+      sandbox.allow_write_temp_and_cache
+
+      expect { sandbox.run "/usr/bin/open", "-W", "-n", app }.to raise_error(ErrorDuringExecution)
+    end
+
     it "fails when writing to file not specified with ##allow_write" do
       expect do
         sandbox.run "touch", file

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -188,6 +188,9 @@ Official macOS casks must also meet the [Gatekeeper requirement](Acceptable-Cask
 
 Generated completion artifacts are different: `generate_completions_from_executable` runs an installed executable only to produce shell completion text. The complete generation operation, including writing the completion, runs in an isolated Ruby subprocess where Homebrew has an available sandbox. The sandbox allows reading the staged cask, writing the completion and temporary/cache files and blocks network access. This limits side effects from commands that should only print completion data.
 
+On macOS, sandboxed operations cannot launch applications through LaunchServices (including `open`) or send Apple Events to other applications.
+These restrictions also apply to steps with `network_access: true`.
+
 `installer script:` is not sandboxed. Many installer scripts are vendor installers that require broad filesystem writes, macOS services or `sudo`; macOS sandboxing does not work for root processes, and narrowing the write allowlist to the Caskroom plus uninstall or zap paths would break installers that legitimately write elsewhere. It would also change documented `SystemCommand` behaviours such as `sudo:`, `must_succeed:` and output handling.
 
 `pkg` artifacts are not run in the cask sandbox either. They are installed by macOS `/usr/sbin/installer`, which applies package payloads, scripts and receipts according to the package metadata.


### PR DESCRIPTION
- Keep sandboxed macOS subprocesses focused on command-line work by disabling application launching and cross-application automation.
- Apply the same policy when network access is enabled and document the behaviour for cask steps.
- Add profile and application-launch checks, allowing profile checks to run when Homebrew is already inside a sandbox.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Codex with GPT 6 Astra at High effort, with local review and testing.

-----