### PR TITLE
Run stale PR approvals with standalone Ruby

### DIFF
--- a/.github/scripts/.rubocop.yml
+++ b/.github/scripts/.rubocop.yml
@@ -1,0 +1,2 @@
+inherit_from:
+  - ../../Library/.rubocop.yml

--- a/.github/scripts/approve_stale_lead_maintainer_prs.rb
+++ b/.github/scripts/approve_stale_lead_maintainer_prs.rb
@@ -2,15 +2,19 @@
 # frozen_string_literal: true
 
 require "date"
+require "json"
+require "open3"
+require "sorbet-runtime"
 require "time"
 require "uri"
-require "utils/formatter"
-require "utils/github"
-require "utils/output"
 
 # Approves stale lead maintainer PRs from GitHub Actions.
 class StaleLeadMaintainerPrApproval
-  include Utils::Output::Mixin
+  # Standalone Ruby does not include T::Sig in Module.
+  extend T::Sig # rubocop:disable Sorbet/RedundantExtendTSig
+
+  API_URL = "https://api.github.com"
+  MAX_PER_PAGE = 100
 
   REPOSITORY = "Homebrew/brew"
   GITHUB_ACTIONS_URL = "https://github.com/apps/github-actions"
@@ -81,7 +85,7 @@ class StaleLeadMaintainerPrApproval
     lead_maintainers_line = File.read("README.md").each_line.find do |line|
       line.start_with?("Homebrew's [Lead Maintainers]")
     end
