### PR TITLE
Overwrite cask binary symlinks when linking kegs

### DIFF
--- a/Library/Homebrew/cask/artifact/binary.rb
+++ b/Library/Homebrew/cask/artifact/binary.rb
@@ -9,15 +9,17 @@ module Cask
     class Binary < Symlinked
       sig {
         override.params(
-          force:    T::Boolean,
-          adopt:    T::Boolean,
-          command:  T.class_of(SystemCommand),
-          _options: T.anything,
+          force:     T::Boolean,
+          adopt:     T::Boolean,
+          overwrite: T::Boolean,
+          dry_run:   T::Boolean,
+          command:   T.class_of(SystemCommand),
+          _options:  T.anything,
         ).void
       }
-      def link(force: false, adopt: false, command: SystemCommand, **_options)
+      def link(force: false, adopt: false, overwrite: false, dry_run: false, command: SystemCommand, **_options)
         super
-        return if source.executable?
+        return if dry_run || source.executable?
 
         if source.writable?
           FileUtils.chmod "+x", source

--- a/Library/Homebrew/cask/artifact/command_wrapper.rb
+++ b/Library/Homebrew/cask/artifact/command_wrapper.rb
@@ -65,19 +65,24 @@ module Cask
 
       sig {
         override.params(
-          force:   T::Boolean,
-          adopt:   T::Boolean,
-          command: T.class_of(SystemCommand),
-          options: T.anything,
+          force:     T::Boolean,
+          adopt:     T::Boolean,
+          overwrite: T::Boolean,
+          dry_run:   T::Boolean,
+          command:   T.class_of(SystemCommand),
+          options:   T.anything,
         ).void
       }
-      def install_phase(force: false, adopt: false, command: SystemCommand, **options)
-        if (content = @content)
-          source.dirname.mkpath
-          source.write(content)
-        elsif (executable = @executable)
-          args = @args.map { |arg| Shellwords.shellescape(arg) }
-          source.write_env_script(executable, args, @env)
+      def install_phase(force: false, adopt: false, overwrite: false, dry_run: false, command: SystemCommand,
+                        **options)
+        unless dry_run
+          if (content = @content)
+            source.dirname.mkpath
+            source.write(content)
+          elsif (executable = @executable)
+            args = @args.map { |arg| Shellwords.shellescape(arg) }
+            source.write_env_script(executable, args, @env)
+          end
         end
         super
       end

--- a/Library/Homebrew/cask/artifact/symlinked.rb
+++ b/Library/Homebrew/cask/artifact/symlinked.rb
@@ -19,24 +19,28 @@ module Cask
 
       sig {
         params(
-          force:   T::Boolean,
-          adopt:   T::Boolean,
-          command: T.class_of(SystemCommand),
-          options: T.anything,
+          force:     T::Boolean,
+          adopt:     T::Boolean,
+          overwrite: T::Boolean,
+          dry_run:   T::Boolean,
+          command:   T.class_of(SystemCommand),
+          options:   T.anything,
         ).void
       }
-      def install_phase(force: false, adopt: false, command: SystemCommand, **options)
-        link(force:, adopt:, command:, **options)
+      def install_phase(force: false, adopt: false, overwrite: false, dry_run: false, command: SystemCommand,
+                        **options)
+        link(force:, adopt:, overwrite:, dry_run:, command:, **options)
       end
 
       sig {
         params(
+          dry_run:  T::Boolean,
           command:  T.class_of(SystemCommand),
           _options: T.anything,
         ).void
       }
-      def uninstall_phase(command: SystemCommand, **_options)
-        unlink(command:)
+      def uninstall_phase(dry_run: false, command: SystemCommand, **_options)
+        unlink(dry_run:, command:)
       end
 
       sig { returns(String) }
@@ -54,57 +58,99 @@ module Cask
         end
       end
 
+      # Whether the target is this cask's symlink, even if the source has since gone.
+      sig { returns(T::Boolean) }
+      def target_links_to_source?
+        target.symlink? && (target.readlink == source || target.realpath == source.realpath)
+      rescue => e
+        odebug "Error checking whether #{target} links to #{source}: #{e}"
+        false
+      end
+
+      # What linking would do to the current target without changing anything:
+      # `:link`, `:overwrite`, `:already_linked`, `:skip_formula` or `:conflict`.
+      sig { params(force: T::Boolean, adopt: T::Boolean, overwrite: T::Boolean).returns(Symbol) }
+      def link_action(force: false, adopt: false, overwrite: false)
+        return :link unless target.exist?
+
+        if overwrite ||
+           ((force || adopt) && target.symlink? &&
+            (target_links_to_source? || target.realpath.to_s.start_with?("#{cask.caskroom_path}/")))
+          :overwrite
+        elsif target_links_to_source?
+          :already_linked
+        elsif conflicting_formula
+          :skip_formula
+        else
+          :conflict
+        end
+      end
+
       private
 
       sig {
         overridable.params(
-          force:    T::Boolean,
-          adopt:    T::Boolean,
-          command:  T.class_of(SystemCommand),
-          _options: T.anything,
+          force:     T::Boolean,
+          adopt:     T::Boolean,
+          overwrite: T::Boolean,
+          dry_run:   T::Boolean,
+          command:   T.class_of(SystemCommand),
+          _options:  T.anything,
         ).void
       }
-      def link(force: false, adopt: false, command: SystemCommand, **_options)
-        unless source.exist?
+      def link(force: false, adopt: false, overwrite: false, dry_run: false, command: SystemCommand, **_options)
+        if !dry_run && !source.exist?
           raise CaskError,
                 "It seems the #{self.class.link_type_english_name.downcase} " \
                 "source '#{source}' is not there."
         end
 
