### PR TITLE
Maintain bottle coverage during macOS bootstrap

### DIFF
--- a/Library/Homebrew/bottle_transition.rb
+++ b/Library/Homebrew/bottle_transition.rb
@@ -1,0 +1,78 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "formula"
+require "formulary"
+require "test_runner_formula"
+
+# Preserve bottles while bootstrapping a macOS release.
+# TODO: remove this class and its callers when `HOMEBREW_MACOS_NEWEST_SUPPORTED` is `27`.
+class BottleTransition
+  MACOS = :golden_gate
+
+  sig { returns(Utils::Bottles::Tag) }
+  def self.tag
+    Utils::Bottles::Tag.new(system: MACOS, arch: :arm64)
+  end
+
+  sig { returns(T::Boolean) }
+  def self.active?
+    MacOSVersion.from_symbol(MACOS) > HOMEBREW_MACOS_NEWEST_SUPPORTED
+  end
+
+  sig { params(base_ref: T.nilable(String)).void }
+  def initialize(base_ref: nil)
+    if ENV.fetch("GITHUB_EVENT_NAME", nil) == "merge_group"
+      event = JSON.parse(File.read(ENV.fetch("GITHUB_EVENT_PATH")))
+      base_ref = event.dig("merge_group", "base_sha")
+      if !base_ref.is_a?(String) || !/\A[0-9a-f]{40}\z/.match?(base_ref)
+        raise UsageError, "Missing immutable merge-group base SHA."
+      end
+    end
+    base_branch = ENV.fetch("GITHUB_BASE_REF", nil).presence
+    @base_ref = T.let(base_ref || (base_branch ? "origin/#{base_branch}" : "origin/HEAD"), String)
+    @base_revision = T.let(nil, T.nilable(String))
+    @required = T.let({}, T::Hash[String, T::Boolean])
+  end
+
+  sig { params(formula: Formula).returns(T::Boolean) }
+  def required?(formula)
+    return false unless self.class.active?
+    return false unless formula.tap&.core_tap?
+    return false if formula.disabled?
+
+    compatible = Homebrew::SimulateSystem.with(os: MACOS, arch: :arm) do
+      candidate = TestRunnerFormula.new(Formulary.factory(formula.path))
+      candidate.compatible?(platform: :macos, arch: :arm64, macos_version: MacOSVersion.from_symbol(MACOS))
+    end
+    return false unless compatible
+
+    @required.fetch(formula.name) do
+      repository = CoreTap.instance.path
+      @base_revision ||= Utils.safe_popen_read("git", "-C", repository, "rev-parse", "--verify",
+                                               "#{@base_ref}^{commit}").strip
+      path = formula.tap_path.relative_path_from(repository)
+      files = Utils.safe_popen_read("git", "-C", repository, "ls-tree", "--name-only", "-z",
+                                    @base_revision, "--", path)
+      return @required[formula.name] = false if files.empty?
+
+      contents = Utils.safe_popen_read("git", "-C", repository, "show", "#{@base_revision}:#{path}")
+      @required[formula.name] = Homebrew::SimulateSystem.with(os: MACOS, arch: :arm) do
+        previous = Formulary.from_contents(formula.name, formula.tap_path, contents)
+        previous.bottle_specification.collector.tags.include?(self.class.tag)
+      end
+    end
+  end
+
+  sig { params(formula: Formula, tags: T::Array[Utils::Bottles::Tag]).void }
+  def check!(formula, tags:)
+    return unless required?(formula)
+    return if tags.include?(self.class.tag) || tags.include?(Utils::Bottles.tag(:all))
+
+    raise UsageError, <<~EOS
+      #{formula.full_name} already has #{self.class.tag} bottle coverage on #{@base_ref}.
+      Build an #{self.class.tag} bottle for #{formula.pkg_version} before publishing or merging.
+      Re-run CI against the updated base branch if mass bottling finished after CI started.
+    EOS
+  end
+end

--- a/Library/Homebrew/dev-cmd/pr-upload.rb
+++ b/Library/Homebrew/dev-cmd/pr-upload.rb
@@ -8,6 +8,7 @@ require "formula"
 require "github_packages"
 require "github_releases"
 require "extend/hash/deep_merge"
+require "bottle_transition"
 
 module Homebrew
   module DevCmd
@@ -108,6 +109,8 @@ module Homebrew
           end
         end
 
+        check_transition_bottles!(bottles_hash)
+
         if github_releases?(bottles_hash)
           github_releases = GitHubReleases.new
           github_releases.upload_bottles(bottles_hash)
@@ -123,6 +126,43 @@ module Homebrew
       end
 
       private
+
+      sig { params(bottles_hash: T::Hash[String, T.untyped]).void }
+      def check_transition_bottles!(bottles_hash)
+        # Reload the bottle block written by `brew bottle --merge`.
+        Formulary.clear_cache
+        transition = BottleTransition.new
+        bottles_hash.each_value do |bottle_hash|
+          formula_path = HOMEBREW_REPOSITORY/bottle_hash.fetch("formula").fetch("path")
+          formula = Formulary.factory(formula_path)
+          next unless transition.required?(formula)
+
+          spec = formula.bottle_specification
+          transition.check!(formula, tags: spec.collector.tags)
+          bottle = bottle_hash.fetch("bottle")
+          tags = bottle.fetch("tags").keys.map { |tag| Utils::Bottles.tag(tag.to_sym) }
+          if !args.keep_old? && tags.exclude?(BottleTransition.tag) && tags.exclude?(Utils::Bottles.tag(:all))
+            raise UsageError, <<~EOS
+              #{formula.full_name} #{formula.pkg_version}: upload set is missing
+              #{BottleTransition.tag} or `all` bottle artifacts.
+              Restore the matching bottle artifacts and JSON files before retrying.
+            EOS
+          end
+
+          root_url = bottle.fetch("root_url")
+          metadata_matches = bottle_hash.fetch("formula").fetch("pkg_version") == formula.pkg_version.to_s &&
+                             bottle.fetch("rebuild", 0).to_i == spec.rebuild &&
+                             (GitHubPackages.root_url_if_match(root_url) || root_url) == spec.root_url &&
+                             bottle.fetch("tags").all? do |tag, tag_hash|
+                               tag_spec = spec.collector.specification_for(Utils::Bottles.tag(tag.to_sym),
+                                                                           no_older_versions: true)
+                               tag_spec && tag_spec.checksum.hexdigest == tag_hash.fetch("sha256")
+                             end
+          next if metadata_matches
+
+          raise UsageError, "#{formula.full_name}: bottle metadata does not match the committed formula."
+        end
+      end
 
       sig { params(bottles_hash: T::Hash[String, T.untyped]).void }
       def check_bottled_formulae!(bottles_hash)