-    raise "Could not find lead maintainers in README.md." if lead_maintainers_line.blank?
+    raise "Could not find lead maintainers in README.md." if lead_maintainers_line.nil?
 
     lead_maintainers = T.let({}, T::Hash[String, T::Boolean])
     lead_maintainers_line.scan(%r{https://github\.com/([A-Za-z0-9-]+)}) do |login|
@@ -116,9 +120,9 @@ class StaleLeadMaintainerPrApproval
     end
 
     pull_requests = if @pull_request_number.empty?
-      paginated_rest("#{GitHub::API_URL}/repos/#{@repository}/pulls", "state=open&per_page=#{GitHub::MAX_PER_PAGE}")
+      paginated_rest("#{API_URL}/repos/#{@repository}/pulls", "state=open")
     else
-      [T.cast(rest("#{GitHub::API_URL}/repos/#{@repository}/pulls/#{Integer(@pull_request_number)}"), GitHubPayload)]
+      [T.cast(rest("#{API_URL}/repos/#{@repository}/pulls/#{Integer(@pull_request_number)}"), GitHubPayload)]
     end
     puts "Evaluating #{pull_requests.length} pull request(s)."
     facts = pull_requests.map { |pull_request| evaluate(pull_request, exhaustive: false) }
@@ -136,7 +140,7 @@ class StaleLeadMaintainerPrApproval
     approval_facts.each do |data|
       puts "Approving pull request ##{data.number}."
       rest(
-        "#{GitHub::API_URL}/repos/#{@repository}/pulls/#{data.number}/reviews",
+        "#{API_URL}/repos/#{@repository}/pulls/#{data.number}/reviews",
         data:           {
           event: "APPROVE",
           body:  <<~MARKDOWN,
@@ -164,7 +168,7 @@ class StaleLeadMaintainerPrApproval
   def report
     branch = ENV.fetch("GITHUB_REF_NAME", REPORT_BRANCH)
     query = URI.encode_www_form(state: "open", head: "Homebrew:#{branch}", per_page: 1)
-    pull_requests = T.cast(rest("#{GitHub::API_URL}/repos/#{@repository}/pulls?#{query}"), GitHubPayloads)
+    pull_requests = T.cast(rest("#{API_URL}/repos/#{@repository}/pulls?#{query}"), GitHubPayloads)
     raise "No open pull request found for branch #{branch}." if pull_requests.empty?
 
     data = evaluate(pull_requests.fetch(0), exhaustive: true)
@@ -262,8 +266,7 @@ class StaleLeadMaintainerPrApproval
         issues = T.cast(
           T.cast(
             rest(
-              "#{GitHub::API_URL}/search/issues?#{URI.encode_www_form(q: query, per_page: GitHub::MAX_PER_PAGE,
-                                                                      page:)}",
+              "#{API_URL}/search/issues?#{URI.encode_www_form(q: query, per_page: MAX_PER_PAGE, page:)}",
             ),
             GitHubPayload,
           ).fetch("items"),
@@ -271,7 +274,7 @@ class StaleLeadMaintainerPrApproval
         )
         @recent_approval_search_pages[data.author] = page
         @recent_approval_issues.fetch(data.author).concat(issues)
-        @recent_approval_search_complete[data.author] = true if issues.length < GitHub::MAX_PER_PAGE
+        @recent_approval_search_complete[data.author] = true if issues.length < MAX_PER_PAGE
       end
     end
     data.approved_another_pr_checked = true
@@ -319,12 +322,15 @@ class StaleLeadMaintainerPrApproval
       return finish(data, failures_for(data, include_ci: false))
     end
 
-    changed_files = paginated_rest("#{GitHub::API_URL}/repos/#{@repository}/pulls/#{data.number}/files")
+    changed_files = paginated_rest("#{API_URL}/repos/#{@repository}/pulls/#{data.number}/files")
     data.sensitive_files_checked = true
     data.changed_sensitive_files = changed_files.filter_map do |file|
       filename = T.cast(file.fetch("filename"), String)
+      # Homebrew's core extensions are not available in this standalone script.
+      # rubocop:disable Homebrew/NegateInclude
       next if SENSITIVE_PATH_PREFIXES.none? { |prefix| filename.start_with?(prefix) } &&
-              SENSITIVE_PATHS.exclude?(filename)
+              !SENSITIVE_PATHS.include?(filename)
+      # rubocop:enable Homebrew/NegateInclude
 
       filename
     end
@@ -334,11 +340,11 @@ class StaleLeadMaintainerPrApproval
                     failures_for(data, include_ci: false))
     end
 
-    check_runs = paginated_rest("#{GitHub::API_URL}/repos/#{@repository}/commits/#{data.head_sha}/check-runs")
+    check_runs = paginated_rest("#{API_URL}/repos/#{@repository}/commits/#{data.head_sha}/check-runs")
                  .flat_map do |page|
                    T.cast(page.fetch("check_runs"), GitHubPayloads)
                  end
-    commit_status = T.cast(rest("#{GitHub::API_URL}/repos/#{@repository}/commits/#{data.head_sha}/status"),
+    commit_status = T.cast(rest("#{API_URL}/repos/#{@repository}/commits/#{data.head_sha}/status"),
                            GitHubPayload)
     data.ci_checked = true
     data.failing_ci_jobs = check_runs.filter_map do |check_run|
@@ -382,15 +388,15 @@ class StaleLeadMaintainerPrApproval
     puts if @printed_pull_request_summary
     @printed_pull_request_summary = true
     result = if @event_name == "push"
-      data.should_approve ? Formatter.success("would approve") : Formatter.error("would not approve")
+      data.should_approve ? "would approve" : "would not approve"
     elsif data.should_approve
-      Formatter.success("will approve")
+      "will approve"
     else
-      Formatter.error("will not approve")
+      "will not approve"
     end
-    oh1 "Pull request ##{data.number}: #{data.title}"
+    puts "==> Pull request ##{data.number}: #{data.title}"
     puts "- Result: #{result}"
-    puts "- Author: #{Formatter.identifier("@#{data.author}")}"
+    puts "- Author: @#{data.author}"
     puts "- Not from a fork: #{status_label(data.not_from_fork)}"
     puts "- Not a draft: #{status_label(!data.draft)}"
     puts "- Weekday approval window: #{status_label(data.weekday_approval_window)}"
@@ -405,30 +411,30 @@ class StaleLeadMaintainerPrApproval
     if data.reviews_checked
       puts "- Human reviews since creation:"
       if data.human_reviews_since_creation.empty?
-        puts "  - #{Formatter.success("none")}"
+        puts "  - none"
       else
-        data.human_reviews_since_creation.each { |review| puts "  - #{Formatter.warning(review)}" }
+        data.human_reviews_since_creation.each { |review| puts "  - #{review}" }
       end
     else
-      puts "- Human reviews since creation: #{Formatter.warning("not checked")}"
+      puts "- Human reviews since creation: not checked"
     end
     puts "- Copilot reviewed: #{status_label(data.reviews_checked ? data.copilot_reviewed : nil)}"
     sensitive_files_unchanged = data.sensitive_files_checked ? data.sensitive_files_unchanged : nil
     puts "- .github/ and sensitive files unchanged: #{status_label(sensitive_files_unchanged)}"
     if data.sensitive_files_checked && !data.changed_sensitive_files.empty?
       puts "- Changed .github/ or sensitive files:"
-      data.changed_sensitive_files.each { |file| puts "  - #{Formatter.error(file)}" }
+      data.changed_sensitive_files.each { |file| puts "  - #{file}" }
     end
     puts "- CI passing: #{status_label(data.ci_checked ? data.ci_passing : nil)}"
     if data.ci_checked
       puts "- Failing CI jobs:"
       if data.failing_ci_jobs.empty?
-        puts "  - #{Formatter.success("none")}"
+        puts "  - none"
       else
-        data.failing_ci_jobs.each { |job| puts "  - #{Formatter.error(job)}" }
+        data.failing_ci_jobs.each { |job| puts "  - #{job}" }
       end
     else
-      puts "- Failing CI jobs: #{Formatter.warning("not checked")}"
+      puts "- Failing CI jobs: not checked"
     end
     already_approved = data.reviews_checked ? data.already_approved : nil
     puts "- Already approved by github-actions[bot] for this commit: #{status_label(already_approved)}"
@@ -438,9 +444,9 @@ class StaleLeadMaintainerPrApproval
 
   sig { params(value: T.nilable(T::Boolean)).returns(String) }
   def status_label(value)
-    return Formatter.warning("not checked") if value.nil?
+    return "not checked" if value.nil?
 
-    value ? Formatter.success("true") : Formatter.error("false")
+    value.to_s
   end
 
   sig { params(data: PullRequestFacts, include_ci: T::Boolean).returns(T::Array[String]) }
@@ -476,7 +482,7 @@ class StaleLeadMaintainerPrApproval
   sig { params(facts: T::Array[PullRequestFacts]).void }
   def summarise(facts)
     summary_path = ENV.fetch("GITHUB_STEP_SUMMARY", nil)
-    return if summary_path.blank?
+    return if summary_path.nil? || summary_path.match?(/\A[[:space:]]*\z/)
 
     File.open(summary_path, "a") do |summary|
       summary.puts "## Stale lead maintainer PR approval"
@@ -524,21 +530,18 @@ class StaleLeadMaintainerPrApproval
 
   sig { params(number: Integer).returns(GitHubPayloads) }
   def reviews_for(number)
-    @reviews[number] ||= paginated_rest("#{GitHub::API_URL}/repos/#{@repository}/pulls/#{number}/reviews")
+    @reviews[number] ||= paginated_rest("#{API_URL}/repos/#{@repository}/pulls/#{number}/reviews")
   end
 
   sig { params(url: T.any(String, URI::Generic), additional_query_params: String).returns(GitHubPayloads) }
   def paginated_rest(url, additional_query_params = "")
-    results = T.let([], GitHubPayloads)
-    GitHub::API.paginate_rest(url, additional_query_params:) do |result|
-      page = T.cast(result, GitHubPage)
-      if page.is_a?(Array)
-        results.concat(page)
-      else
-        results << page
-      end
+    pages = T.cast(
+      JSON.parse(gh_api("#{url}?per_page=#{MAX_PER_PAGE}&#{additional_query_params}", "--paginate", "--slurp")),
+      T::Array[GitHubPage],
+    )
+    pages.flat_map do |page|
+      page.is_a?(Array) ? page : [page]
     end
-    results
   end
 
   sig {
@@ -549,8 +552,21 @@ class StaleLeadMaintainerPrApproval
     ).returns(GitHubResult)
   }
   def rest(url, data: {}, request_method: :GET)
-    GitHub::API.open_rest(url, data:, request_method:)
+    T.cast(JSON.parse(gh_api(url.to_s, "--method", request_method.to_s, data:)), GitHubResult)
+  end
+
+  sig { params(args: String, data: RequestData).returns(String) }
+  def gh_api(*args, data: {})
+    args += ["--input", "-"] unless data.empty?
+    stdout, stderr, status = Open3.capture3("gh", "api", *args, stdin_data: JSON.generate(data))
+    # `Open3` tags output with the default external encoding, which is US-ASCII when
+    # the runner has no UTF-8 locale. `gh` always emits UTF-8.
+    stdout.force_encoding(Encoding::UTF_8)
+    stderr.force_encoding(Encoding::UTF_8)
+    raise "GitHub API request failed: #{stderr.strip}" unless status.success?
+
+    stdout
   end
 end
 
-StaleLeadMaintainerPrApproval.new.run
+StaleLeadMaintainerPrApproval.new.run if $PROGRAM_NAME == __FILE__

--- a/.github/workflows/approve-stale-lead-maintainer-prs.yml
+++ b/.github/workflows/approve-stale-lead-maintainer-prs.yml
@@ -16,9 +16,6 @@ on:
 
 permissions: {}
 
-env:
-  HOMEBREW_DEVELOPER: 1
-
 defaults:
   run:
     shell: bash -euo pipefail {0}
@@ -34,12 +31,21 @@ jobs:
       pull-requests: write
       statuses: read
     env:
-      HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ github.token }}
       PR_NUMBER: ${{ github.event.inputs.pull_request || '' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
+      - name: Set up Ruby
+        uses: Homebrew/actions/setup-ruby@3cdb78d0f62ad29dd32de765782654f4eedea607 # 2026.08.31.1
+        with:
+          setup-homebrew: true
+          portable-ruby: true
+          working-directory: Library/Homebrew
+
       - name: Evaluate stale lead maintainer PRs
-        run: ./bin/brew ruby -- .github/scripts/approve_stale_lead_maintainer_prs.rb
+        run: bundle exec ruby .github/scripts/approve_stale_lead_maintainer_prs.rb
+        env:
+          BUNDLE_GEMFILE: Library/Homebrew/Gemfile

--- a/Library/Homebrew/sorbet/config
+++ b/Library/Homebrew/sorbet/config
@@ -1,4 +1,5 @@
 --dir=.
+--dir=../../.github/scripts
 --enable-experimental-requires-ancestor
 --enable-experimental-rspec
 --ignore=/vendor/bundle

--- a/Library/Homebrew/test/stale_lead_maintainer_pr_approval_spec.rb
+++ b/Library/Homebrew/test/stale_lead_maintainer_pr_approval_spec.rb
@@ -1,0 +1,437 @@
+# typed: true
+# frozen_string_literal: true
+
+require "open3"
+require_relative "../../../.github/scripts/approve_stale_lead_maintainer_prs"
+
+RSpec.describe StaleLeadMaintainerPrApproval do
+  subject(:approval) { described_class.new }
+
+  let(:now) { Time.utc(2026, 9, 8, 12) }
+  let(:api_url) { "https://api.github.com/repos/Homebrew/brew" }
+  let(:report_query) { "state=open&head=Homebrew%3Aapprove-stale-lead-maintainer-prs&per_page=1" }
+  let(:event_name) { "schedule" }
+  let(:pr_number) { "" }
+  let(:approvals) { [] }
+  let(:pull_request) do
+    {
+      "number"     => 1,
+      "title"      => "Update a command",
+      "user"       => { "login" => "lead-maintainer" },
+      "created_at" => (now - (48 * 60 * 60)).iso8601,
+      "draft"      => false,
+      "head"       => { "sha" => "head-sha", "repo" => { "full_name" => "Homebrew/brew", "fork" => false } },
+    }
+  end
+  let(:reviews) do
+    [{ "user"         => { "login" => "copilot-pull-request-reviewer[bot]", "type" => "Bot" },
+       "state"        => "COMMENTED",
+       "submitted_at" => (now - 3600).iso8601,
+       "commit_id"    => "head-sha" }]
+  end
+  let(:other_reviews) do
+    [{ "user"         => { "login" => "lead-maintainer", "type" => "User" },
+       "state"        => "APPROVED",
+       "submitted_at" => (now - (7 * 24 * 60 * 60)).iso8601 }]
+  end
+  let(:search_pages) { { 1 => [{ "number" => 2 }] } }
+  let(:files) { [{ "filename" => "Library/Homebrew/cmd/example.rb" }] }
+  let(:check_runs) { [{ "name" => "tests", "status" => "completed", "conclusion" => "success" }] }
+  let(:statuses) { [] }
+  let(:responses) do
+    {
+      "#{api_url}/pulls?per_page=100&state=open"             => [[pull_request]],
+      "#{api_url}/pulls/1"                                   => pull_request,
+      "#{api_url}/pulls?#{report_query}"                     => [pull_request],
+      "#{api_url}/pulls/1/reviews?per_page=100&"             => [reviews],
+      "#{api_url}/pulls/2/reviews?per_page=100&"             => [other_reviews],
+      "#{api_url}/pulls/1/files?per_page=100&"               => [files],
+      "#{api_url}/commits/head-sha/check-runs?per_page=100&" => [{ "check_runs" => check_runs }],
+      "#{api_url}/commits/head-sha/status"                   => { "statuses" => statuses },
+    }
+  end
+
+  around do |example|
+    Dir.mktmpdir do |directory|
+      Dir.chdir(directory) do
+        File.write("README.md", "Homebrew's [Lead Maintainers] include [a maintainer](https://github.com/lead-maintainer).\n")
+        File.write("gh", <<~SH)
+          #!/bin/sh
+          printf '%s\\n' "$@" > "$GH_TEST_ARGS"
+          cat > "$GH_TEST_INPUT"
+          if [ -n "${GH_TEST_RESPONSES:-}" ]; then
+            exec "#{RbConfig.ruby}" -rjson -e \
+              'puts JSON.generate(JSON.parse(File.read(ARGV[0], encoding: Encoding::UTF_8)).fetch(ARGV[1]))' \
+              "$GH_TEST_RESPONSES" "$2"
+          fi
+          printf '%s' "$GH_TEST_RESPONSE"
+          printf '%s' "$GH_TEST_ERROR" >&2
+          exit "${GH_TEST_EXIT:-0}"
+        SH
+        File.chmod(0755, "gh")
+        ENV["PATH"] = "#{directory}:#{ENV.fetch("PATH")}"
+        ENV["GH_TEST_ARGS"] = File.join(directory, "args")
+        ENV["GH_TEST_INPUT"] = File.join(directory, "input")
+        ENV["GH_TEST_RESPONSE"] = "[[]]"
+        ENV["GH_TEST_ERROR"] = ""
+        ENV["GH_TEST_EXIT"] = "0"
+        ENV.delete("GH_TEST_RESPONSES")
+        example.run
+      end
+    end
+  end
+
+  before do
+    ENV["GITHUB_REPOSITORY"] = "Homebrew/brew"
+    ENV["GITHUB_SERVER_URL"] = "https://github.com"
+    ENV["GITHUB_EVENT_NAME"] = event_name
+    ENV["PR_NUMBER"] = pr_number
+    ENV.delete("GITHUB_STEP_SUMMARY")
+    ENV.delete("GITHUB_REF_NAME")
+    allow(Time).to receive(:now).and_return(now)
+    allow(approval).to receive(:puts)
+    allow(approval).to receive(:gh_api) do |url, *flags, data: {}|
+      if flags == ["--method", "POST"]
+        approvals << [url, data]
+        "{}"
+      elsif url.start_with?("https://api.github.com/search/issues?")
+        page = URI.decode_www_form(URI.parse(url).query.to_s).to_h.fetch("page")
+        JSON.generate("items" => search_pages.fetch(Integer(page)))
+      else
+        JSON.generate(responses.fetch(url))
+      end
+    end
+  end
+
+  it "loads independently of Homebrew without running approvals" do
+    stdout, stderr, status = Open3.capture3(
+      { "RUBYOPT" => nil, "RUBYLIB" => nil, "GITHUB_REPOSITORY" => nil },
+      RbConfig.ruby, "-I", "#{Gem.loaded_specs.fetch("sorbet-runtime").full_gem_path}/lib",
+      "-e", "require ARGV.fetch(0); puts defined?(Homebrew).inspect",
+      File.expand_path("../../../.github/scripts/approve_stale_lead_maintainer_prs.rb", __dir__)
+    )
+
+    expect([status.success?, stdout, stderr]).to eq([true, "nil\n", ""])
+  end
+
+  it "runs as a standalone Ruby script when there are no open PRs" do
+    stdout, stderr, status = Open3.capture3(
+      { "RUBYOPT" => nil, "RUBYLIB" => nil },
+      RbConfig.ruby, "-I", "#{Gem.loaded_specs.fetch("sorbet-runtime").full_gem_path}/lib",
+      File.expand_path("../../../.github/scripts/approve_stale_lead_maintainer_prs.rb", __dir__)
+    )
+
+    expect([status.success?, stdout, stderr])
+      .to eq([true, "Evaluating 0 pull request(s).\nApproving 0 pull request(s).\n", ""])
+  end
+
+  it "approves an eligible PR at the age and recent-approval boundaries" do
+    approval.run
+
+    expect(approvals).to contain_exactly(
+      ["#{api_url}/pulls/1/reviews", hash_including(event: "APPROVE", body: include("PR [#2]"))],
+    )
+  end
+
+  it "runs the complete approval path under standalone Ruby" do
+    query = URI.encode_www_form(
+      q:        "repo:Homebrew/brew is:pr reviewed-by:lead-maintainer review:approved updated:>=2026-09-01",
+      per_page: 100,
+      page:     1,
+    )
+    responses["https://api.github.com/search/issues?#{query}"] = { "items" => search_pages.fetch(1) }
+    responses["#{api_url}/pulls/1/reviews"] = {}
+    File.write("responses.json", JSON.generate(responses))
+    ENV["GH_TEST_RESPONSES"] = File.expand_path("responses.json")
+    File.write("clock.rb", "def Time.now = Time.at(#{now.to_i}).utc\n")
+    stdout, stderr, status = Open3.capture3(
+      { "RUBYOPT" => nil, "RUBYLIB" => nil },
+      RbConfig.ruby, "-I", "#{Gem.loaded_specs.fetch("sorbet-runtime").full_gem_path}/lib",
+      "-r", "./clock.rb", File.expand_path("../../../.github/scripts/approve_stale_lead_maintainer_prs.rb", __dir__)
+    )
+
+    expect([status.success?, stdout, stderr, JSON.parse(File.read(ENV.fetch("GH_TEST_INPUT")))])
+      .to match([true, include("Approved pull request #1."), "", hash_including("event" => "APPROVE")])
+  end
+
+  it "parses non-ASCII API responses without a UTF-8 locale" do
+    pull_request["title"] = "Update a command \u{1F37A}"
+    query = URI.encode_www_form(
+      q:        "repo:Homebrew/brew is:pr reviewed-by:lead-maintainer review:approved updated:>=2026-09-01",
+      per_page: 100,
+      page:     1,
+    )
+    responses["https://api.github.com/search/issues?#{query}"] = { "items" => search_pages.fetch(1) }
+    responses["#{api_url}/pulls/1/reviews"] = {}
+    File.write("responses.json", JSON.generate(responses))
+    File.write("clock.rb", "def Time.now = Time.at(#{now.to_i}).utc\n")
+    stdout, stderr, status = Open3.capture3(
+      { "RUBYOPT" => nil, "RUBYLIB" => nil, "LC_ALL" => "C", "LANG" => "C",
+        "GH_TEST_RESPONSES" => File.expand_path("responses.json") },
+      RbConfig.ruby, "-I", "#{Gem.loaded_specs.fetch("sorbet-runtime").full_gem_path}/lib",
+      "-r", "./clock.rb", File.expand_path("../../../.github/scripts/approve_stale_lead_maintainer_prs.rb", __dir__)
+    )
+
+    expect([status.success?, stdout, stderr]).to match([true, include("\u{1F37A}"), ""])
+  end
+
+  it "reports a non-ASCII API error without a UTF-8 locale" do
+    stdout, stderr, status = Open3.capture3(
+      { "RUBYOPT" => nil, "RUBYLIB" => nil, "LC_ALL" => "C", "LANG" => "C",
+        "GH_TEST_ERROR" => "gh: not found \u{1F37A}", "GH_TEST_EXIT" => "1" },
+      RbConfig.ruby, "-I", "#{Gem.loaded_specs.fetch("sorbet-runtime").full_gem_path}/lib",
+      File.expand_path("../../../.github/scripts/approve_stale_lead_maintainer_prs.rb", __dir__)
+    )
+
+    expect([status.success?, stdout, stderr])
+      .to match([false, "", include("GitHub API request failed: gh: not found \u{1F37A}")])
+  end
+
+  it "rejects a draft" do
+    pull_request["draft"] = true
+    approval.run
+
+    expect(approvals).to be_empty
+  end
+
+  it "rejects a fork" do
+    pull_request["head"]["repo"]["fork"] = true
+    approval.run
+
+    expect(approvals).to be_empty
+  end
+
+  it "rejects a different head repository" do
+    pull_request["head"]["repo"]["full_name"] = "someone/brew"
+    approval.run
+
+    expect(approvals).to be_empty
+  end
+
+  it "rejects an author who is not a lead maintainer" do
+    pull_request["user"]["login"] = "contributor"
+    approval.run
+
+    expect(approvals).to be_empty
+  end
+
+  it "rejects a PR younger than 48 hours" do
+    pull_request["created_at"] = (now - (48 * 60 * 60) + 1).iso8601
+    approval.run
+
+    expect(approvals).to be_empty
+  end
+
+  it "rejects a recent approval older than seven days" do
+    other_reviews.first["submitted_at"] = (now - (7 * 24 * 60 * 60) - 1).iso8601
+    approval.run
+
+    expect(approvals).to be_empty
+  end
+
+  it "does not count an approval of the candidate PR itself" do
+    search_pages[1] = [{ "number" => 1 }]
+    approval.run
+
+    expect(approvals).to be_empty
+  end
+
+  it "checks later search pages for a qualifying approval" do
+    search_pages[1] = Array.new(100) { { "number" => 1 } }
+    search_pages[2] = [{ "number" => 2 }]
+    approval.run
+
+    expect(approvals.length).to eq(1)
+  end
+
+  it "rejects a PR with a human review" do
+    reviews << reviews.first.merge("user" => { "login" => "reviewer", "type" => "User" })
+    approval.run
+
+    expect(approvals).to be_empty
+  end
+
+  it "requires a Copilot bot review" do
+    reviews.clear
+    approval.run
+
+    expect(approvals).to be_empty
+  end
+
+  it "does not approve the same commit twice" do
+    reviews << reviews.first.merge("user"  => { "login" => "github-actions[bot]", "type" => "Bot" },
+                                   "state" => "APPROVED")
+    approval.run
+
+    expect(approvals).to be_empty
+  end
+
+  it "can approve a new commit after an earlier bot approval" do
+    reviews << reviews.first.merge("user" => { "login" => "github-actions[bot]", "type" => "Bot" },
+                                   "state" => "APPROVED", "commit_id" => "old-head")
+    approval.run
+
+    expect(approvals.length).to eq(1)
+  end
+
+  it "rejects a change to its own script" do
+    files << { "filename" => ".github/scripts/approve_stale_lead_maintainer_prs.rb" }
+    approval.run
+
+    expect(approvals).to be_empty
+  end
+
+  it "rejects a change to the lead maintainer list" do
+    files << { "filename" => "README.md" }
+    approval.run
+
+    expect(approvals).to be_empty
+  end
+
+  it "preserves the existing exclusion for the GitHub helper" do
+    files << { "filename" => "Library/Homebrew/utils/github.rb" }
+    approval.run
+
+    expect(approvals).to be_empty
+  end
+
+  it "rejects a failing non-required check" do
+    check_runs << { "name" => "optional", "status" => "completed", "conclusion" => "failure" }
+    approval.run
+
+    expect(approvals).to be_empty
+  end
+
+  it "rejects an unfinished check" do
+    check_runs.first["status"] = "in_progress"
+    check_runs.first["conclusion"] = nil
+    approval.run
+
+    expect(approvals).to be_empty
+  end
+
+  it "requires at least one check run" do
+    check_runs.clear
+    approval.run
+
+    expect(approvals).to be_empty
+  end
+
+  it "accepts neutral and skipped checks" do
+    check_runs.push(
+      { "name" => "neutral", "status" => "completed", "conclusion" => "neutral" },
+      { "name" => "skipped", "status" => "completed", "conclusion" => "skipped" },
+    )
+    approval.run
+
+    expect(approvals.length).to eq(1)
+  end
+
+  it "rejects a failing commit status" do
+    statuses << { "context" => "external CI", "state" => "failure" }
+    approval.run
+
+    expect(approvals).to be_empty
+  end
+
+  context "when triggered by a push" do
+    let(:event_name) { "push" }
+
+    it "reports eligibility without approving" do
+      approval.run
+
+      expect(approvals).to be_empty
+    end
+  end
+
+  context "when triggered manually" do
+    let(:event_name) { "workflow_dispatch" }
+    let(:pr_number) { "1" }
+
+    it "fails a request for an ineligible PR" do
+      pull_request["draft"] = true
+
+      status = begin
+        approval.run
+      rescue SystemExit => e
+        e.status
+      end
+
+      expect(status).to eq(1)
+    end
+
+    it "approves an eligible requested PR" do
+      approval.run
+
+      expect(approvals.length).to eq(1)
+    end
+  end
+
+  it "writes the approval result to the step summary" do
+    ENV["GITHUB_STEP_SUMMARY"] = "summary.md"
+    approval.run
+
+    expect(File.read("summary.md")).to include("- Approved by this run: true")
+  end
+
+  context "when running on a weekend" do
+    let(:now) { Time.utc(2026, 9, 12, 12) }
+
+    it "does not approve" do
+      approval.run
+
+      expect(approvals).to be_empty
+    end
+  end
+
+  describe "GitHub API requests" do
+    before do
+      described_class.class_eval { public :rest, :paginated_rest }
+      allow(approval).to receive(:gh_api).and_call_original
+    end
+
+    it "combines array pages returned by gh" do
+      ENV["GH_TEST_RESPONSE"] = '[[{"number":1}],[{"number":2}]]'
+
+      expect(approval.paginated_rest("#{api_url}/pulls")).to eq([{ "number" => 1 }, { "number" => 2 }])
+    end
+
+    it "preserves object pages for check runs" do
+      ENV["GH_TEST_RESPONSE"] = '[{"check_runs":[{"name":"first"}]},{"check_runs":[{"name":"second"}]}]'
+
+      expect(approval.paginated_rest("#{api_url}/commits/head-sha/check-runs"))
+        .to eq([{ "check_runs" => [{ "name" => "first" }] }, { "check_runs" => [{ "name" => "second" }] }])
+    end
+
+    it "requests all pages with the existing query parameters" do
+      approval.paginated_rest("#{api_url}/pulls", "state=open")
+
+      expect(File.readlines(ENV.fetch("GH_TEST_ARGS"), chomp: true))
+        .to eq(["api", "#{api_url}/pulls?per_page=100&state=open", "--paginate", "--slurp"])
+    end
+
+    it "sends approval bodies as JSON on stdin" do
+      ENV["GH_TEST_RESPONSE"] = "{}"
+      body = "Approval with quotes, a newline\nand literal $(text) and `text`."
+      approval.rest("#{api_url}/pulls/1/reviews", data: { event: "APPROVE", body: }, request_method: :POST)
+
+      expect([File.readlines(ENV.fetch("GH_TEST_ARGS"), chomp: true),
+              JSON.parse(File.read(ENV.fetch("GH_TEST_INPUT")))])
+        .to eq([["api", "#{api_url}/pulls/1/reviews", "--method", "POST", "--input", "-"],
+                { "event" => "APPROVE", "body" => body }])
+    end
+
+    it "stops on an API failure even if stdout contains valid JSON" do
+      ENV["GH_TEST_EXIT"] = "1"
+      ENV["GH_TEST_ERROR"] = "permission denied"
+
+      expect { approval.run }.to raise_error(RuntimeError, "GitHub API request failed: permission denied")
+    end
+
+    it "stops on invalid JSON" do
+      ENV["GH_TEST_RESPONSE"] = "invalid"
+
+      expect { approval.run }.to raise_error(JSON::ParserError)
+    end
+  end
+end


### PR DESCRIPTION
This was the last executable `brew ruby` invocation in our repositories. The script now runs under standalone Ruby with `gh api`, so it no longer depends on `brew`'s internals or on developer mode being enabled. The eligibility rules and the approval script itself are unchanged, and Copilot's permissions are untouched.

`Open3` tags subprocess output with the default external encoding, which is US-ASCII when the runner has no UTF-8 locale, so `gh` output is forced to UTF-8 before it is parsed. Without that, a 🍺 in a pull request title fails `JSON.parse` and a non-ASCII error message fails `String#strip`.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the port and its 37 tests; I reviewed the diff, reproduced both locale failures against live API data before fixing them, verified the new tests fail without the fix and pass with it, and ran `brew lgtm --online`, `actionlint` and `zizmor`.

-----