-        if target.exist?
-          message = "It seems there is already #{self.class.english_article} " \
-                    "#{self.class.english_name} at '#{target}'"
-
-          if (force || adopt) && target.symlink? &&
-             (target.realpath == source.realpath || target.realpath.to_s.start_with?("#{cask.caskroom_path}/"))
-            opoo "#{message}; overwriting."
-            Utils.gain_permissions_remove(target, command:)
-          elsif target_links_to_source?
-            ohai "#{self.class.english_name} '#{source.basename}' is already linked to '#{target}'"
+        message = "It seems there is already #{self.class.english_article} " \
+                  "#{self.class.english_name} at '#{target}'"
+        case link_action(force:, adopt:, overwrite:)
+        when :overwrite
+          if dry_run
+            puts target
             return
-          elsif (formula = conflicting_formula)
-            opoo "#{message} from formula #{formula}; skipping link."
-            return
-          else
-            raise CaskError, "#{message}."
           end
+
+          opoo "#{message}; overwriting."
+          Utils.gain_permissions_remove(target, command:)
+        when :already_linked
+          ohai "#{self.class.english_name} '#{source.basename}' is already linked to '#{target}'" unless dry_run
+          return
+        when :skip_formula
+          opoo "#{message} from formula #{conflicting_formula}; skipping link."
+          return
+        when :conflict
+          raise CaskError, "#{message}."
+        end
+
+        if dry_run
+          # `ln --force` also replaces broken symlinks.
+          puts target if !overwrite || target.symlink?
+          return
         end
 
         ohai "Linking #{self.class.english_name} '#{source.basename}' to '#{target}'"
         create_filesystem_link(command)
       end
 
-      sig { params(command: T.class_of(SystemCommand)).void }
-      def unlink(command: SystemCommand)
+      sig { params(dry_run: T::Boolean, command: T.class_of(SystemCommand)).void }
+      def unlink(dry_run: false, command: SystemCommand)
         return unless target.symlink?
-
-        ohai "Unlinking #{self.class.english_name} '#{target}'"
 
         if (formula = conflicting_formula)
           odebug "#{target} is from formula #{formula}; skipping unlink."
           return
         end
 
+        if dry_run
+          puts target
+          return
+        end
+
+        ohai "Unlinking #{self.class.english_name} '#{target}'"
         Utils.gain_permissions_remove(target, command:)
       end
 
@@ -114,14 +160,6 @@ module Cask
 
         command.run! "/bin/ln", args: ["--no-dereference", "--force", "--symbolic", source, target],
                                 sudo: !target.dirname.writable?
-      end
-
-      sig { returns(T::Boolean) }
-      def target_links_to_source?
-        target.symlink? && target.realpath == source.realpath
-      rescue => e
-        odebug "Error checking whether #{target} links to #{source}: #{e}"
-        false
       end
 
       # Check if the target file is a symlink that originates from a formula

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -281,11 +281,10 @@ module Homebrew
       end
 
       sig {
-        params(only: T.nilable(Symbol), ignore_unavailable: T::Boolean, all_kegs: T.nilable(T::Boolean))
+        params(only: T.nilable(Symbol), ignore_unavailable: T::Boolean, method: Symbol)
           .returns([T::Array[Keg], T::Array[Cask::Cask]])
       }
-      def to_kegs_to_casks(only: parent.only_formula_or_cask, ignore_unavailable: false, all_kegs: nil)
-        method = all_kegs ? :kegs : :default_kegs
+      def to_kegs_to_casks(only: parent.only_formula_or_cask, ignore_unavailable: false, method: :default_kegs)
         key = [method, only, ignore_unavailable]
 
         @to_kegs_to_casks ||= T.let(

--- a/Library/Homebrew/cmd/link.rb
+++ b/Library/Homebrew/cmd/link.rb
@@ -12,9 +12,10 @@ module Homebrew
     class Link < AbstractCommand
       cmd_args do
         description <<~EOS
-          Symlink all of <formula>'s installed files into Homebrew's prefix.
-          This is done automatically when you install formulae but can be useful
-          for manual installations.
+          Symlink all of <formula>'s installed files or <cask>'s binaries, manpages
+          and shell completions into Homebrew's prefix. This is done automatically
+          when you install formulae and casks but can be useful for manual
+          installations.
         EOS
         switch "--overwrite",
                description: "Delete files that already exist in the prefix while linking."
@@ -22,11 +23,19 @@ module Homebrew
                description: "List files which would be linked or deleted by " \
                             "`brew link --overwrite` without actually linking or deleting any files."
         switch "-f", "--force",
-               description: "Allow keg-only formulae to be linked."
+               description: "Allow keg-only formulae to be linked. When linking casks, overwrite " \
+                            "existing symlinks originally from the same cask."
         switch "--HEAD",
                description: "Link the HEAD version of the formula if it is installed."
+        switch "--formula", "--formulae",
+               description: "Treat all named arguments as formulae."
+        switch "--cask", "--casks",
+               description: "Treat all named arguments as casks."
 
-        named_args :installed_formula, min: 1
+        conflicts "--formula", "--cask"
+        conflicts "--HEAD", "--cask"
+
+        named_args [:installed_formula, :installed_cask], min: 1
       end
 
       sig { override.void }
@@ -37,8 +46,13 @@ module Homebrew
           verbose:   args.verbose?,
         }
 
-        kegs = if args.HEAD?
-          args.named.to_kegs.group_by(&:name).filter_map do |name, resolved_kegs|
+        kegs, casks = if args.HEAD?
+          args.named.to_kegs_to_casks(only: :formula, method: :kegs)
+        else
+          args.named.to_kegs_to_casks(method: :latest_kegs)
+        end
+        if args.HEAD?
+          kegs = kegs.group_by(&:name).filter_map do |name, resolved_kegs|
             head_keg = resolved_kegs.find { |keg| keg.version.head? }
             next head_keg if head_keg.present?
 