@@ -159,7 +199,20 @@ module Homebrew
         puts "Reading JSON files: #{json_files.join(", ")}" if args.verbose?
 
         bottles_hash = json_files.reduce({}) do |hash, json_file|
-          hash.deep_merge(JSON.parse(File.read(json_file)))
+          incoming = JSON.parse(File.read(json_file))
+          incoming.each do |name, bottle_hash|
+            bottle = bottle_hash.fetch("bottle")
+            bottle["root_url"] = GitHubPackages.root_url_if_match(bottle["root_url"]) || bottle["root_url"]
+            previous = hash[name]
+            next unless previous
+            next if previous.fetch("formula").slice("path", "pkg_version") ==
+                    bottle_hash.fetch("formula").slice("path", "pkg_version") &&
+                    previous.fetch("bottle").slice("root_url", "rebuild") ==
+                    bottle_hash.fetch("bottle").slice("root_url", "rebuild")
+
+            raise UsageError, "Inconsistent bottle metadata for #{name} in #{json_file}."
+          end
+          hash.deep_merge(incoming)
         end
 
         if args.root_url

--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -3,8 +3,12 @@
 
 require "test_runner_formula"
 require "github_runner"
+require "bottle_transition"
+require "utils/output"
 
 class GitHubRunnerMatrix
+  include Utils::Output::Mixin
+
   # When bumping newest runner, run e.g. `git log -p --reverse -G "sha256 tahoe"`
   # on homebrew/core and tag the first commit with a bottle e.g.
   # `git tag 15-sequoia f42c4a659e4da887fc714f8f41cc26794a4bb320`
@@ -209,7 +213,77 @@ class GitHubRunnerMatrix
 
   sig { params(macos_version: MacOSVersion).returns(T::Boolean) }
   def runner_enabled?(macos_version)
-    macos_version.between?(OLDEST_HOMEBREW_CORE_MACOS_RUNNER, NEWEST_HOMEBREW_CORE_MACOS_RUNNER)
+    return true if macos_version.between?(OLDEST_HOMEBREW_CORE_MACOS_RUNNER, NEWEST_HOMEBREW_CORE_MACOS_RUNNER)
+    return false if @all_supported || @dependent_matrix
+
+    macos_version.to_sym == BottleTransition::MACOS && transition_formulae.present?
+  end
+
+  sig { returns(T::Array[TestRunnerFormula]) }
+  def transition_formulae
+    @transition_formulae ||= T.let(begin
+      transition = BottleTransition.new
+      covered = @testing_formulae.select { |formula| transition.required?(formula.formula) }
+      needed_names = []
+      testing_names = @testing_formulae.map(&:name)
+
+      Homebrew::SimulateSystem.with(os: BottleTransition::MACOS, arch: :arm) do
+        covered.each do |formula|
+          dependencies = Formulary.factory(formula.name).recursive_dependencies do |dependent, dependency|
+            next Dependable::PRUNE if dependency.optional?
+
+            if dependency.test? && !dependency.build? && testing_names.exclude?(dependency.name) &&
+               transition_test_dependency_bottled?(dependency.to_formula)
+              next Dependable::PRUNE
+            end
+            if dependency.is_a?(UsesFromMacOSDependency) && dependency.use_macos_install?
+              next Dependable::PRUNE
+            end
+            next unless dependent.is_a?(Formula)
+            next unless dependency.build?
+            next if testing_names.include?(dependent.name)
+
+            Dependable::PRUNE unless dependent.bottle_specification.tag?(Utils::Bottles.tag(:all))
+          end
+          missing = dependencies.reject do |dependency|
+            dependency_formula = dependency.to_formula
+            if testing_names.include?(dependency.name)
+              candidate = TestRunnerFormula.new(dependency_formula)
+              candidate.compatible?(platform: :macos, arch: :arm64,
+                                    macos_version: BottleTransition.tag.to_macos_version)
+            else
+              dependency_formula.bottle_specification.tag?(BottleTransition.tag, no_older_versions: true)
+            end
+          end
+          if missing.present?
+            opoo <<~EOS
+              Skipping #{formula.name}'s #{BottleTransition.tag} build: unavailable dependencies: #{missing.map(&:name).join(", ")}.
+              Resolve these dependencies and retry CI before publishing.
+            EOS
+            next
+          end
+
+          needed_names << formula.name
+          needed_names.concat(dependencies.map(&:name) & testing_names)
+        end
+      end
+
+      @testing_formulae.select { |formula| needed_names.include?(formula.name) }
+    end, T.nilable(T::Array[TestRunnerFormula]))
+  end
+
+  sig { params(formula: Formula).returns(T::Boolean) }
+  def transition_test_dependency_bottled?(formula)
+    spec = formula.bottle_specification
+    if spec.tag?(Utils::Bottles.tag(:all))
+      return formula.deps.all? { |dependency| transition_test_dependency_bottled?(dependency.to_formula) }
+    end
+
+    # Runner selection also runs on Linux, without macOS bottle fallback.
+    spec.collector.tags.any? do |tag|
+      tag.macos? && tag.standardized_arch == BottleTransition.tag.standardized_arch &&
+        tag.to_macos_version <= BottleTransition.tag.to_macos_version
+    end
   end
 
   sig { returns(String) }
