### PR TITLE
Document the one AI-assisted pull request limit

### DIFF
--- a/docs/How-To-Open-a-Homebrew-Pull-Request.md
+++ b/docs/How-To-Open-a-Homebrew-Pull-Request.md
@@ -153,6 +153,7 @@ We allow you to create issues and pull requests with AI/LLM with the following r
 * You must review all AI/LLM generated code, prose, etc. content before you ask anyone in Homebrew to review it for you.
 * You must not attribute a commit to AI/LLM as an author, co-author, committer or signatory, including through an `Assisted-by`, `Co-developed-by` or similar commit trailer.
 * You must answer all maintainer questions and pull request review comments yourself, without using AI/LLM.
+* Unless you are a maintainer, you may only have one AI-assisted/generated pull request open at a time.
 * If you reach the point where you feel unwilling or unable to do the above, please close your issue or pull request.
 
 ## Following up


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [ ] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

AI-assisted contribution by Claude Code (Claude Opus 5, model `claude-opus-5[1m]`) of 100% of the work. `brew style --changed`, `brew tests --changed`, `brew typecheck` run by AI. Verified by the contributor: read the diff and confirmed the bullet matches CONTRIBUTING.md verbatim and sits in the same position in the list.

Built and tested locally on macOS 26.2 running arm64

Adds the concurrency limit that
  CONTRIBUTING.md states but this page omits.