@@ -50,8 +64,6 @@ module Homebrew
 
             nil
           end
-        else
-          args.named.to_latest_kegs
         end
 
         kegs.freeze.each do |keg|
@@ -125,6 +137,25 @@ module Homebrew
               puts_keg_only_path_message(keg)
             end
           end
+        end
+
+        casks.each do |cask|
+          raise Cask::CaskNotInstalledError, cask unless cask.installed?
+
+          artifacts = cask.artifacts.grep(Cask::Artifact::Symlinked)
+          conflict = artifacts.find do |artifact|
+            artifact.link_action(force: args.force?, overwrite: args.overwrite?) == :conflict
+          end
+          if conflict
+            raise Cask::CaskError, <<~EOS
+              Could not link #{cask}: #{conflict.target} already exists.
+              To force the link and overwrite all conflicting files:
+                brew link --cask --overwrite #{cask}
+            EOS
+          end
+
+          puts(args.overwrite? ? "Would remove:" : "Would link:") if args.dry_run?
+          artifacts.each { |artifact| artifact.install_phase(force: args.force?, **options) }
         end
       end
 

--- a/Library/Homebrew/cmd/unlink.rb
+++ b/Library/Homebrew/cmd/unlink.rb
@@ -9,22 +9,29 @@ module Homebrew
     class UnlinkCmd < AbstractCommand
       cmd_args do
         description <<~EOS
-          Remove symlinks for <formula> from Homebrew's prefix. This can be useful
-          for temporarily disabling a formula:
+          Remove symlinks for <formula> or <cask> from Homebrew's prefix. This can be
+          useful for temporarily disabling a formula:
           `brew unlink` <formula> `&&` <commands> `&& brew link` <formula>
         EOS
         switch "-n", "--dry-run",
                description: "List files which would be unlinked without actually unlinking or " \
                             "deleting any files."
+        switch "--formula", "--formulae",
+               description: "Treat all named arguments as formulae."
+        switch "--cask", "--casks",
+               description: "Treat all named arguments as casks."
 
-        named_args :installed_formula, min: 1
+        conflicts "--formula", "--cask"
+
+        named_args [:installed_formula, :installed_cask], min: 1
       end
 
       sig { override.void }
       def run
         options = { dry_run: args.dry_run?, verbose: args.verbose? }
 
-        args.named.to_default_kegs.each do |keg|
+        kegs, casks = args.named.to_kegs_to_casks
+        kegs.each do |keg|
           if args.dry_run?
             puts "Would remove:"
             keg.unlink(**options)
@@ -32,6 +39,15 @@ module Homebrew
           end
 
           Unlink.unlink(keg, dry_run: args.dry_run?, verbose: args.verbose?)
+        end
+
+        casks.each do |cask|
+          raise Cask::CaskNotInstalledError, cask unless cask.installed?
+
+          puts "Would remove:" if args.dry_run?
+          cask.artifacts.grep(Cask::Artifact::Symlinked).select(&:target_links_to_source?).each do |artifact|
+            artifact.uninstall_phase(**options)
+          end
         end
       end
     end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1280,12 +1280,7 @@ on_request: installed_on_request?, options:)
   def link(keg)
     Formula.clear_cache
 
-    cask_installed_with_formula_name = Cask::Caskroom.cask_installed?(formula.name)
-
-    if cask_installed_with_formula_name
-      ohai "#{formula.name} cask is installed, skipping link."
-      @link_keg = false
-    elsif skip_link? && !quiet?
+    if skip_link? && !quiet?
       ohai "Skipping 'link' on request"
       puts "You can run it manually using:"
       puts "  brew link #{formula.full_name}"

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -216,6 +216,8 @@ class Keg
     @opt_record = T.let(HOMEBREW_PREFIX/"opt/#{name}", Pathname)
     @oldname_opt_records = T.let([], T::Array[Pathname])
     @require_relocation = T.let(false, T::Boolean)
+    @overwritten_cask_symlinks = T.let({}, T::Hash[Pathname, [String, Pathname]])
+    @cask_symlink_tokens = T.let(nil, T.nilable(T::Hash[Pathname, String]))
   end
 
   sig { returns(Pathname) }
@@ -572,11 +574,28 @@ class Keg
       end
     end
     make_relative_symlink(linked_keg_record, path, verbose:, dry_run:, overwrite:) unless dry_run
-  rescue LinkError
+    @overwritten_cask_symlinks.group_by { |_, (cask_token, _)| cask_token }.each do |cask_token, symlinks|
+      opoo <<~EOS
+        Overwrote symlinks from the #{cask_token} cask:
+          #{symlinks.map(&:first).join("\n  ")}
+        To restore them, run:
+          brew unlink --formula #{name} && brew link --cask #{cask_token}
+      EOS
+    end
+  rescue => e
+    raise if dry_run || e.is_a?(AlreadyLinkedError)
+
     unlink(verbose:)
+    @overwritten_cask_symlinks.each do |dst, (_, source)|
+      dst.dirname.mkpath
+      FileUtils.ln_sf(source, dst)
+    end
     raise
   else
     ObserverPathnameExtension.n
+  ensure
+    @overwritten_cask_symlinks.clear
+    @cask_symlink_tokens = nil
   end
 
   sig { void }
@@ -818,10 +837,13 @@ class Keg
       return
     end
 
-    dst.delete if overwrite && (dst.exist? || dst.symlink?)
+    if overwrite && (dst.exist? || dst.symlink?)
+      record_cask_symlink(dst)
+      dst.delete
+    end
     dst.make_relative_symlink(src)
   rescue Errno::EEXIST => e