@@ -254,13 +328,14 @@ class GitHubRunnerMatrix
       arch = runner.arch
       macos_version = runner.macos_version
 
-      @testing_formulae.select do |formula|
-        Homebrew::SimulateSystem.with(os: platform, arch: Homebrew::SimulateSystem.arch_symbols.fetch(arch)) do
-          simulated_formula = TestRunnerFormula.new(Formulary.factory(formula.name))
-          next false if macos_version && !simulated_formula.compatible_with?(macos_version)
+      transition_runner = BottleTransition.active? && macos_version&.to_sym == BottleTransition::MACOS
+      testing_formulae = transition_runner ? transition_formulae : @testing_formulae
+      os = transition_runner ? BottleTransition::MACOS : platform
 
-          simulated_formula.public_send(:"#{platform}_compatible?") &&
-            simulated_formula.public_send(:"#{arch}_compatible?")
+      testing_formulae.select do |formula|
+        Homebrew::SimulateSystem.with(os:, arch: Homebrew::SimulateSystem.arch_symbols.fetch(arch)) do
+          simulated_formula = TestRunnerFormula.new(Formulary.factory(formula.name))
+          simulated_formula.compatible?(platform:, arch:, macos_version:)
         end
       end
     end
@@ -278,10 +353,7 @@ class GitHubRunnerMatrix
                                        .select do |dependent_f|
           Homebrew::SimulateSystem.with(os: platform, arch: Homebrew::SimulateSystem.arch_symbols.fetch(arch)) do
             simulated_dependent_f = dependent_f
-            next false if macos_version && !simulated_dependent_f.compatible_with?(macos_version)
-
-            simulated_dependent_f.public_send(:"#{platform}_compatible?") &&
-              simulated_dependent_f.public_send(:"#{arch}_compatible?") &&
+            simulated_dependent_f.compatible?(platform:, arch:, macos_version:) &&
               !simulated_dependent_f.formula.disabled? &&
               !simulated_dependent_f.formula.deprecated?
           end

