### PR TITLE
test_bot: source-building more deps on Linux

### DIFF
--- a/Library/Homebrew/extend/os/linux/test_bot.rb
+++ b/Library/Homebrew/extend/os/linux/test_bot.rb
@@ -31,22 +31,6 @@ module OS
         end
       end
 
-      module FormulaeDependents
-        extend T::Helpers
-
-        requires_ancestor { ::Homebrew::TestBot::FormulaeDependents }
-
-        sig { params(formula: Formula, args: ::Homebrew::Cmd::TestBotCmd::Args).returns(T::Boolean) }
-        def skip_recursive_dependents?(formula, args:)
-          super || formula.requirements.exclude?(LinuxRequirement.new)
-        end
-
-        sig { params(dependent: Formula).returns(T::Boolean) }
-        def build_dependent_from_source?(dependent)
-          dependent.requirements.include?(LinuxRequirement.new)
-        end
-      end
-
       module CleanupBefore
         extend T::Helpers
 
@@ -67,5 +51,4 @@ end
 
 Homebrew::TestBot.singleton_class.prepend(OS::Linux::TestBot::ClassMethods)
 Homebrew::TestBot::TestFormulae.prepend(OS::Linux::TestBot::TestFormulae)
-Homebrew::TestBot::FormulaeDependents.prepend(OS::Linux::TestBot::FormulaeDependents)
 Homebrew::TestBot::CleanupBefore.prepend(OS::Linux::TestBot::CleanupBefore)

--- a/Library/Homebrew/extend/os/mac/test_bot.rb
+++ b/Library/Homebrew/extend/os/mac/test_bot.rb
@@ -49,17 +49,6 @@ module OS
         end
       end
 
-      module FormulaeDependents
-        extend T::Helpers
-
-        requires_ancestor { ::Homebrew::TestBot::FormulaeDependents }
-
-        sig { params(_formula: Formula, args: ::Homebrew::Cmd::TestBotCmd::Args).returns(T::Boolean) }
-        def skip_recursive_dependents?(_formula, args:)
-          super || ::Hardware::CPU.intel?
-        end
-      end
-
       module CleanupBefore
         extend T::Helpers
 
@@ -88,5 +77,4 @@ end
 Homebrew::TestBot.singleton_class.prepend(OS::Mac::TestBot::ClassMethods)
 Homebrew::TestBot::TestFormulae.prepend(OS::Mac::TestBot::TestFormulae)
 Homebrew::TestBot::Formulae.prepend(OS::Mac::TestBot::Formulae)
-Homebrew::TestBot::FormulaeDependents.prepend(OS::Mac::TestBot::FormulaeDependents)
 Homebrew::TestBot::CleanupBefore.prepend(OS::Mac::TestBot::CleanupBefore)


### PR DESCRIPTION
Previously, this was disabled as Linux dependency trees are more complicated. Now that we have a fixed limit on total dependents we source-build, we can allot the same popular dependents as Linux and macOS can behave differently.

There is a side effect where we no longer prioritize Linux-only dependents, but I think this is fine and it aligns with macOS side. We prioritize the popular formulae, which have higher chance of Tier 2/3 users hitting issues.

Also remove unused `skip_recursive_dependents?`

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