-    raise ConflictError.new(self, src.relative_path_from(path), dst, e) if dst.exist?
+    raise ConflictError.new(self, src.relative_path_from(path), dst, e) if dst.exist? && record_cask_symlink(dst).nil?
 
     if dst.symlink?
       dst.unlink
@@ -842,6 +864,28 @@ class Keg
     elsif alias_symlink.symlink? || alias_symlink.exist?
       alias_symlink.delete
     end
+  end
+
+  # Casks skip linking over formula symlinks (`Cask::Artifact::Symlinked#conflicting_formula`) and
+  # formulae overwrite cask symlinks, so record `dst` for the trailing warning and rollback if it is one,
+  # returning the cask's token.
+  sig { params(dst: Pathname).returns(T.nilable(String)) }
+  def record_cask_symlink(dst)
+    return unless dst.symlink?
+
+    @cask_symlink_tokens ||= begin
+      require "cask/caskroom"
+      Cask::Caskroom.casks.each_with_object({}) do |cask, tokens|
+        cask.artifacts.each do |artifact|
+          next unless artifact.is_a?(Cask::Artifact::Symlinked)
+
+          tokens[artifact.target] = cask.token if artifact.target_links_to_source?
+        end
+      end
+    end
+    cask_token = @cask_symlink_tokens[dst]
+    @overwritten_cask_symlinks[dst] = [cask_token, dst.readlink] if cask_token
+    cask_token
   end
 
   protected

--- a/Library/Homebrew/test/cask/artifact/binary_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/binary_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Cask::Artifact::Binary, :cask do
 
   it "raises a clean error when the target symlink cannot be resolved" do
     artifact = artifacts.first
-    expected_path.make_symlink(artifact.source)
+    expected_path.make_symlink(binarydir)
     allow(artifact.target).to receive(:realpath).and_raise(Errno::EACCES)
 
     expect do

--- a/Library/Homebrew/test/cask/artifact/command_wrapper_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/command_wrapper_spec.rb
@@ -42,6 +42,14 @@ RSpec.describe Cask::Artifact::CommandWrapper, :cask do
     )
   end
 
