### PR TITLE
Refine macOS sandbox compatibility

### DIFF
--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -82,22 +82,34 @@ module Homebrew
 
             exec_args << "--HEAD" if f.head?
 
-            Sandbox.run_or_fork(
-              *exec_args,
-              step:                 "testing #{f.full_name}",
-              warn_without_sandbox: false,
-            ) do |sandbox|
-              f.logs.mkpath
-              sandbox.record_log(f.logs/"test.sandbox.log")
-              sandbox.allow_write_temp_and_cache
-              sandbox.allow_write_log(f)
-              sandbox.allow_write_xcode
-              sandbox.allow_write_path(HOMEBREW_PREFIX/"var/homebrew/locks")
-              sandbox.deny_read_home
-              optional_prefix_var_dirs.each do |dir|
-                sandbox.allow_write_path_if_exists HOMEBREW_PREFIX/dir
+            Mktemp.new("#{f.name}-test", retain: args.keep_tmp?).run(chdir: false) do |staging|
+              testpath = staging.tmpdir
+              raise "Test path is unexpectedly unset." if testpath.nil?
+
+              ENV["HOMEBREW_TEST_PATH"] = testpath.to_s
+
+              Sandbox.run_or_fork(
+                *exec_args,
+                step:                 "testing #{f.full_name}",
+                warn_without_sandbox: false,
+              ) do |sandbox|
+                f.logs.mkpath
+                sandbox.record_log(f.logs/"test.sandbox.log")
+                sandbox.allow_write_temp_and_cache
+                sandbox.allow_write_log(f)
+                sandbox.allow_write_xcode
+                sandbox.allow_write_path(HOMEBREW_PREFIX/"var/homebrew/locks")
+                sandbox.deny_read_home
+                optional_prefix_var_dirs.each do |dir|
+                  sandbox.allow_write_path_if_exists HOMEBREW_PREFIX/dir
+                end
+                sandbox.deny_all_network unless f.class.network_access_allowed?(:test)
+                sandbox.allow_network path: testpath, type: :subpath
               end
-              sandbox.deny_all_network unless f.class.network_access_allowed?(:test)
+            # Preserve the parent's test directory for interactive debugging.
+            rescue Exception # rubocop:disable Lint/RescueException
+              staging.retain! if args.debug?
+              raise
             end
           # Rescue any possible exception types.
           rescue Exception => e # rubocop:disable Lint/RescueException

--- a/Library/Homebrew/extend/os/mac/sandbox.rb
+++ b/Library/Homebrew/extend/os/mac/sandbox.rb
@@ -21,6 +21,10 @@ module OS
       SEATBELT_ERB = <<~ERB
         (version 1)
         (debug deny) ; log all denied operations to /var/log/system.log