--- a/Library/Homebrew/test/bottle_transition_spec.rb
+++ b/Library/Homebrew/test/bottle_transition_spec.rb
@@ -1,0 +1,207 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "bottle_transition"
+
+RSpec.describe BottleTransition do
+  sig { returns(BottleTransition) }
+  subject(:transition) { described_class.new }
+
+  sig { returns(String) }
+  def current_contents
+    <<~RUBY
+      class TransitionTest < Formula
+        url "https://brew.sh/transition-test-2.0.tar.gz"
+      end
+    RUBY
+  end
+  sig { returns(Formula) }
+  let(:current) do
+    path = CoreTap.instance.path/"Formula/t/transition-test.rb"
+    path.dirname.mkpath
+    path.write(current_contents)
+    Homebrew::SimulateSystem.with(os: :linux, arch: :intel) { Formulary.factory(path) }
+  end
+
+  sig { returns(String) }
+  def base_revision
+    "a" * 40
+  end
+
+  sig { returns(String) }
+  def base_contents
+    <<~RUBY
+      class TransitionTest < Formula
+        url "https://brew.sh/transition-test-1.0.tar.gz"
+        bottle do
+          sha256 arm64_golden_gate: "#{"b" * 64}"
+        end
+      end
+    RUBY
+  end
+
+  before do
+    stub_const("HOMEBREW_MACOS_NEWEST_SUPPORTED", "26")
+    ENV.delete("GITHUB_BASE_REF")
+    ENV.delete("GITHUB_EVENT_NAME")
+    allow(Utils).to receive(:safe_popen_read).and_call_original
+    allow(Utils).to receive(:safe_popen_read)
+      .with("git", "-C", CoreTap.instance.path, "rev-parse", "--verify", "origin/HEAD^{commit}")
+      .and_return("#{base_revision}\n")
+    allow(Utils).to receive(:safe_popen_read)
+      .with("git", "-C", CoreTap.instance.path, "ls-tree", "--name-only", "-z", base_revision,
+            "--", current.tap_path.relative_path_from(CoreTap.instance.path))
+      .and_return("#{current.tap_path.relative_path_from(CoreTap.instance.path)}\0")
+    allow(Utils).to receive(:safe_popen_read)
+      .with("git", "-C", CoreTap.instance.path, "show",
+            "#{base_revision}:#{current.tap_path.relative_path_from(CoreTap.instance.path)}")
+      .and_return(base_contents)
+  end
+
+  it "uses base-branch coverage even when the new version has no bottle block" do
+    expect(transition.required?(current)).to be true
+  end
+
+  it "does not enrol a formula with only older macOS bottles" do
+    allow(Utils).to receive(:safe_popen_read)
+      .with("git", "-C", CoreTap.instance.path, "show",
+            "#{base_revision}:#{current.tap_path.relative_path_from(CoreTap.instance.path)}")
+      .and_return(base_contents.sub("arm64_golden_gate", "arm64_tahoe"))
+
+    expect(transition.required?(current)).to be false
+  end
+
+  it "rejects publication that drops transition coverage" do
+    expect do
+      transition.check!(current, tags: [Utils::Bottles.tag(:arm64_tahoe)])
+    end.to raise_error(UsageError, /Build an arm64_golden_gate bottle for 2.0/)
+  end
+
+  it "accepts an all bottle as replacement coverage" do
+    expect { transition.check!(current, tags: [Utils::Bottles.tag(:all)]) }.not_to raise_error
+  end
+
+  context "when the base has a universal bottle" do
+    it "does not enrol universal bottles in transition CI" do
+      allow(Utils).to receive(:safe_popen_read)
+        .with("git", "-C", CoreTap.instance.path, "show",
+              "#{base_revision}:#{current.tap_path.relative_path_from(CoreTap.instance.path)}")
+        .and_return(base_contents.sub("arm64_golden_gate", "all"))
+
+      expect(transition.required?(current)).to be false
+    end
+  end
+
+  context "when a formula no longer supports macOS" do
+    sig { returns(String) }
+    def current_contents
+      super.sub("class TransitionTest < Formula", "class TransitionTest < Formula\n  depends_on :linux")
+    end
+
+    it "allows its macOS coverage to be retired" do
+      expect(transition.required?(current)).to be false
+    end
+  end
+
+  context "when a requirement exists only on macOS" do
+    sig { returns(String) }
+    def current_contents
+      super.sub("class TransitionTest < Formula", <<~RUBY)
+        class TransitionTest < Formula
+          on_macos do
+            depends_on maximum_macos: :tahoe
+          end
+      RUBY
+    end
+
+    it "checks Golden Gate compatibility even when called on Linux" do
+      expect(transition.required?(current)).to be false
+    end
+  end
+
+  context "when a pull request targets a topic branch" do
+    it "checks coverage against that branch" do
+      ENV["GITHUB_BASE_REF"] = "topic"
+      allow(Utils).to receive(:safe_popen_read)
+        .with("git", "-C", CoreTap.instance.path, "rev-parse", "--verify", "origin/topic^{commit}")
+        .and_return("#{base_revision}\n")
+      allow(Utils).to receive(:safe_popen_read)
+        .with("git", "-C", CoreTap.instance.path, "rev-parse", "--verify", "origin/HEAD^{commit}")
+        .and_raise("Wrong base branch")
+
+      expect(transition.required?(current)).to be true
+    end
+  end
+
+  context "when the package version is unchanged" do
+    it "still requires evidence of transition coverage" do
+      allow(current).to receive(:pkg_version).and_return(PkgVersion.parse("1.0"))
+
+      expect do
+        transition.check!(current, tags: [Utils::Bottles.tag(:arm64_tahoe)])
+      end.to raise_error(UsageError, /before publishing or merging/)
+    end
+  end
+
+  context "when the formula is new" do
+    it "does not require transition coverage" do
+      allow(Utils).to receive(:safe_popen_read)
+        .with("git", "-C", CoreTap.instance.path, "ls-tree", "--name-only", "-z", base_revision,
+              "--", current.tap_path.relative_path_from(CoreTap.instance.path))
+        .and_return("")
+
+      expect(transition.required?(current)).to be false
+    end
+  end
+
+  context "when the transition OS is fully supported" do
+    it "ends the transition policy" do
+      stub_const("HOMEBREW_MACOS_NEWEST_SUPPORTED", "27")
+
+      expect(transition.required?(current)).to be false
+    end
+  end
+
+  context "when running against a pull request base branch" do
+    it "uses the base branch instead of the default branch" do
+      ENV["GITHUB_BASE_REF"] = "example"
+      allow(Utils).to receive(:safe_popen_read)
+        .with("git", "-C", CoreTap.instance.path, "rev-parse", "--verify", "origin/example^{commit}")
+        .and_return("#{base_revision}\n")
+
+      expect(transition.required?(current)).to be true
+    end
+  end
+
+  context "when running in the merge queue" do
+    it "uses the immutable merge-group base" do
+      event_path = mktmpdir/"event.json"
+      event_path.write(JSON.generate({ merge_group: { base_sha: base_revision } }))
+      ENV["GITHUB_EVENT_NAME"] = "merge_group"
+      ENV["GITHUB_EVENT_PATH"] = event_path.to_s
+      allow(Utils).to receive(:safe_popen_read)
+        .with("git", "-C", CoreTap.instance.path, "rev-parse", "--verify", "#{base_revision}^{commit}")
+        .and_return("#{base_revision}\n")
+
+      expect(transition.required?(current)).to be true
+    end
+
+    it "rejects a mutable or malformed merge-group base" do
+      event_path = mktmpdir/"event.json"
+      event_path.write(JSON.generate({ merge_group: { base_sha: "main" } }))
+      ENV["GITHUB_EVENT_NAME"] = "merge_group"
+      ENV["GITHUB_EVENT_PATH"] = event_path.to_s
+
+      expect { transition }.to raise_error(UsageError, /immutable merge-group base SHA/)
+    end
+  end
+
+  it "fails closed when the base formula cannot be loaded" do
+    allow(Utils).to receive(:safe_popen_read)
+      .with("git", "-C", CoreTap.instance.path, "show",
+            "#{base_revision}:#{current.tap_path.relative_path_from(CoreTap.instance.path)}")
+      .and_return("class TransitionTest < Formula\ninvalid ruby\n")
+
+    expect { transition.required?(current) }.to raise_error(FormulaUnreadableError)
+  end
+end

--- a/Library/Homebrew/test/dev-cmd/determine-test-runners_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/determine-test-runners_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe Homebrew::DevCmd::DetermineTestRunners do
     {
       "HOMEBREW_LINUX_RUNNER"       => linux_runner,
       "HOMEBREW_MACOS_LONG_TIMEOUT" => "false",
+      "GITHUB_BASE_REF"             => nil,
+      "GITHUB_EVENT_NAME"           => nil,
       "GITHUB_RUN_ID"               => ephemeral_suffix.split("-").second,
     }.freeze
   end
@@ -47,7 +49,21 @@ RSpec.describe Homebrew::DevCmd::DetermineTestRunners do
 
   it_behaves_like "parseable arguments"
 