+  it "lists the target in a dry run without writing the wrapper" do
+    expect do
+      artifact.install_phase(command: NeverSudoSystemCommand, force: false, dry_run: true)
+    end.to output("#{target}\n").to_stdout
+
+    expect(artifact.source).not_to exist
+  end
+
   it "serialises the wrapper definition" do
     expect(artifact.to_args).to eq([
       "example",

--- a/Library/Homebrew/test/cask/artifact/symlinked_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/symlinked_spec.rb
@@ -26,16 +26,15 @@ RSpec.describe Cask::Artifact::Symlinked, :cask do
     end
 
     context "when target is already linked from a formula" do
-      it "detects the conflict and skips linking with warning" do
-        # Create a fake formula directory structure
-        formula_cellar_path = HOMEBREW_CELLAR/"with-binary/1.0.0/bin"
-        formula_cellar_path.mkpath
-        formula_binary_path = formula_cellar_path/"binary"
+      let(:formula_binary_path) { HOMEBREW_CELLAR/"with-binary/1.0.0/bin/binary" }
+
+      before do
+        formula_binary_path.dirname.mkpath
         FileUtils.touch formula_binary_path
-
-        # Create symlink from the expected location to the formula binary
         target_path.make_symlink(formula_binary_path)
+      end
 
+      it "detects the conflict and skips linking with warning" do
         stderr = <<~EOS
           Warning: It seems there is already a Binary at '#{target_path}' from formula with-binary; skipping link.
         EOS
@@ -47,6 +46,20 @@ RSpec.describe Cask::Artifact::Symlinked, :cask do
         expect(target_path).to be_a_symlink
         expect(target_path.readlink).to eq(formula_binary_path)
       end
+
+      it "overwrites the formula's symlink when overwriting" do
+        expect do
+          binary_artifact.install_phase(command: NeverSudoSystemCommand, force: false, overwrite: true)
+        end.to output(/; overwriting\.$/).to_stderr
+
+        expect(target_path.readlink).to eq(binary_artifact.source)
+      end
+
+      it "does not list the formula's symlink when unlinking in a dry run" do
+        expect do
+          binary_artifact.uninstall_phase(command: NeverSudoSystemCommand, dry_run: true)
+        end.not_to output.to_stdout
+      end
     end
 
     context "when target doesn't exist" do
@@ -57,6 +70,14 @@ RSpec.describe Cask::Artifact::Symlinked, :cask do
 
         expect(target_path).to be_a_symlink
         expect(target_path.readlink).to exist
+      end
+
+      it "only lists the target in a dry run" do
+        expect do
+          binary_artifact.install_phase(command: NeverSudoSystemCommand, force: false, dry_run: true)
+        end.to output("#{target_path}\n").to_stdout
+
+        expect(target_path).not_to be_a_symlink
       end
     end
   end

--- a/Library/Homebrew/test/cmd/link_spec.rb
+++ b/Library/Homebrew/test/cmd/link_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Homebrew::Cmd::Link do
     keg = instance_double(Keg, rack: HOMEBREW_CELLAR/"testball", linked?: false, name: "testball")
 
     cmd = described_class.new(["testball"])
-    allow(cmd.args.named).to receive(:to_latest_kegs).and_return([keg])
+    allow(cmd.args.named).to receive(:to_kegs_to_casks).and_return([[keg], []])
     allow(Formulary).to receive(:keg_only?).with(keg.rack).and_return(false)
     allow(keg).to receive(:to_formula).and_return(formula)
     expect(Homebrew::Unlink).to receive(:unlink_link_overwrite_formulae).with(formula, verbose: false)
@@ -23,6 +23,27 @@ RSpec.describe Homebrew::Cmd::Link do
     expect(keg).to receive(:link).with(dry_run: false, verbose: false, overwrite: false).and_return(1)
 
     expect { cmd.run }.to output(/Linking .*1 symlinks created\./).to_stdout
+  end
+
+  it "links a given Cask's symlinked artifacts", :cask do
+    cask = Cask::CaskLoader.load(cask_path("with-binary"))
+    InstallHelper.install_without_artifacts_with_caskfile(cask)
+    cmd = described_class.new(["--cask", "with-binary"])
+    allow(cmd.args.named).to receive(:to_kegs_to_casks).and_return([[], [cask]])
+
+    expect { cmd.run }.to output(/Linking Binary 'binary'/).to_stdout
+    expect(cask.config.binarydir/"binary").to be_a_symlink
+  end
+
+  it "refuses to link a Cask over an existing file before linking anything", :cask do
+    cask = Cask::CaskLoader.load(cask_path("with-binary"))
+    InstallHelper.install_without_artifacts_with_caskfile(cask)
+    cask.config.binarydir.mkpath
+    FileUtils.touch cask.config.binarydir/"binary"
+    cmd = described_class.new(["--cask", "with-binary"])
+    allow(cmd.args.named).to receive(:to_kegs_to_casks).and_return([[], [cask]])
+
+    expect { cmd.run }.to raise_error(Cask::CaskError, /brew link --cask --overwrite with-binary/)
   end
 
   it "links a given Formula", :integration_test do
@@ -64,7 +85,7 @@ RSpec.describe Homebrew::Cmd::Link do
       )
       cmd = described_class.new([formula_name])
 
-      allow(cmd.args.named).to receive(:to_latest_kegs).and_return([keg])
+      allow(cmd.args.named).to receive(:to_kegs_to_casks).and_return([[keg], []])
       allow(Formulary).to receive(:keg_only?).with(keg.rack).and_return(true)
       allow(Homebrew::Unlink).to receive(:unlink_link_overwrite_formulae)
       allow(keg).to receive(:lock).and_yield

--- a/Library/Homebrew/test/cmd/unlink_spec.rb
+++ b/Library/Homebrew/test/cmd/unlink_spec.rb
@@ -7,6 +7,32 @@ require "cmd/unlink"
 RSpec.describe Homebrew::Cmd::UnlinkCmd do
   it_behaves_like "parseable arguments"
 
+  it "unlinks a given Cask's symlinked artifacts", :cask do
+    cask = Cask::CaskLoader.load(cask_path("with-binary"))
+    InstallHelper.install_without_artifacts_with_caskfile(cask)
+    binary = cask.config.binarydir/"binary"
+    binary.dirname.mkpath
+    binary.make_symlink(cask.staged_path/"binary")
+    cmd = described_class.new(["--cask", "with-binary"])
+    allow(cmd.args.named).to receive(:to_kegs_to_casks).and_return([[], [cask]])
+
+    expect { cmd.run }.to output(/Unlinking Binary/).to_stdout
+    expect(binary).not_to be_a_symlink
+  end
+
+  it "leaves symlinks the Cask no longer owns alone", :cask do
+    cask = Cask::CaskLoader.load(cask_path("with-binary"))
+    InstallHelper.install_without_artifacts_with_caskfile(cask)
+    binary = cask.config.binarydir/"binary"
+    binary.dirname.mkpath
+    binary.make_symlink(cask.staged_path/"other")
+    cmd = described_class.new(["--cask", "with-binary"])
+    allow(cmd.args.named).to receive(:to_kegs_to_casks).and_return([[], [cask]])
+
+    expect { cmd.run }.not_to output.to_stdout
+    expect(binary).to be_a_symlink
+  end
+
   it "unlinks a Formula", :integration_test do
     setup_test_formula "testball", tab_attributes: { installed_on_request: true }
     formula_prefix = Formula["testball"].prefix

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -1129,7 +1129,6 @@ RSpec.describe FormulaInstaller do
 
     before do
       allow(Formula).to receive(:clear_cache)
-      allow(Cask::Caskroom).to receive(:path).and_return(Pathname("/tmp/nonexistent-caskroom"))
       allow(versioned_formula).to receive_messages(link_overwrite_formulae: [other_version],
                                                    any_version_installed?:  false)
       allow(other_version).to receive(:any_version_installed?).and_return(true)

--- a/Library/Homebrew/test/keg_spec.rb
+++ b/Library/Homebrew/test/keg_spec.rb
@@ -134,10 +134,11 @@ RSpec.describe Keg do
       end
     end
 
-    it "fails when already linked" do
+    it "fails when already linked without unlinking" do
       keg.link
 
       expect { keg.link }.to raise_error(Keg::AlreadyLinkedError)
+      expect(keg).to be_linked
     end
 
     it "fails when files exist" do
@@ -151,6 +152,70 @@ RSpec.describe Keg do
       dst.make_symlink(nonexistent)
       keg.link
       expect(dst.readlink).to eq(src.relative_path_from(dst.dirname))
+    end
+
+    context "when a cask's binary artifact targets a file" do
+      let(:cask_binary) { HOMEBREW_PREFIX/"lib/helloworld" }
+
+      before do
+        touch cask_binary
+        source = cask_binary
+        allow(Cask::Caskroom).to receive(:casks).and_return([Cask::Cask.new("dotnet-sdk") { binary source }])
+      end
+
+      it "overwrites the cask's symlink with a trailing warning" do
+        dst.make_symlink(cask_binary)
+
+        expect { keg.link }.to output(<<~EOS).to_stderr
+          Warning: Overwrote symlinks from the dotnet-sdk cask:
+            #{dst}
+          To restore them, run:
+            brew unlink --formula foo && brew link --cask dotnet-sdk
+        EOS
+        expect(dst.readlink).to eq((keg/"bin/helloworld").relative_path_from(dst.dirname))
+      end
+
+      it "warns about the cask's symlink when overwriting and forgets it afterwards" do
+        dst.make_symlink(cask_binary)
+
+        expect { keg.link(overwrite: true) }.to output(/Overwrote symlinks from the dotnet-sdk cask/).to_stderr
+        keg.unlink
+        expect { keg.link }.not_to output.to_stderr
+      end
+
+      it "restores the cask's symlink in a pruned directory when a later file conflicts" do
+        completion = HOMEBREW_PREFIX/"share/fish/vendor_completions.d/helloworld.fish"
+        (keg/"share/fish/vendor_completions.d").mkpath
+        touch keg/"share/fish/vendor_completions.d/helloworld.fish"
+        touch keg/"share/zzz"
+        completion.dirname.mkpath
+        completion.make_symlink(cask_binary)
+        touch HOMEBREW_PREFIX/"share/zzz"
+        source = cask_binary
+        allow(Cask::Caskroom).to receive(:casks)
+          .and_return([Cask::Cask.new("dotnet-sdk") { binary source, target: completion }])
+
+        expect { keg.link }.to raise_error(Keg::ConflictError)
+        expect(completion.readlink).to eq(cask_binary)
+        expect { keg.link(dry_run: true, overwrite: true) }.not_to output.to_stderr
+      end
+
+      it "restores the cask's symlink when linking fails with any error" do
+        dst.make_symlink(cask_binary)
+        (keg/"share/info").mkpath
+        touch keg/"share/info/helloworld.info"
+        allow(Utils::Path).to receive(:install_info).and_raise("boom")
+
+        expect { keg.link }.to raise_error(RuntimeError, "boom")
+        expect(dst.readlink).to eq(cask_binary)
+      end
+
+      it "does not overwrite a symlink that doesn't resolve to the cask's binary" do
+        touch HOMEBREW_PREFIX/"lib/other"
+        dst.make_symlink(HOMEBREW_PREFIX/"lib/other")
+
+        expect { keg.link }.to raise_error(Keg::ConflictError)
+      end
     end
 
     context "with overwrite set to true" do

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -2134,9 +2134,11 @@ _brew_link() {
     -*)
       __brewcomp "
       --HEAD
+      --cask
       --debug
       --dry-run
       --force
+      --formula
       --help
       --overwrite
       --quiet
@@ -2147,6 +2149,7 @@ _brew_link() {
     *) ;;
   esac
   __brew_complete_installed_formulae
+  __brew_complete_installed_casks
 }
 
 _brew_linkage() {
@@ -3313,8 +3316,10 @@ _brew_unlink() {
   case "${cur}" in
     -*)
       __brewcomp "
+      --cask
       --debug
       --dry-run
+      --formula
       --help
       --quiet
       --verbose
@@ -3324,6 +3329,7 @@ _brew_unlink() {
     *) ;;
   esac
   __brew_complete_installed_formulae
+  __brew_complete_installed_casks
 }
 
 _brew_unpack() {

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -1391,16 +1391,19 @@ __fish_brew_complete_arg 'lgtm' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'lgtm' -l verbose -d 'Make some output more verbose'
 
 
-__fish_brew_complete_cmd 'link' 'Symlink all of formula\'s installed files into Homebrew\'s prefix'
+__fish_brew_complete_cmd 'link' 'Symlink all of formula\'s installed files or cask\'s binaries, manpages and shell completions into Homebrew\'s prefix'
 __fish_brew_complete_arg 'link' -l HEAD -d 'Link the HEAD version of the formula if it is installed'
+__fish_brew_complete_arg 'link' -l cask -d 'Treat all named arguments as casks'
 __fish_brew_complete_arg 'link' -l debug -d 'Display any debugging information'
 __fish_brew_complete_arg 'link' -l dry-run -d 'List files which would be linked or deleted by `brew link --overwrite` without actually linking or deleting any files'
-__fish_brew_complete_arg 'link' -l force -d 'Allow keg-only formulae to be linked'
+__fish_brew_complete_arg 'link' -l force -d 'Allow keg-only formulae to be linked. When linking casks, overwrite existing symlinks originally from the same cask'
+__fish_brew_complete_arg 'link' -l formula -d 'Treat all named arguments as formulae'
 __fish_brew_complete_arg 'link' -l help -d 'Show this message'
 __fish_brew_complete_arg 'link' -l overwrite -d 'Delete files that already exist in the prefix while linking'
 __fish_brew_complete_arg 'link' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'link' -l verbose -d 'Make some output more verbose'
-__fish_brew_complete_arg 'link' -a '(__fish_brew_suggest_formulae_installed)'
+__fish_brew_complete_arg 'link; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_installed)'
+__fish_brew_complete_arg 'link; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_installed)'
 
 
 __fish_brew_complete_cmd 'linkage' 'Check the library links from the given formula kegs'
@@ -2101,13 +2104,16 @@ __fish_brew_complete_arg 'uninstall; and not __fish_seen_argument -l cask -l cas
 __fish_brew_complete_arg 'uninstall; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_installed)'
 
 
-__fish_brew_complete_cmd 'unlink' 'Remove symlinks for formula from Homebrew\'s prefix'
+__fish_brew_complete_cmd 'unlink' 'Remove symlinks for formula or cask from Homebrew\'s prefix'
+__fish_brew_complete_arg 'unlink' -l cask -d 'Treat all named arguments as casks'
 __fish_brew_complete_arg 'unlink' -l debug -d 'Display any debugging information'
 __fish_brew_complete_arg 'unlink' -l dry-run -d 'List files which would be unlinked without actually unlinking or deleting any files'
+__fish_brew_complete_arg 'unlink' -l formula -d 'Treat all named arguments as formulae'
 __fish_brew_complete_arg 'unlink' -l help -d 'Show this message'
 __fish_brew_complete_arg 'unlink' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'unlink' -l verbose -d 'Make some output more verbose'
-__fish_brew_complete_arg 'unlink' -a '(__fish_brew_suggest_formulae_installed)'
+__fish_brew_complete_arg 'unlink; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_installed)'
+__fish_brew_complete_arg 'unlink; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_installed)'
 
 
 __fish_brew_complete_cmd 'unpack' 'Unpack the files for the formula or cask into subdirectories of the current working directory'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -213,7 +213,7 @@ __brew_internal_commands() {
     'irb:Enter the interactive Homebrew Ruby shell'
     'leaves:List installed formulae that are not dependencies of another installed formula or cask'
     'lgtm:Run `brew typecheck`, `brew style --changed` and the relevant `brew tests`, `brew audit` and `brew test` checks in one go'
-    'link:Symlink all of formula'\''s installed files into Homebrew'\''s prefix'
+    'link:Symlink all of formula'\''s installed files or cask'\''s binaries, manpages and shell completions into Homebrew'\''s prefix'
     'linkage:Check the library links from the given formula kegs'
     'list:List all installed formulae and casks'
     'livecheck:Check for newer versions of formulae and/or casks from upstream'
@@ -254,7 +254,7 @@ __brew_internal_commands() {
     'unalias:Remove aliases'
     'unbottled:Show the unbottled dependents of formulae'
     'uninstall:Uninstall a formula or cask'
-    'unlink:Remove symlinks for formula from Homebrew'\''s prefix'
+    'unlink:Remove symlinks for formula or cask from Homebrew'\''s prefix'
     'unpack:Unpack the files for the formula or cask into subdirectories of the current working directory'
     'unpin:Unpin the specified package, allowing it to be upgraded by `brew upgrade` formula or cask'
     'untap:Remove a tapped formula repository'
@@ -1806,16 +1806,20 @@ _brew_lgtm() {
 # brew link
 _brew_link() {
   _arguments \
-    '--HEAD[Link the HEAD version of the formula if it is installed]' \
+    '(--cask)--HEAD[Link the HEAD version of the formula if it is installed]' \
     '--debug[Display any debugging information]' \
     '--dry-run[List files which would be linked or deleted by `brew link --overwrite` without actually linking or deleting any files]' \
-    '--force[Allow keg-only formulae to be linked]' \
+    '--force[Allow keg-only formulae to be linked. When linking casks, overwrite existing symlinks originally from the same cask]' \
     '--help[Show this message]' \
     '--overwrite[Delete files that already exist in the prefix while linking]' \
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - installed_formula \
-    '*:installed_formula:__brew_installed_formulae'
+    '(--cask)--formula[Treat all named arguments as formulae]' \
+    '*:installed_formula:__brew_installed_formulae' \
+    - installed_cask \
+    '(--formula --HEAD)--cask[Treat all named arguments as casks]' \
+    '*:installed_cask:__brew_installed_casks'
 }
 
 # brew linkage
@@ -2705,7 +2709,11 @@ _brew_unlink() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - installed_formula \
-    '*:installed_formula:__brew_installed_formulae'
+    '(--cask)--formula[Treat all named arguments as formulae]' \
+    '*:installed_formula:__brew_installed_formulae' \
+    - installed_cask \
+    '(--formula)--cask[Treat all named arguments as casks]' \
+    '*:installed_cask:__brew_installed_casks'
 }
 
 # brew unpack

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1523,11 +1523,11 @@ or cask.
 
 : Only list leaves that were installed as dependencies.
 
-### `link`, `ln` \[*`options`*\] *`installed_formula`* \[...\]
+### `link`, `ln` \[*`options`*\] *`installed_formula`*\|*`installed_cask`* \[...\]
 
-Symlink all of *`formula`*'s installed files into Homebrew's prefix. This is
-done automatically when you install formulae but can be useful for manual
-installations.
+Symlink all of *`formula`*'s installed files or *`cask`*'s binaries, manpages
+and shell completions into Homebrew's prefix. This is done automatically when
+you install formulae and casks but can be useful for manual installations.
 
 `--overwrite`
 
@@ -1540,11 +1540,20 @@ installations.
 
 `-f`, `--force`
 
-: Allow keg-only formulae to be linked.
+: Allow keg-only formulae to be linked. When linking casks, overwrite existing
+  symlinks originally from the same cask.
 
 `--HEAD`
 
 : Link the HEAD version of the formula if it is installed.
+
+`--formula`
+
+: Treat all named arguments as formulae.
+
+`--cask`
+
+: Treat all named arguments as casks.
 
 ### `list`, `ls` \[*`options`*\] \[*`installed_formula`*\|*`installed_cask`* ...\]
 
@@ -2281,16 +2290,24 @@ Uninstall a *`formula`* or *`cask`*.
 
 : Treat all named arguments as casks.
 
-### `unlink` \[`--dry-run`\] *`installed_formula`* \[...\]
+### `unlink` \[*`options`*\] *`installed_formula`*\|*`installed_cask`* \[...\]
 
-Remove symlinks for *`formula`* from Homebrew's prefix. This can be useful for
-temporarily disabling a formula: `brew unlink` *`formula`* `&&` *`commands`* `&&
-brew link` *`formula`*
+Remove symlinks for *`formula`* or *`cask`* from Homebrew's prefix. This can be
+useful for temporarily disabling a formula: `brew unlink` *`formula`* `&&`
+*`commands`* `&& brew link` *`formula`*
 
 `-n`, `--dry-run`
 
 : List files which would be unlinked without actually unlinking or deleting any
   files.
+
+`--formula`
+
+: Treat all named arguments as formulae.
+
+`--cask`
+
+: Treat all named arguments as casks.
 
 ### `unpin` \[`--formula`\] \[`--cask`\] *`installed_formula`*\|*`installed_cask`* \[...\]
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -976,8 +976,8 @@ Only list leaves that were manually installed\.
 .TP
 \fB\-p\fP, \fB\-\-installed\-as\-dependency\fP
 Only list leaves that were installed as dependencies\.
-.SS "\fBlink\fP, \fBln\fP \fR[\fIoptions\fP] \fIinstalled_formula\fP \fR[\.\.\.]"
-Symlink all of \fIformula\fP\[u2019]s installed files into Homebrew\[u2019]s prefix\. This is done automatically when you install formulae but can be useful for manual installations\.
+.SS "\fBlink\fP, \fBln\fP \fR[\fIoptions\fP] \fIinstalled_formula\fP|\fIinstalled_cask\fP \fR[\.\.\.]"
+Symlink all of \fIformula\fP\[u2019]s installed files or \fIcask\fP\[u2019]s binaries, manpages and shell completions into Homebrew\[u2019]s prefix\. This is done automatically when you install formulae and casks but can be useful for manual installations\.
 .TP
 \fB\-\-overwrite\fP
 Delete files that already exist in the prefix while linking\.
@@ -986,10 +986,16 @@ Delete files that already exist in the prefix while linking\.
 List files which would be linked or deleted by \fBbrew link \-\-overwrite\fP without actually linking or deleting any files\.
 .TP
 \fB\-f\fP, \fB\-\-force\fP
-Allow keg\-only formulae to be linked\.
+Allow keg\-only formulae to be linked\. When linking casks, overwrite existing symlinks originally from the same cask\.
 .TP
 \fB\-\-HEAD\fP
 Link the HEAD version of the formula if it is installed\.
+.TP
+\fB\-\-formula\fP
+Treat all named arguments as formulae\.
+.TP
+\fB\-\-cask\fP
+Treat all named arguments as casks\.
 .SS "\fBlist\fP, \fBls\fP \fR[\fIoptions\fP] \fR[\fIinstalled_formula\fP|\fIinstalled_cask\fP \.\.\.]"
 List all installed formulae and casks\. If \fIformula\fP is provided, summarise the paths within its current keg\. If \fIcask\fP is provided, list its artifacts\.
 .TP
@@ -1447,11 +1453,17 @@ Treat all named arguments as formulae\.
 .TP
 \fB\-\-cask\fP
 Treat all named arguments as casks\.
-.SS "\fBunlink\fP \fR[\fB\-\-dry\-run\fP] \fIinstalled_formula\fP \fR[\.\.\.]"
-Remove symlinks for \fIformula\fP from Homebrew\[u2019]s prefix\. This can be useful for temporarily disabling a formula: \fBbrew unlink\fP \fIformula\fP \fB&&\fP \fIcommands\fP \fB&& brew link\fP \fIformula\fP
+.SS "\fBunlink\fP \fR[\fIoptions\fP] \fIinstalled_formula\fP|\fIinstalled_cask\fP \fR[\.\.\.]"
+Remove symlinks for \fIformula\fP or \fIcask\fP from Homebrew\[u2019]s prefix\. This can be useful for temporarily disabling a formula: \fBbrew unlink\fP \fIformula\fP \fB&&\fP \fIcommands\fP \fB&& brew link\fP \fIformula\fP
 .TP
 \fB\-n\fP, \fB\-\-dry\-run\fP
 List files which would be unlinked without actually unlinking or deleting any files\.
+.TP
+\fB\-\-formula\fP
+Treat all named arguments as formulae\.
+.TP
+\fB\-\-cask\fP
+Treat all named arguments as casks\.
 .SS "\fBunpin\fP \fR[\fB\-\-formula\fP] \fR[\fB\-\-cask\fP] \fIinstalled_formula\fP|\fIinstalled_cask\fP \fR[\.\.\.]"
 Unpin the specified package, allowing it to be upgraded by \fBbrew upgrade\fP \fIformula\fP or \fIcask\fP\&\. See also \fBpin\fP\&\.
 .TP


### PR DESCRIPTION
- Casks such as `dotnet-sdk` link `binary` artifacts into `HOMEBREW_PREFIX/bin`, so installing a formula that ships the same binary (e.g. `dotnet` as a `powershell` dependency) failed at the `brew link` step with a conflict on a file Homebrew itself created.
- Formula links now always overwrite symlinks that resolve to an installed cask's `binary`-style artifact, while casks keep skipping links already owned by a formula (`Cask::Artifact::Symlinked#conflicting_formula`), so neither direction fails or exits non-zero. A single trailing warning per cask lists the overwritten symlinks and how to restore them, and a later link failure restores them itself.
- Doing this in `Keg#link` covers `brew install`, `brew upgrade` and `brew link` alike; installed casks are only enumerated on a conflict.
- Drop `FormulaInstaller#link` skipping formulae with a same-named cask installed (6f184ea0dd3): it only existed because the link would fail.
- Let `brew link` and `brew unlink` take casks, with `--formula` and `--cask` switches like `brew uninstall`, and (un)link their `binary`, `manpage` and shell completion artifacts so overwritten cask symlinks can be restored without reinstalling the cask. `--dry-run` lists the targets, `--overwrite` removes whatever already exists at a target and `--force` keeps the cask installer's meaning of overwriting symlinks originally from the same cask.
- Take the keg resolution `method` in `NamedArgs#to_kegs_to_casks` so `brew link` can keep using latest kegs.

Fixes #23922