### PR TITLE
curl_download_strategy: fix caching edgecase

### DIFF
--- a/Library/Homebrew/download_strategy/curl_download_strategy.rb
+++ b/Library/Homebrew/download_strategy/curl_download_strategy.rb
@@ -249,30 +249,25 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
       [*parse_content_disposition.call("Content-Disposition: #{header}")]
     end
 
-    time =  parsed_headers
-            .flat_map { |headers| [*headers["last-modified"]] }
-            .filter_map do |t|
-              t.match?(/^\d+$/) ? Time.at(t.to_i) : Time.parse(t)
-            rescue ArgumentError # When `Time.parse` gets a badly formatted date.
-              nil
-            end
+    final_headers = parsed_headers.last || {}
 
-    file_size = parsed_headers
-                .flat_map { |headers| [*headers["content-length"]&.to_i] }
-                .last
+    time = [*final_headers["last-modified"]].filter_map do |t|
+      t.match?(/^\d+$/) ? Time.at(t.to_i) : Time.parse(t)
+    rescue ArgumentError # When `Time.parse` gets a badly formatted date.
+      nil
+    end
+
+    file_size = [*final_headers["content-length"]].last&.to_i
 
     # Fallback to content-range header if content-length is not available.
     # Content-Range format: "bytes start-end/total" or "bytes */total" or "bytes start-end/*"
     if file_size.nil? || file_size.zero?
-      file_size = parsed_headers
-                  .flat_map { |headers| [*headers["content-range"]] }
+      file_size = [*final_headers["content-range"]]
                   .filter_map { |range| Integer(range.split("/").last, 10, exception: false) }
                   .last
     end
 
-    content_type = parsed_headers
-                   .flat_map { |headers| [*headers["content-type"]] }
-                   .last
+    content_type = [*final_headers["content-type"]].last
 
     is_redirection = url != final_url
     basename = filenames.last || parse_basename(final_url, search_query: !is_redirection)

--- a/Library/Homebrew/test/download_strategies/curl_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_spec.rb
@@ -18,9 +18,11 @@ RSpec.describe CurlDownloadStrategy do
     }
   end
 
+  let(:responses) { [{ headers: }] }
+
   before do
     allow(strategy).to receive(:curl_headers).with(any_args)
-                                             .and_return({ responses: [{ headers: }] })
+                                             .and_return({ responses: })
   end
 
   it "parses the opts and sets the corresponding args" do
@@ -228,6 +230,53 @@ RSpec.describe CurlDownloadStrategy do
         end.at_least(:once)
 
         strategy.fetch
+      end
+    end
+
+    context "with an HTML redirect before the downloaded file" do
+      let(:final_headers) { headers }
+      let(:responses) do
+        [
+          { headers: { "content-type"   => "text/html; charset=UTF-8",
+                       "content-length" => "100",
+                       "location"       => "https://example.com/media/foo.tar.gz" } },
+          { headers: final_headers },
+        ]
+      end
+
+      before do
+        allow(strategy).to receive(:curl)
+
+        strategy.cached_location.dirname.mkpath
+        strategy.cached_location.write("cached")
+      end
+
+      it "ignores a cached download of a different size" do
+        expect { strategy.fetch }.to output(/differs from Content-Length header: 37182/).to_stdout
+      end
+
+      context "when the file is newer than the cached download" do
+        let(:final_headers) { { "last-modified" => (Time.now + 3600).httpdate } }
+
+        it "ignores the cached download" do
+          expect { strategy.fetch }.to output(/is before Last-Modified header/).to_stdout
+        end
+      end
+
+      context "when the redirect ends on a web page" do
+        let(:final_headers) { headers.merge("content-type" => "text/html; charset=UTF-8") }
+
+        it "keeps the cached download" do
+          expect { strategy.fetch }.to output(/Already downloaded/).to_stdout
+        end
+      end
+
+      context "when the file is sent without a size or a modification time" do
+        let(:final_headers) { { "transfer-encoding" => "chunked" } }
+
+        it "keeps the cached download" do
+          expect { strategy.fetch }.to output(/Already downloaded/).to_stdout
+        end
       end
     end
 


### PR DESCRIPTION
- a redirect's `text/html` prevented the `last-modified` and `content-length` checks when the final response had no content-type

Resolves https://github.com/orgs/Homebrew/discussions/7045

-----

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://gitxub.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Claude with Opus 5 at High effort, with local review and testing.