-  it "assigns all runners for formulae without any requirements", :integration_test do
+  it "preserves base-branch transition coverage after the bottle block is removed", :integration_test do
+    path = setup_test_formula "testball", bottle_block: <<~RUBY
+      bottle do
+        sha256 arm64_golden_gate: "#{"a" * 64}"
+      end
+    RUBY
+    repository = CoreTap.instance.path
+    Utils.safe_popen_read("git", "-C", repository, "init", "--quiet")
+    Utils.safe_popen_read("git", "-C", repository, "add", path)
+    Utils.safe_popen_read("git", "-C", repository, "-c", "user.name=Test", "-c", "user.email=test@brew.sh",
+                          "commit", "--quiet", "--no-gpg-sign", "-m", "Initial bottle")
+    revision = Utils.safe_popen_read("git", "-C", repository, "rev-parse", "HEAD").strip
+    Utils.safe_popen_read("git", "-C", repository, "update-ref", "refs/remotes/origin/main", revision)
+    Utils.safe_popen_read("git", "-C", repository, "symbolic-ref", "refs/remotes/origin/HEAD",
+                          "refs/remotes/origin/main")
     setup_test_formula "testball"
 
     expect { brew "determine-test-runners", "testball", runner_env.merge({ "GITHUB_OUTPUT" => github_output }) }
@@ -55,7 +71,7 @@ RSpec.describe Homebrew::DevCmd::DetermineTestRunners do
       .and be_a_success
 
     expect(File.read(github_output)).not_to be_empty
-    expect(get_runners(github_output).sort).to eq(all_runners.sort)
+    expect(get_runners(github_output).sort).to eq((all_runners + ["27-arm64"]).uniq.sort)
   end
 end
 

--- a/Library/Homebrew/test/dev-cmd/pr-upload_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-upload_spec.rb
@@ -4,6 +4,170 @@
 require "cmd/shared_examples/args_parse"
 require "dev-cmd/pr-upload"
 
+class PrUploadForTesting < Homebrew::DevCmd::PrUpload
+  sig { override.returns(Homebrew::CLI::Parser) }
+  def self.parser = Homebrew::DevCmd::PrUpload.parser
+
+  sig { params(bottles_hash: T::Hash[String, T.anything]).void }
+  def validate_transition_bottles!(bottles_hash) = check_transition_bottles!(bottles_hash)
+
+  sig { params(json_files: T::Array[String]).returns(T::Hash[String, T.anything]) }
+  def merge_bottle_metadata(json_files) = bottles_hash_from_json_files(json_files, args)
+end
+
 RSpec.describe Homebrew::DevCmd::PrUpload do
+  before do
+    formula_path.dirname.mkpath
+    formula_path.write(formula_source)
+    Formulary.enable_factory_cache!
+    allow_any_instance_of(BottleTransition).to receive(:required?).and_return(true)
+  end
+
+  sig {
+    returns(T::Hash[String, {
+      "formula" => T::Hash[String, String],
+      "bottle"  => { "root_url" => String, "rebuild" => Integer, "tags" => T::Hash[String, T::Hash[String, String]] },
+    }])
+  }
+  let(:bottles) do
+    {
+      current.name => {
+        "formula" => { "path" => current.path.relative_path_from(HOMEBREW_REPOSITORY).to_s, "pkg_version" => "2.0" },
+        "bottle"  => {
+          "root_url" => current.bottle_specification.root_url,
+          "rebuild"  => 0,
+          "tags"     => { "arm64_golden_gate" => { "sha256" => "a" * 64 } },
+        },
+      },
+    }
+  end
+
+  sig { returns(Formula) }
+  def current
+    Formulary.factory(formula_path)
+  end
+
+  sig { returns(String) }
+  def formula_source
+    <<~RUBY
+      class TransitionTest < Formula
+        url "https://brew.sh/transition-test-2.0.tar.gz"
+        bottle do
+          sha256 arm64_golden_gate: "#{"a" * 64}"
+        end
+      end
+    RUBY
+  end
+  sig { returns(Pathname) }
+  def formula_path
+    CoreTap.instance.path/"Formula/t/transition-test.rb"
+  end
+
   it_behaves_like "parseable arguments"