+        (deny network-outbound (to unix-socket))
+        <% if network_access_allowed %>
+        (allow network-outbound (to unix-socket (path-literal "/private/var/run/mDNSResponder")))
+        <% end %>
         <%= rules.join("\n") %>
         (allow file-write*
             (literal "/dev/ptmx")
@@ -36,6 +40,8 @@ module OS
         (deny file-write-mode) ; deny non-allowlist file write mode operations
         (deny mach-lookup)
         (allow mach-lookup
+            (global-name "com.apple.mobileassetd.v2")
+            (global-name "com.apple.sysmond")
             (global-name "com.apple.bsd.dirhelper")
             (global-name "com.apple.system.opendirectoryd.libinfo")
             (global-name "com.apple.system.opendirectoryd.membership")
@@ -174,7 +180,12 @@ module OS
 
       sig { returns(String) }
       def seatbelt_profile
-        ERB.new(SEATBELT_ERB).result_with_hash(rules: profile.rules.map { |rule| seatbelt_rule(rule) })
+        ERB.new(SEATBELT_ERB).result_with_hash(
+          rules:                  profile.rules.map { |rule| seatbelt_rule(rule) },
+          network_access_allowed: profile.rules.none? do |rule|
+            !rule.allow && rule.operation == "network*" && rule.filter.nil?
+          end,
+        )
       end
 
       sig { params(rule: T.untyped).returns(String) }
@@ -182,6 +193,7 @@ module OS
         s = +"("
         s << (rule.allow ? "allow" : "deny")
         s << " #{rule.operation}"
+        s << " network-outbound" if rule.allow && rule.operation == "network*"
         s << " (#{seatbelt_path_filter(rule.filter)})" if rule.filter
         s << " (with #{rule.modifier})" if rule.modifier
         s << ")"

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -3432,8 +3432,11 @@ class Formula
     ENV.clear_sensitive_environment!
     Utils::Git.set_name_email!
 
-    mktemp("#{name}-test") do |staging|
-      staging.retain! if keep_tmp
+    test_path = ENV.delete("HOMEBREW_TEST_PATH")
+    staging = Mktemp.new("#{name}-test", retain: keep_tmp || !test_path.nil?,
+                                         path:   (Pathname(test_path) if test_path))
+    staging.quiet! if test_path
+    staging.run do
       testpath = staging.tmpdir
       raise "Test path is unexpectedly unset." if testpath.nil?
 

--- a/Library/Homebrew/test/dev-cmd/test_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/test_spec.rb
@@ -6,14 +6,22 @@ require "dev-cmd/test"
 require "sandbox"
 
 RSpec.describe Homebrew::DevCmd::Test do
+  define_negated_matcher :not_matching, :matching
+
   it_behaves_like "parseable arguments"
 
-  it "tests a given Formula", :integration_test do
+  it "tests a given Formula without process-listing warnings", :integration_test do
     skip "Nested sandboxing is not supported." if Sandbox.nested_sandbox?
 
     setup_test_formula "testball", <<~'RUBY', tab_attributes: { installed_on_request: true }
       test do
         assert_equal "test", shell_output("#{bin}/test")
+        (logs/"testpath").write(testpath)
+        require "socket"
+        (testpath/"sockets").mkpath
+        UNIXServer.open("sockets/test.sock") do
+          UNIXSocket.open("sockets/test.sock", &:close)
+        end
       end
     RUBY
     formula_prefix = Formula["testball"].prefix
@@ -27,9 +35,12 @@ RSpec.describe Homebrew::DevCmd::Test do
     (HOMEBREW_LINKED_KEGS/"testball").make_relative_symlink(formula_prefix)
 
     expect { brew "test", "--verbose", "testball", "HOMEBREW_NO_INSTALL_FROM_API" => "1" }
-      .to output(/Testing testball/).to_stdout
+      .to output(a_string_matching(/Testing testball/)
+        .and(not_matching(/sysmon request failed|pgrep: Cannot get process list/))).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
+
+    expect(Pathname((Formula["testball"].logs/"testpath").read)).not_to exist
   end
 
   it "blocks network access when test phase is offline", :integration_test, :needs_sandbox do
@@ -40,6 +51,10 @@ RSpec.describe Homebrew::DevCmd::Test do
     setup_test_formula formula_name, <<~RUBY, tab_attributes: { installed_on_request: true }
       deny_network_access! :test
       test do
+        require "socket"
+        UNIXServer.open("test.sock") do
+          UNIXSocket.open("test.sock", &:close)
+        end
         system "curl", "example.org"
       end
     RUBY

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -33,6 +33,64 @@ RSpec.describe Formula do
     end
   end
 
+  describe "#run_test" do
+    let(:f) { Testball.new }
+    let(:testpath) { mktmpdir }
+
+    it "uses the test directory supplied by the parent" do
+      ENV["HOMEBREW_TEST_PATH"] = testpath.to_s
+      observed = []
+      allow(f).to receive(:test) do
+        observed.push(f.testpath, Pathname.pwd, Pathname(Dir.home), ENV.fetch("HOMEBREW_TEST_PATH", nil))
+      end
+
+      f.run_test
+
+      expect(observed).to eq([testpath, testpath, testpath, nil])
+    end
+
+    it "preserves an environment-supplied directory and its contents" do
+      ENV["HOMEBREW_TEST_PATH"] = testpath.to_s
+      (testpath/"existing").write("keep")
+      allow(f).to receive(:test)
+
+      f.run_test
+
+      expect(testpath/"existing").to exist
+    end
+
+    it "preserves an environment-supplied directory when the test fails" do
+      ENV["HOMEBREW_TEST_PATH"] = testpath.to_s
+      (testpath/"existing").write("keep")
+      allow(f).to receive(:test).and_raise("test failed")
+
+      expect { f.run_test }.to raise_error("test failed")
+      expect(testpath/"existing").to exist
+    end
+
+    it "preserves an environment-supplied directory when entering it fails" do
+      ENV["HOMEBREW_TEST_PATH"] = testpath.to_s
+      (testpath/"existing").write("keep")
+      allow(Dir).to receive(:chdir).and_call_original
+      allow(Dir).to receive(:chdir).with(testpath).and_raise(Errno::EACCES)
+
+      expect { f.run_test }.to raise_error(Errno::EACCES).and output("").to_stdout
+      expect(testpath/"existing").to exist
+    end
+
+    it "retains a generated test directory when requested" do
+      ENV.delete("HOMEBREW_TEST_PATH")
+      generated_testpath = T.let(nil, T.nilable(Pathname))
+      allow(f).to receive(:test) { generated_testpath = f.testpath }
+
+      f.run_test(keep_tmp: true)
+
+      expect(generated_testpath).to exist
+    ensure
+      FileUtils.rm_rf(generated_testpath) if generated_testpath
+    end
+  end
+
   describe "::new" do
     let(:klass) do
       Class.new(described_class) do

--- a/Library/Homebrew/test/sandbox_spec.rb
+++ b/Library/Homebrew/test/sandbox_spec.rb
@@ -27,8 +27,44 @@ RSpec.describe Sandbox, :needs_macos do
       end.new
     end
 
-    it "restricts Mach services, LaunchServices and Apple Events even when network access is allowed" do
-      expect(sandbox.seatbelt_profile).to include("(deny mach-lookup)", "(deny lsopen)", "(deny appleevent-send)")
+    it "restricts macOS services even when network access is allowed" do
+      expect(sandbox.seatbelt_profile).to include(
+        "(deny mach-lookup)", "(deny lsopen)", "(deny appleevent-send)",
+        "(deny network-outbound (to unix-socket))",
+        '(allow network-outbound (to unix-socket (path-literal "/private/var/run/mDNSResponder")))'
+      )
+    end
+
+    it "does not allow the DNS socket when network access is denied" do
+      sandbox.deny_all_network
+      sandbox.allow_network path: dir, type: :subpath
+      expect(sandbox.seatbelt_profile).not_to include("mDNSResponder")
+    end
+
+    it "explicitly allows outbound access to a permitted socket" do
+      sandbox.deny_all_network
+      sandbox.allow_network path: file
+
+      expect(sandbox.seatbelt_profile).to include("(allow network* network-outbound (literal \"#{file}\"))")
+    end
+
+    it "explicitly allows outbound access within a permitted socket directory" do
+      sandbox.deny_all_network
+      sandbox.allow_network path: dir, type: :subpath
+
+      expect(sandbox.seatbelt_profile).to include("(allow network* network-outbound (subpath \"#{dir}\"))")
+    end
+
+    it "allows installed Metal Toolchain discovery when network access is denied" do
+      sandbox.deny_all_network
+
+      expect(sandbox.seatbelt_profile).to include('(global-name "com.apple.mobileassetd.v2")')
+    end
+
+    it "allows process discovery when network access is denied" do
+      sandbox.deny_all_network
+
+      expect(sandbox.seatbelt_profile).to include('(global-name "com.apple.sysmond")')
     end
   end
 
@@ -92,6 +128,262 @@ RSpec.describe Sandbox, :needs_macos do
           }
         JS
       end
+    end
+
+    it "denies connections to Unix sockets in writable directories" do
+      UNIXServer.open(file) do
+        UNIXSocket.open(file, &:close)
+        sandbox.allow_write_path(dir)
+
+        expect do
+          sandbox.run RbConfig.ruby, "-rsocket", "-e", "UNIXSocket.open(ARGV.fetch(0), &:close)", file
+        end.to raise_error(ErrorDuringExecution)
+      end
+    end
+
+    it "denies datagrams to Unix sockets in writable directories" do
+      server = Socket.new(Socket::AF_UNIX, Socket::SOCK_DGRAM)
+      server.bind(Socket.sockaddr_un(file.to_s))
+      sandbox.allow_write_path(dir)
+
+      expect do
+        sandbox.run RbConfig.ruby, "-rsocket", "-e", <<~RUBY, file
+          Socket.open(:UNIX, :DGRAM) { |socket| socket.send("test", 0, Socket.sockaddr_un(ARGV.fetch(0))) }
+        RUBY
+      end.to raise_error(ErrorDuringExecution)
+    ensure
+      server&.close
+    end
+
+    it "allows explicitly permitted Unix sockets when network access is denied" do
+      UNIXServer.open(file) do
+        sandbox.deny_all_network
+        sandbox.allow_network path: file
+
+        expect do
+          sandbox.run RbConfig.ruby, "-rsocket", "-e", "UNIXSocket.open(ARGV.fetch(0), &:close)", file
+        end.not_to raise_error
+      end
+    end
+
+    it "allows the child error socket when network access is denied" do
+      sandbox.deny_all_network
+
+      expect do
+        sandbox.run RbConfig.ruby, "-rsocket", "-e", <<~RUBY
+          UNIXSocket.open(ENV.fetch("HOMEBREW_ERROR_PIPE")) { |socket| socket.recv_io.close }
+        RUBY
+      end.not_to raise_error
+    end
+
+    it "allows Unix sockets in a permitted directory when network access is denied" do
+      (dir/"sockets").mkpath
+      UNIXServer.open(dir/"sockets/test.sock") do
+        sandbox.deny_all_network
+        sandbox.allow_network path: dir, type: :subpath
+
+        expect do
+          sandbox.run RbConfig.ruby, "-rsocket", "-e", "UNIXSocket.open(ARGV.fetch(0), &:close)",
+                      dir/"sockets/test.sock"
+        end.not_to raise_error
+      end
+    end
+
+    it "runs a private Unix socket service online and offline" do
+      sandbox.allow_write_path(dir)
+
+      expect do
+        [true, false].each do |network_access_allowed|
+          sandbox.deny_all_network unless network_access_allowed
+          sandbox.allow_network path: dir, type: :subpath
+          sandbox.run RbConfig.ruby, "-rsocket", "-rtimeout", "-e", <<~'RUBY', dir
+            Dir.chdir(ARGV.fetch(0))
+            Dir.mkdir("sockets")
+            UNIXServer.open("sockets/database.sock") do |server|
+              pid = fork do
+                Timeout.timeout(5) do
+                  client = server.accept
+                  client.write(client.gets.upcase)
+                  client.close
+                end
+              end
+              begin
+                Timeout.timeout(5) do
+                  UNIXSocket.open("sockets/database.sock") do |client|
+                    client.sendmsg("query\n")
+                    abort "Unexpected service response" unless client.gets == "QUERY\n"
+                  end
+                end
+              ensure
+                Process.wait(pid)
+              end
+              abort "Service failed" unless $?.success?
+            end
+            File.unlink("sockets/database.sock")
+            Dir.rmdir("sockets")
+          RUBY
+        end
+      end.not_to raise_error
+    end
+
+    it "allows a private datagram service when network access is denied" do
+      sandbox.allow_write_path(dir)
+      sandbox.deny_all_network
+      sandbox.allow_network path: dir, type: :subpath
+
+      expect do
+        sandbox.run RbConfig.ruby, "-rsocket", "-rtimeout", "-e", <<~RUBY, file
+          Socket.open(:UNIX, :DGRAM) do |server|
+            server.bind(Socket.sockaddr_un(ARGV.fetch(0)))
+            Socket.open(:UNIX, :DGRAM) do |client|
+              client.connect(Socket.sockaddr_un(ARGV.fetch(0)))
+              client.send("message", 0)
+              Timeout.timeout(5) { abort "Unexpected datagram" unless server.recv(64) == "message" }
+            end
+          end
+          File.unlink(ARGV.fetch(0))
+        RUBY
+      end.not_to raise_error
+    end
+
+    it "allows HTTP over a private Unix socket when network access is denied" do
+      sandbox.allow_write_path(dir)
+      sandbox.deny_all_network
+      sandbox.allow_network path: dir, type: :subpath
+
+      expect do
+        sandbox.run RbConfig.ruby, "-rsocket", "-rtimeout", "-e", <<~'RUBY', file
+          UNIXServer.open(ARGV.fetch(0)) do |server|
+            pid = fork do
+              Timeout.timeout(10) do
+                client = server.accept
+                loop { break if client.gets == "\r\n" }
+                client.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK")
+                client.close
+              end
+            end
+            begin
+              response = IO.popen(["/usr/bin/curl", "--fail", "--silent", "--show-error", "--max-time", "5",
+                                   "--noproxy", "*", "--unix-socket", ARGV.fetch(0), "http://localhost/"], &:read)
+              abort "Unexpected HTTP response" unless $?.success? && response == "OK"
+            ensure
+              Process.wait(pid)
+            end
+            abort "HTTP service failed" unless $?.success?
+          end
+          File.unlink(ARGV.fetch(0))
+        RUBY
+      end.not_to raise_error
+    end
+
+    it "denies Unix sockets outside a permitted directory" do
+      (dir/"sockets").mkpath
+      UNIXServer.open(file) do
+        sandbox.allow_network path: dir/"sockets", type: :subpath
+
+        expect do
+          sandbox.run RbConfig.ruby, "-rsocket", "-e", "UNIXSocket.open(ARGV.fetch(0), &:close)", file
+        end.to raise_error(ErrorDuringExecution)
+      end
+    end
+
+    it "denies symlinks to Unix sockets outside a permitted directory" do
+      (dir/"sockets").mkpath
+      UNIXServer.open(file) do
+        (dir/"sockets/test.sock").make_symlink(file)
+        UNIXSocket.open(dir/"sockets/test.sock", &:close)
+        sandbox.allow_network path: dir/"sockets", type: :subpath
+
+        expect do
+          sandbox.run RbConfig.ruby, "-rsocket", "-e", "UNIXSocket.open(ARGV.fetch(0), &:close)",
+                      dir/"sockets/test.sock"
+        end.to raise_error(ErrorDuringExecution)
+      end
+    end
+
+    it "denies hard links to Unix sockets outside a permitted directory" do
+      (dir/"sockets").mkpath
+      UNIXServer.open(file) do
+        File.link(file, dir/"sockets/test.sock")
+        UNIXSocket.open(dir/"sockets/test.sock", &:close)
+        sandbox.allow_network path: dir/"sockets", type: :subpath
+
+        expect do
+          sandbox.run RbConfig.ruby, "-rsocket", "-e", "UNIXSocket.open(ARGV.fetch(0), &:close)",
+                      dir/"sockets/test.sock"
+        end.to raise_error(ErrorDuringExecution)
+      end
+    end
+
+    it "allows TCP connections when network access is allowed" do
+      server = TCPServer.new("127.0.0.1", 0)
+      expect do
+        sandbox.run RbConfig.ruby, "-rsocket", "-e", <<~RUBY, server.addr[1].to_s
+          TCPSocket.open("127.0.0.1", ARGV.fetch(0).to_i, &:close)
+        RUBY
+      end.not_to raise_error
+    ensure
+      server&.close
+    end
+
+    it "allows DNS resolution when network access is allowed", :needs_network do
+      expect do
+        sandbox.run RbConfig.ruby, "-rsocket", "-e", 'Socket.getaddrinfo("formulae.brew.sh", 443)'
+      end.not_to raise_error
+    end
+
+    it "allows HTTPS downloads in network-enabled install hooks", :needs_network do
+      sandbox.add_install_hook_rules(network_access_allowed: true)
+
+      expect do
+        sandbox.run "/usr/bin/curl", "--fail", "--silent", "--show-error", "--max-time", "15",
+                    "--output", file, "https://formulae.brew.sh/api/formula/hello.json"
+      end.not_to raise_error
+    end
+
+    it "allows extended attribute changes in offline install hooks" do
+      file.write("test")
+      sandbox.add_install_hook_rules(network_access_allowed: false)
+
+      expect do
+        sandbox.run "/bin/sh", "-ec", <<~SH, "--", file
+          /usr/bin/xattr -wx com.apple.FinderInfo 5445535400000000000000000000000000000000000000000000000000000000 "$1"
+          /usr/bin/xattr -d com.apple.FinderInfo "$1"
+        SH
+      end.not_to raise_error
+    end
+
+    it "discovers the installed Metal compiler without using the xcrun cache" do
+      unless SystemCommand.run("/usr/bin/xcrun",
+                               args: ["--no-cache", "--sdk", "macosx", "metal", "--version"]).success?
+        skip "Metal Toolchain not installed."
+      end
+
+      sandbox.allow_write_temp_and_cache
+      sandbox.allow_write_xcode
+      sandbox.deny_read_home
+      sandbox.deny_all_network
+
+      expect do
+        sandbox.run "/usr/bin/xcrun", "--no-cache", "--sdk", "macosx", "metal", "--version"
+      end.not_to raise_error
+    end
+
+    it "allows pgrep to find a child process when network access is denied" do
+      sandbox.deny_all_network
+
+      expect do
+        sandbox.run RbConfig.ruby, "-e", <<~RUBY
+          pid = spawn "/bin/sleep", "10"
+          begin
+            output = IO.popen(["/usr/bin/pgrep", "-P", Process.pid.to_s], &:read)
+            abort "Child process not found" unless $?.success? && output.lines.map(&:to_i).include?(pid)
+          ensure
+            Process.kill("TERM", pid)
+            Process.wait(pid)
+          end
+        RUBY
+      end.not_to raise_error
     end
 
     it "reports an empty array for an unregistered URL scheme" do

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -193,6 +193,8 @@ Generated completion artifacts are different: `generate_completions_from_executa
 On macOS, sandboxed operations can only look up explicitly allowed Mach services for directory information, power management, networking and certificates.
 They cannot register or launch applications through LaunchServices (including `lsregister` and `open`) or send Apple Events to other applications.
 These restrictions also apply to steps with `network_access: true`.
+Outbound Unix socket connections are denied except for Homebrew's internal communication and, when network access is allowed, macOS DNS resolution.
+Allowing writes to a directory does not allow connections to sockets in it.
 
 `installer script:` is not sandboxed. Many installer scripts are vendor installers that require broad filesystem writes, macOS services or `sudo`; macOS sandboxing does not work for root processes, and narrowing the write allowlist to the Caskroom plus uninstall or zap paths would break installers that legitimately write elsewhere. It would also change documented `SystemCommand` behaviours such as `sudo:`, `must_succeed:` and output handling.
 

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -310,6 +310,9 @@ Add a valid test to the [`test do`](/rubydoc/Formula.html#test-class_method) blo
 
 The [`test do`](/rubydoc/Formula.html#test-class_method) block automatically creates and changes to a temporary directory which is deleted after run. You can access this [`Pathname`](/rubydoc/Pathname.html) with the [`testpath`](/rubydoc/Formula.html#testpath-instance_method) function. The environment variable `HOME` is set to [`testpath`](/rubydoc/Formula.html#testpath-instance_method) within the [`test do`](/rubydoc/Formula.html#test-class_method) block.
 
+On macOS, the test sandbox allows Unix socket connections within `testpath`, including its subdirectories, even when the formula disables network access for tests.
+Create sockets for test services in this directory; connections to sockets elsewhere are denied except for Homebrew's internal communication and, when network access is allowed, macOS DNS resolution.
+
 We want tests that don't require any user input and test the basic functionality of the application. For example `foo build-foo input.foo` is a good test and (despite their widespread use) `foo --version` and `foo --help` are bad tests. However, a bad test is better than no test at all.
 
 See the [`cmake`](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/c/cmake.rb) formula for an example of a good test. It writes a basic `CMakeLists.txt` file into the test directory then calls CMake to generate Makefiles. This test checks that CMake doesn't e.g. segfault during basic operation.


### PR DESCRIPTION
- Restore discovery of installed Metal toolchains and process listing by allowing the required MobileAsset and sysmond services.
- Keep local endpoint access explicit while retaining DNS and Homebrew's per-run communication channel, including offline runs.
- Prepare each formula's private `testpath` before configuring the sandbox so its tests can start and use their own local services.
- Preserve temporary-directory cleanup and retention, and use relative socket paths in fixtures to accommodate longer test directories.
- Cover uncached Metal discovery, child-process discovery, private services, HTTP over Unix sockets and install-hook operations.

Fixes #23919

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Codex with GPT 6 Astra at High effort, with local review and testing.

-----