### PR TITLE
bump-formula-pr: support bumping resource using revision as version

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -575,6 +575,7 @@ module Homebrew
           end
 
           is_downgraded = Version.new(current_version) > Version.new(latest_version)
+          is_downgraded &&= current_version != resource.specs[:revision]
 
           begin
             result = update_resource_block!(formula, resource, latest_version)
@@ -750,31 +751,43 @@ module Homebrew
         ).returns(Symbol)
       }
       def update_resource_block!(formula, resource, new_version)
-        ohai "Updating resource \"#{resource.name}\" from #{resource.version} to #{new_version}"
+        old_version = resource.version.to_s
+        ohai "Updating resource \"#{resource.name}\" from #{old_version} to #{new_version}"
 
         old_url = resource.url
         raise ArgumentError, "resource \"#{resource.name}\" has no URL" if old_url.nil?
 
-        if (old_tag = resource.specs[:tag].presence) && resource.download_strategy <= GitDownloadStrategy
-          tag = update_url(old_tag, resource.version.to_s, new_version)
-          if tag == old_tag
-            opoo <<~EOS
-              You need to bump resource "#{resource.name}" manually since the new tag
-              and old tag are both:
-                #{tag}
-            EOS
-            return :tag_unchanged
-          end
+        if resource.download_strategy <= GitDownloadStrategy
+          old_tag = resource.specs[:tag].presence
+          old_revision = resource.specs[:revision].presence
 
           # `specs` omits `using:`, so pass it through to keep an explicit strategy
-          git_specs = { tag: }
+          git_specs = {}
           if (using = resource.using.presence)
             git_specs[:using] = using
           end
+
+          if old_tag
+            git_specs[:tag] = tag = update_url(old_tag, old_version, new_version)
+            if tag == old_tag
+              opoo <<~EOS
+                You need to bump resource "#{resource.name}" manually since the new tag
+                and old tag are both:
+                  #{tag}
+              EOS
+              return :tag_unchanged
+            end
+          elsif old_revision == old_version
+            git_specs[:revision] = new_revision = new_version
+          else
+            opoo "Could not resolve a revision for resource \"#{resource.name}\" version #{new_version}."
+            return :revision_unresolved
+          end
+
           resource_path, forced_version = fetch_resource_and_forced_version(resource, new_version, old_url,
                                                                             **git_specs)
-          new_revision = Utils.popen_read("git", "-C", resource_path.to_s, "rev-parse", "-q", "--verify",
-                                          "HEAD").strip
+          new_revision ||= Utils.popen_read("git", "-C", resource_path.to_s, "rev-parse", "-q", "--verify",
+                                            "HEAD").strip
           if new_revision.blank?
             opoo "Could not resolve a revision for resource \"#{resource.name}\" tag #{tag}."
             return :revision_unresolved
@@ -782,8 +795,8 @@ module Homebrew
 
           resource_name = resource.name.to_s
           formula_ast = Utils::AST::FormulaAST.new(formula.path.read)
-          formula_ast.replace_resource_stanza_hash_value(resource_name, :url, :tag, tag)
-          if resource.specs[:revision].present?
+          formula_ast.replace_resource_stanza_hash_value(resource_name, :url, :tag, tag) if tag
+          if old_revision.present?
             formula_ast.replace_resource_stanza_hash_value(resource_name, :url, :revision, new_revision)
           end
 

--- a/Library/Homebrew/test/dev-cmd/bump-formula-pr_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-formula-pr_spec.rb
@@ -424,6 +424,38 @@ RSpec.describe Homebrew::DevCmd::BumpFormulaPr do
       expect(formula_path.read).to include("revision: \"#{"b" * 40}\"")
     end
 
+    it "updates revision for a git resource without a tag" do
+      old_revision = "b" * 40
+      new_revision = "a" * 40
+      formula_path = CoreTap.instance.new_formula_path("gitresourceball")
+      formula_path.dirname.mkpath
+      formula_path.write <<~RUBY
+        class Gitresourceball < Formula
+          url "https://brew.sh/gitresourceball-1.0.tar.gz"
+
+          resource "foo" do
+            url "https://brew.sh/foo.git",
+                revision: "#{old_revision}"
+            version "#{old_revision}"
+          end
+        end
+      RUBY
+      CoreTap.instance.clear_cache
+      Formulary.clear_cache
+      Formula.clear_cache
+      formula = Formulary.from_contents("gitresourceball", formula_path, formula_path.read)
+
+      resource = Resource.new("foo")
+      allow(Resource).to receive(:new).with("foo").and_return(resource)
+      allow(Resource).to receive(:new).with("gitresourceball").and_return(instance_double(Resource))
+      allow(resource).to receive(:fetch).and_return(mktmpdir)
+
+      resource_versions = { "foo" => { current_version: old_revision, latest_version: new_revision } }
+
+      expect(bump_formula_pr.update_resources!(formula, resource_versions:)).to eq({ "foo" => :success })
+      expect(formula_path.read).to include("revision: \"#{new_revision}\"", "version \"#{new_revision}\"")
+    end
+
     it "updates the URL for a non-git resource carrying a tag" do
       formula_path = CoreTap.instance.new_formula_path("tarballwithtag")
       formula_path.dirname.mkpath
@@ -476,6 +508,35 @@ RSpec.describe Homebrew::DevCmd::BumpFormulaPr do
       resource_versions = { "foo" => { current_version: "1.2.3", latest_version: "2.0.0" } }
 
       expect(bump_formula_pr.update_resources!(formula, resource_versions:)).to eq({ "foo" => :tag_unchanged })
+    end
+
+    it "reports git resources where new revision cannot be detected from new version" do
+      formula_path = CoreTap.instance.new_formula_path("sametagball")
+      formula_path.dirname.mkpath
+      formula_path.write <<~RUBY
+        class Sametagball < Formula
+          url "https://brew.sh/sametagball-1.0.tar.gz"
+
+          resource "foo" do
+            url "https://brew.sh/foo.git",
+                revision: "#{"a" * 40}"
+            version "1.2.3"
+          end
+        end
+      RUBY
+      CoreTap.instance.clear_cache
+      Formulary.clear_cache
+      Formula.clear_cache
+      formula = Formulary.from_contents("sametagball", formula_path, formula_path.read)
+
+      resource = Resource.new("foo")
+      allow(Resource).to receive(:new).with("foo").and_return(resource)
+      allow(Resource).to receive(:new).with("sametagball").and_return(instance_double(Resource))
+      allow(resource).to receive(:fetch).and_return(mktmpdir)
+
+      resource_versions = { "foo" => { current_version: "1.2.3", latest_version: "2.0.0" } }
+
+      expect(bump_formula_pr.update_resources!(formula, resource_versions:)).to eq({ "foo" => :revision_unresolved })
     end
 
     it "downgrades to requested version" do


### PR DESCRIPTION
Commonly used for googlesource repos, e.g. Chromium tooling, which usually lack useful tags and don't have reproducible git archives. Thus, we need to version resource via the commit hash.

e.g. `v8`'s gn resource https://github.com/Homebrew/homebrew-core/blob/main/Formula/v/v8.rb#L59-L68
```rb
  resource "gn" do
    url "https://gn.googlesource.com/gn.git",
        revision: "7324363900ccab92518649e9693d71a4ae71a747"
    version "7324363900ccab92518649e9693d71a4ae71a747"

    livecheck do
      url "https://raw.githubusercontent.com/v8/v8/refs/tags/#{LATEST_VERSION}/DEPS"
      regex(/["']gn_version["']:\s*["']git_revision:([0-9a-f]+)["']/i)
    end
  end
```

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

n/a

-----