+
+  it "keeps upload helpers private" do
+    expect(described_class.private_instance_methods)
+      .to include(:check_transition_bottles!, :bottles_hash_from_json_files)
+  end
+
+  describe "#check_transition_bottles!" do
+    it "rejects metadata for a different package version in upload-only mode" do
+      bottles.fetch(current.name).fetch("formula")["pkg_version"] = "1.0"
+
+      expect do
+        PrUploadForTesting.new(["--upload-only"]).validate_transition_bottles!(bottles)
+      end.to raise_error(UsageError, /metadata does not match/)
+    end
+
+    it "rejects a different rebuild when keeping old bottles" do
+      bottles.fetch(current.name).fetch("bottle")["rebuild"] = 1
+
+      expect do
+        PrUploadForTesting.new(["--keep-old", "--upload-only"]).validate_transition_bottles!(bottles)
+      end.to raise_error(UsageError, /metadata does not match/)
+    end
+
+    it "rejects a bottle commit that omits the transition platform" do
+      bottles
+      formula_path.atomic_write(formula_source.sub("arm64_golden_gate", "arm64_tahoe"))
+
+      expect do
+        PrUploadForTesting.new([]).validate_transition_bottles!(bottles)
+      end.to raise_error(UsageError, /before publishing or merging/)
+    end
+
+    it "reloads retained coverage from disk when keeping old bottles" do
+      bottles.fetch(current.name).fetch("bottle")["tags"] = { "arm64_tahoe" => { "sha256" => "a" * 64 } }
+      formula_path.atomic_write(formula_source.sub("arm64_golden_gate", "arm64_tahoe"))
+      Formulary.clear_cache
+      Formulary.factory(formula_path)
+      formula_path.atomic_write(formula_source.sub("bottle do", "bottle do\n    sha256 arm64_tahoe: \"#{"a" * 64}\""))
+
+      expect do
+        PrUploadForTesting.new(["--keep-old"]).validate_transition_bottles!(bottles)
+      end.not_to raise_error
+    end
+
+    it "identifies missing upload artifacts separately from committed coverage" do
+      bottles.fetch(current.name).fetch("bottle")["tags"] = { "arm64_tahoe" => {} }
+
+      expect do
+        PrUploadForTesting.new(["--upload-only"]).validate_transition_bottles!(bottles)
+      end.to raise_error(UsageError, /upload set is missing/)
+    end
+
+    it "normalises the registry organisation before comparing URLs" do
+      bottles.fetch(current.name).fetch("bottle")["root_url"] = "https://ghcr.io/v2/Homebrew/core"
+
+      expect { PrUploadForTesting.new([]).validate_transition_bottles!(bottles) }.not_to raise_error
+    end
+
+    it "skips a formula that is not enrolled" do
+      allow_any_instance_of(BottleTransition).to receive(:required?).and_return(false)
+      bottles.fetch(current.name).fetch("bottle")["tags"] = {}
+
+      expect { PrUploadForTesting.new([]).validate_transition_bottles!(bottles) }.not_to raise_error
+    end
+
+    context "when the formula belongs to another tap" do
+      it "does not apply the core transition policy" do
+        allow(current).to receive(:tap).and_return(Tap.fetch("user/test"))
+        allow(Formulary).to receive(:factory).with(current.path).and_return(current)
+        allow_any_instance_of(BottleTransition).to receive(:required?).and_call_original
+        bottles.fetch(current.name).fetch("bottle")["tags"] = {}
+
+        expect { PrUploadForTesting.new([]).validate_transition_bottles!(bottles) }.not_to raise_error
+      end
+    end
+  end
+
+  describe "#bottles_hash_from_json_files" do
+    it "accepts equivalent registry URLs across platform records" do
+      directory = mktmpdir
+      first_json = directory/"first.bottle.json"
+      second_json = directory/"second.bottle.json"
+      first_json.write(JSON.generate(bottles))
+      bottles.fetch(current.name).fetch("bottle")["root_url"] = "https://ghcr.io/v2/Homebrew/homebrew-core"
+      second_json.write(JSON.generate(bottles))
+      command = PrUploadForTesting.new([])
+
+      expect do
+        command.merge_bottle_metadata([first_json.to_s, second_json.to_s])
+      end.not_to raise_error
+    end
+
+    it "rejects mixed package versions before their tag sets can be merged" do
+      directory = mktmpdir
+      old_json = directory/"old.bottle.json"
+      new_json = directory/"new.bottle.json"
+      new_json.write(JSON.generate(bottles))
+      bottles.fetch(current.name).fetch("formula")["pkg_version"] = "1.0"
+      old_json.write(JSON.generate(bottles))
+      command = PrUploadForTesting.new([])
+
+      expect do
+        command.merge_bottle_metadata([old_json.to_s, new_json.to_s])
+      end.to raise_error(UsageError, /Inconsistent bottle metadata/)
+    end
+  end
 end

--- a/Library/Homebrew/test/github_runner_matrix_spec.rb
+++ b/Library/Homebrew/test/github_runner_matrix_spec.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "github_runner_matrix"
+require "bottle_transition"
 require "test/support/fixtures/testball"
 
 RSpec.describe GitHubRunnerMatrix, :no_api do
@@ -23,6 +24,7 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
   end
 
   before do
+    allow_any_instance_of(BottleTransition).to receive(:required?).and_return(false)
     allow(ENV).to receive(:fetch).and_call_original
     allow(ENV).to receive(:fetch).with("HOMEBREW_LINUX_SELF_HOSTED", "false").and_return("false")
     allow(ENV).to receive(:fetch).with("HOMEBREW_MACOS_LONG_TIMEOUT", "false").and_return("false")
@@ -43,6 +45,182 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
   end
 
   describe "#active_runner_specs_hash" do
