### PR TITLE
contributions: match co-authored commits made under a real name/email

### DIFF
--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -344,6 +344,11 @@ module Homebrew
 
         require "utils/github"
         github_users = users.keys.to_h { |user| [user, github_username_for(user, to:)] }
+        # Real names/public emails, so commits under a maintainer's git identity are matched to their username.
+        github_identities = users.keys.to_h do |user|
+          github_user = github_users.fetch(user)
+          [user, github_user ? github_identity_for_username(github_user, to:) : [nil, nil]]
+        end
         git_authored_pull_requests = users.keys.to_h do |user|
           [user, repositories.to_h { |repository| [repository, Set.new] }]
         end
@@ -358,7 +363,8 @@ module Homebrew
           )
           authored_pull_requests = users.keys.to_h { |user| [user, Set.new] }
           merged_pull_requests = users.keys.to_h { |user| [user, Set.new] }
-          parse_git_log(output, users, authored_pull_requests:, merged_pull_requests:).each do |user, counts|
+          parse_git_log(output, users, github_identities:, authored_pull_requests:, merged_pull_requests:)
+            .each do |user, counts|
             results.fetch(user)[repository] = counts
             git_authored_pull_requests.fetch(user)[repository] = authored_pull_requests.fetch(user)
             git_merged_pull_requests.fetch(user)[repository] = merged_pull_requests.fetch(user)
@@ -492,9 +498,23 @@ module Homebrew
         nil
       end
 
+      sig { params(username: String, to: String).returns([T.nilable(String), T.nilable(String)]) }
+      def github_identity_for_username(username, to:)
+        cache_key = ["user-profile", username].join("\0")
+        profile = github_search_with_rate_limit(cache_key, to:) do
+          GitHub::API.open_rest(GitHub.url_to("users", username))
+        rescue GitHub::API::HTTPNotFoundError
+          {}
+        end
+        [profile["name"], profile["email"]]
+      end
+
       sig {
-        params(cache_key: String, to: String, block: T.proc.returns(T::Array[T::Hash[String, T.untyped]]))
-          .returns(T::Array[T::Hash[String, T.untyped]])
+        params(
+          cache_key: String,
+          to:        String,
+          block:     T.proc.returns(T.any(T::Array[T::Hash[String, T.untyped]], T::Hash[String, T.untyped])),
+        ).returns(T::Hash[String, T.untyped])
       }
       def github_search_with_rate_limit(cache_key, to:, &block)
         cache_path = if Date.iso8601(to) <= Date.today
@@ -502,20 +522,19 @@ module Homebrew
         end
         if cache_path&.file?
           begin
-            cached_results = JSON.parse(cache_path.read)
-            return cached_results if cached_results.is_a?(Array)
+            return JSON.parse(cache_path.read)
           rescue JSON::ParserError, Errno::ENOENT
             nil
           end
           cache_path.unlink if cache_path.exist?
         end
 
-        results = yield
+        result = yield
         if cache_path
           HOMEBREW_CACHE.mkpath
-          cache_path.atomic_write(JSON.generate(results))
+          cache_path.atomic_write(JSON.generate(result))
         end
-        results
+        result
       rescue GitHub::API::RateLimitExceededError => e
         GitHub::API.sleep_for_rate_limit(e)
         retry
@@ -525,12 +544,13 @@ module Homebrew
         params(
           output:                 String,
           users:                  T::Hash[String, String],
+          github_identities:      T.nilable(T::Hash[String, [T.nilable(String), T.nilable(String)]]),
           authored_pull_requests: T.nilable(T::Hash[String, T::Set[String]]),
           merged_pull_requests:   T.nilable(T::Hash[String, T::Set[String]]),
         )
           .returns(T::Hash[String, T::Hash[Symbol, Integer]])
       }
-      def parse_git_log(output, users, authored_pull_requests: nil, merged_pull_requests: nil)
+      def parse_git_log(output, users, github_identities: nil, authored_pull_requests: nil, merged_pull_requests: nil)
         counts = users.to_h do |user, _|
           [user, CONTRIBUTION_TYPES.keys.to_h { |type| [type, 0] }]
         end
@@ -539,6 +559,13 @@ module Homebrew
           identity_users[user.downcase] = user
           identity_users[name.downcase] = user
           identity_users[user.split("@").first.to_s.sub(/\A\d+\+/, "").downcase] = user
+
+          github_name, github_email = github_identities&.fetch(user, nil)
+          identity_users[github_name.downcase] ||= user if github_name
+          next unless github_email
+
+          identity_users[github_email.downcase] ||= user
+          identity_users[github_email.split("@").first.to_s.sub(/\A\d+\+/, "").downcase] ||= user
         end
         records = output.split("\x1e").filter_map do |record|
           fields = record.strip.split("\x1f", 5)

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -510,11 +510,11 @@ module Homebrew
       end
 
       sig {
-        params(
+        type_parameters(:U).params(
           cache_key: String,
           to:        String,
-          block:     T.proc.returns(T.any(T::Array[T::Hash[String, T.untyped]], T::Hash[String, T.untyped])),
-        ).returns(T::Hash[String, T.untyped])
+          block:     T.proc.returns(T.type_parameter(:U)),
+        ).returns(T.type_parameter(:U))
       }
       def github_search_with_rate_limit(cache_key, to:, &block)
         cache_path = if Date.iso8601(to) <= Date.today

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -347,7 +347,12 @@ module Homebrew
         # Real names/public emails, so commits under a maintainer's git identity are matched to their username.
         github_identities = users.keys.to_h do |user|
           github_user = github_users.fetch(user)
-          [user, github_user ? github_identity_for_username(github_user, to:) : [nil, nil]]
+          identity = if github_user
+            github_identity_for_username(github_user, to:)
+          else
+            [nil, nil]
+          end
+          [user, identity]
         end
         git_authored_pull_requests = users.keys.to_h do |user|
           [user, repositories.to_h { |repository| [repository, Set.new] }]

--- a/Library/Homebrew/test/dev-cmd/contributions_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/contributions_spec.rb
@@ -7,7 +7,10 @@ require "dev-cmd/contributions"
 require "utils/github"
 
 RSpec.describe Homebrew::DevCmd::Contributions do
-  before { stub_const("HOMEBREW_CACHE", mktmpdir) }
+  before do
+    stub_const("HOMEBREW_CACHE", mktmpdir)
+    allow(GitHub::API).to receive(:open_rest).and_return({})
+  end
 
   it_behaves_like "parseable arguments"
   it_behaves_like "a documented command", "contributions"


### PR DESCRIPTION
`--user` accepts GitHub usernames, but commits and `Co-authored-by:` trailers are attributed by git name/email, not GitHub login. Fetch each user's public name/email from their GitHub profile and add it to `identity_users` so `parse_git_log` can match their commits even when only a username was supplied.

Cache the profile lookups the same way as other GitHub API calls used by this command.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