+    context "when bootstrapping a macOS release" do
+      before do
+        stub_const("GitHubRunnerMatrix::NEWEST_HOMEBREW_CORE_MACOS_RUNNER", :tahoe)
+        stub_const("GitHubRunnerMatrix::OLDEST_HOMEBREW_CORE_MACOS_RUNNER", :sonoma)
+        stub_const("HOMEBREW_MACOS_NEWEST_SUPPORTED", "26")
+      end
+
+      it "assigns exactly the default runners to an unenrolled formula" do
+        runners = described_class.new([testball], [], all_supported: false, dependent_matrix: false)
+                                 .active_runner_specs_hash
+
+        expect(runners.map { |runner| runner[:name] }).to contain_exactly(
+          "Linux arm64", "Linux x86_64", "macOS 26-arm64", "macOS 15-arm64", "macOS 14-arm64"
+        )
+      end
+
+      it "selects only already-bottled formulae for the transition runner" do
+        allow_any_instance_of(BottleTransition).to receive(:required?).with(testball.formula).and_return(true)
+        runners = described_class.new([testball, testball_depender], [],
+                                      all_supported: false, dependent_matrix: false)
+                                 .active_runner_specs_hash
+
+        expect(runners.find { |runner| runner[:name] == "macOS 27-arm64" })
+          .to include(testing_formulae: "testball")
+      end
+
+      it "does not add transition runners to dependent testing" do
+        allow_any_instance_of(BottleTransition).to receive(:required?).and_return(true)
+        allow(Formula).to receive(:all).and_return([testball, testball_depender].map(&:formula))
+        runners = described_class.new([testball], [], all_supported: false, dependent_matrix: true)
+                                 .active_runner_specs_hash
+
+        expect(runners.map { |runner| runner[:name] }).not_to include("macOS 27-arm64")
+      end
+
+      it "includes changed dependencies needed by an already-bottled formula" do
+        allow_any_instance_of(BottleTransition).to receive(:required?)
+          .with(testball_depender.formula).and_return(true)
+        runners = described_class.new([testball, testball_depender], [],
+                                      all_supported: false, dependent_matrix: false)
+                                 .active_runner_specs_hash
+
+        expect(runners.find { |runner| runner[:name] == "macOS 27-arm64" })
+          .to include(testing_formulae: "testball,testball-depender")
+      end
+
+      test_each([{ maximum_macos: :tahoe }, { arch: :x86_64 }, :linux]) do |requirement|
+        it "skips a covered parent whose changed dependency requires #{requirement}" do
+          dependency = setup_test_runner_formula("incompatible-dependency", [requirement])
+          covered = setup_test_runner_formula("covered", [dependency.name])
+          allow_any_instance_of(BottleTransition).to receive(:required?).with(covered.formula).and_return(true)
+          runners = described_class.new([dependency, covered], [], all_supported: false, dependent_matrix: false)
+                                   .active_runner_specs_hash
+
+          expect(runners.map { |runner| runner[:name] }).to contain_exactly(
+            "Linux arm64", "Linux x86_64", "macOS 26-arm64", "macOS 15-arm64", "macOS 14-arm64"
+          )
+        end
+      end
+
+      it "does not reuse a bottle for an incompatible changed dependency" do
+        dependency = setup_test_runner_formula("incompatible-dependency", [{ maximum_macos: :tahoe }])
+        dependency.formula.bottle_specification.sha256(arm64_golden_gate: "a" * 64)
+        covered = setup_test_runner_formula("covered", [dependency.name])
+        allow_any_instance_of(BottleTransition).to receive(:required?).with(covered.formula).and_return(true)
+        runners = described_class.new([dependency, covered], [], all_supported: false, dependent_matrix: false)
+                                 .active_runner_specs_hash
+
+        expect(runners.map { |runner| runner[:name] }).not_to include("macOS 27-arm64")
+      end
+
+      it "keeps standard runners when transition prerequisites are missing" do
+        testball
+        allow_any_instance_of(BottleTransition).to receive(:required?)
+          .with(testball_depender.formula).and_return(true)
+
+        runners = described_class.new([testball_depender], [], all_supported: false, dependent_matrix: false)
+                                 .active_runner_specs_hash
+
+        expect(runners.map { |runner| runner[:name] }).to contain_exactly(
+          "Linux arm64", "Linux x86_64", "macOS 26-arm64", "macOS 15-arm64", "macOS 14-arm64"
+        )
+      end
+
+      it "does not require build dependencies of unchanged bottled dependencies" do
+        setup_test_runner_formula("unbottled-tool")
+        dependency = setup_test_runner_formula("bottled-dependency", [{ "unbottled-tool" => :build }])
+        dependency.formula.bottle_specification.sha256(arm64_golden_gate: "a" * 64)
+        covered = setup_test_runner_formula("covered", [dependency.name])
+        allow_any_instance_of(BottleTransition).to receive(:required?).with(covered.formula).and_return(true)
+        runners = described_class.new([covered], [], all_supported: false, dependent_matrix: false)
+                                 .active_runner_specs_hash
+
+        expect(runners.find { |runner| runner[:name] == "macOS 27-arm64" })
+          .to include(testing_formulae: "covered")
+      end
+
+      it "allows the runner to check older bottles for unchanged test-only dependencies" do
+        dependency = setup_test_runner_formula("test-only-dependency")
+        dependency.formula.bottle_specification.sha256(arm64_tahoe: "a" * 64)
+        covered = setup_test_runner_formula("covered", [{ dependency.name => :test }])
+        allow_any_instance_of(BottleTransition).to receive(:required?).with(covered.formula).and_return(true)
+        runners = described_class.new([covered], [], all_supported: false, dependent_matrix: false)
+                                 .active_runner_specs_hash
+
+        expect(runners.find { |runner| runner[:name] == "macOS 27-arm64" })
+          .to include(testing_formulae: "covered")
+      end
+
+      test_each([nil, :tahoe, :arm64_linux]) do |bottle_tag|
+        it "skips a test-only dependency with #{bottle_tag || "no"} bottles" do
+          dependency = setup_test_runner_formula("test-only-dependency")
+          dependency.formula.bottle_specification.sha256(bottle_tag => "a" * 64) if bottle_tag
+          covered = setup_test_runner_formula("covered", [{ dependency.name => :test }])
+          allow_any_instance_of(BottleTransition).to receive(:required?).with(covered.formula).and_return(true)
+          runners = described_class.new([covered], [], all_supported: false, dependent_matrix: false)
+                                   .active_runner_specs_hash
+
+          expect(runners.map { |runner| runner[:name] }).to contain_exactly(
+            "Linux arm64", "Linux x86_64", "macOS 26-arm64", "macOS 15-arm64", "macOS 14-arm64"
+          )
+        end
+      end
+
+      it "checks dependencies of universal test-only bottles" do
+        setup_test_runner_formula("unbottled-tool")
+        dependency = setup_test_runner_formula("universal-dependency", ["unbottled-tool"])
+        dependency.formula.bottle_specification.sha256(all: "a" * 64)
+        covered = setup_test_runner_formula("covered", [{ dependency.name => :test }])
+        allow_any_instance_of(BottleTransition).to receive(:required?).with(covered.formula).and_return(true)
+        runners = described_class.new([covered], [], all_supported: false, dependent_matrix: false)
+                                 .active_runner_specs_hash
+
+        expect(runners.map { |runner| runner[:name] }).not_to include("macOS 27-arm64")
+      end
+
+      it "allows older bottles for dependencies of universal test-only bottles" do
+        tool = setup_test_runner_formula("older-tool")
+        tool.formula.bottle_specification.sha256(arm64_tahoe: "a" * 64)
+        dependency = setup_test_runner_formula("universal-dependency", [tool.name])
+        dependency.formula.bottle_specification.sha256(all: "a" * 64)
+        covered = setup_test_runner_formula("covered", [{ dependency.name => :test }])
+        allow_any_instance_of(BottleTransition).to receive(:required?).with(covered.formula).and_return(true)
+        runners = described_class.new([covered], [], all_supported: false, dependent_matrix: false)
+                                 .active_runner_specs_hash
+
+        expect(runners.find { |runner| runner[:name] == "macOS 27-arm64" })
+          .to include(testing_formulae: "covered")
+      end
+
+      it "requires current bottles for dependencies used at build, test and runtime" do
+        dependency = setup_test_runner_formula("shared-dependency")
+        dependency.formula.bottle_specification.sha256(arm64_tahoe: "a" * 64)
+        runtime = setup_test_runner_formula("runtime-dependency", [dependency.name])
+        runtime.formula.bottle_specification.sha256(arm64_golden_gate: "a" * 64)
+        covered = setup_test_runner_formula("covered", [{ dependency.name => [:build, :test] }, runtime.name])
+        allow_any_instance_of(BottleTransition).to receive(:required?).with(covered.formula).and_return(true)
+        runners = described_class.new([covered], [], all_supported: false, dependent_matrix: false)
+                                 .active_runner_specs_hash
+
+        expect(runners.map { |runner| runner[:name] }).not_to include("macOS 27-arm64")
+      end
+
+      it "checks build dependencies of universal bottles" do
+        setup_test_runner_formula("unbottled-tool")
+        dependency = setup_test_runner_formula("universal-dependency", [{ "unbottled-tool" => :build }])
+        dependency.formula.bottle_specification.sha256(all: "a" * 64)
+        covered = setup_test_runner_formula("covered", [dependency.name])
+        allow_any_instance_of(BottleTransition).to receive(:required?).with(covered.formula).and_return(true)
+        runners = described_class.new([covered], [], all_supported: false, dependent_matrix: false)
+                                 .active_runner_specs_hash
+
+        expect(runners.map { |runner| runner[:name] }).not_to include("macOS 27-arm64")
+      end
+    end
+
     it "returns an object that responds to `#to_json`" do
       expect(
         described_class.new([], ["deleted"], all_supported: false, dependent_matrix: false)

--- a/Library/Homebrew/test/test_bot/bottles_fetch_spec.rb
+++ b/Library/Homebrew/test/test_bot/bottles_fetch_spec.rb
@@ -6,6 +6,24 @@ require "dev-cmd/test-bot"
 
 RSpec.describe Homebrew::TestBot::BottlesFetch do
   describe "#run!" do
+    it "rejects a merge that drops existing transition coverage" do
+      current = formula("transition-test") do
+        T.bind(self, T.class_of(Formula))
+        url "https://brew.sh/transition-test-2.0.tar.gz"
+        bottle do
+          sha256 arm64_tahoe: ("a" * 64).to_s
+        end
+      end
+      allow(Formula).to receive(:[]).with(current.name).and_return(current)
+      allow_any_instance_of(BottleTransition).to receive(:required?).and_return(true)
+      fetch = described_class.new(tap: nil, git: nil, dry_run: true, fail_fast: false, verbose: false)
+      fetch.testing_formulae = [current.name]
+
+      expect do
+        fetch.run!(args: instance_double(Homebrew::Cmd::TestBotCmd::Args))
+      end.to raise_error(UsageError, /before publishing or merging/)
+    end
+
     it "accepts Utils::Bottles::Tag objects from the bottle collector" do
       # Regression test: bottle_specification.collector.tags returns Utils::Bottles::Tag objects,
       # not Symbols. The fetch_bottles! signature must accept Tag, not Symbol.

--- a/Library/Homebrew/test_bot/bottles_fetch.rb
+++ b/Library/Homebrew/test_bot/bottles_fetch.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "bottle_transition"
+
 module Homebrew
   module TestBot
     class BottlesFetch < TestFormulae
@@ -24,14 +26,15 @@ module Homebrew
       sig { returns(T::Hash[Utils::Bottles::Tag, T::Set[String]]) }
       def formulae_by_tag
         tags = Hash.new { |hash, key| hash[key] = Set.new }
+        transition = BottleTransition.new
 
         testing_formulae.each do |formula_name|
           formula = Formula[formula_name]
           next if formula.disabled?
 
           formula_tags = formula.bottle_specification.collector.tags
-
           odie "#{formula_name} is missing bottles! Did you mean to use `brew pr-publish`?" if formula_tags.blank?
+          transition.check!(formula, tags: formula_tags)
 
           formula_tags.each do |tag|
             tags[tag] << formula_name

--- a/Library/Homebrew/test_runner_formula.rb
+++ b/Library/Homebrew/test_runner_formula.rb
@@ -77,6 +77,14 @@ class TestRunnerFormula
     macos_version.public_send(requirement.comparator, requirement.version)
   end
 
+  sig { params(platform: Symbol, arch: Symbol, macos_version: T.nilable(MacOSVersion)).returns(T::Boolean) }
+  def compatible?(platform:, arch:, macos_version: nil)
+    return false if macos_version && !compatible_with?(macos_version)
+    return false unless public_send(:"#{platform}_compatible?")
+
+    !!public_send(:"#{arch}_compatible?")
+  end
+
   sig {
     params(
       platform:      Symbol,


### PR DESCRIPTION
Homebrew delays adding a new macOS runner to ordinary CI until mass bottling finishes, so routine formula updates during that window drop the coverage mass bottling just created and those formulae need bottling again.

This adds `BottleTransition`, which reads a formula's bottle block on the base branch and requires existing `arm64_golden_gate` coverage to survive later changes. Enrolled formulae get a Golden Gate runner in ordinary CI along with any changed dependencies they need, and publication and merge queue checks reject an upload that drops the coverage. A universal `all` bottle satisfies the requirement but does not enroll a formula by itself, so nothing is enrolled until the first Golden Gate bottle lands on the default branch.

When an unchanged dependency has no usable bottle, runner selection warns and skips that Golden Gate build rather than failing, so the rest of CI still runs. Publication compares the committed bottle block against the artifacts being uploaded, including package version, rebuild, registry URL and per-tag checksums, and rejects a bottle directory holding more than one package version. Runner capacity controls are unchanged, and the checks stop applying once `HOMEBREW_MACOS_NEWEST_SUPPORTED` reaches 27.

The matching homebrew-core workflow change removes the macOS 27 upload guard and will merge after this.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the change and pass with it, and ran `brew lgtm` plus targeted specs.

-----
