### PR TITLE
Promote macOS Golden Gate 27 to full support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       TEMPORARY_CERTIFICATE_FILE: "homebrew_developer_id_installer_certificate.p12"
       TEMPORARY_KEYCHAIN_FILE: "homebrew_installer_signing.keychain-db"
       # Set to the oldest supported version of macOS
-      HOMEBREW_MACOS_OLDEST_SUPPORTED: "14.0"
+      HOMEBREW_MACOS_OLDEST_SUPPORTED: "15.0"
     permissions:
       contents: write # for creating tags and releases
       attestations: write # for actions/attest

--- a/Library/Homebrew/bottle_transition.rb
+++ b/Library/Homebrew/bottle_transition.rb
@@ -22,7 +22,7 @@ class BottleTransition
 
   sig { params(base_ref: T.nilable(String)).void }
   def initialize(base_ref: nil)
-    if ENV.fetch("GITHUB_EVENT_NAME", nil) == "merge_group"
+    if self.class.active? && ENV.fetch("GITHUB_EVENT_NAME", nil) == "merge_group"
       event = JSON.parse(File.read(ENV.fetch("GITHUB_EVENT_PATH")))
       base_ref = event.dig("merge_group", "base_sha")
       if !base_ref.is_a?(String) || !/\A[0-9a-f]{40}\z/.match?(base_ref)

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -328,17 +328,18 @@ HOMEBREW_BOTTLE_DEFAULT_DOMAIN="https://ghcr.io/v2/homebrew/core"
 # - https://github.com/Homebrew/install/blob/HEAD/install.sh
 # - Library/Homebrew/os/mac.rb (latest_sdk_version)
 # - Library/Homebrew/os/mac/xcode.rb (latest_version), (minimum_version)
+# - Library/Homebrew/os/mac/xcode.rb (detect_version_from_clang_version), (latest_clang_version)
 # and, if needed:
 # - MacOSVersion::RELEASES
-HOMEBREW_MACOS_NEWEST_UNSUPPORTED="27"
+HOMEBREW_MACOS_NEWEST_UNSUPPORTED="28"
 # TODO: bump version when new macOS is released
-HOMEBREW_MACOS_NEWEST_SUPPORTED="26"
+HOMEBREW_MACOS_NEWEST_SUPPORTED="27"
 # TODO: bump version when new macOS is released and update references in:
 # - docs/Installation.md
 # - HOMEBREW_MACOS_OLDEST_SUPPORTED in .github/workflows/release.yml
 # - `os-version min` in package/Distribution.xml
 # - https://github.com/Homebrew/install/blob/HEAD/install.sh
-HOMEBREW_MACOS_OLDEST_SUPPORTED="14"
+HOMEBREW_MACOS_OLDEST_SUPPORTED="15"
 HOMEBREW_MACOS_OLDEST_ALLOWED="11"
 
 setup-os-details

--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -13,8 +13,8 @@ class GitHubRunnerMatrix
   # on homebrew/core and tag the first commit with a bottle e.g.
   # `git tag 15-sequoia f42c4a659e4da887fc714f8f41cc26794a4bb320`
   # to allow people to jump to specific commits based on their macOS version.
-  NEWEST_HOMEBREW_CORE_MACOS_RUNNER = :tahoe
-  OLDEST_HOMEBREW_CORE_MACOS_RUNNER = :sonoma
+  NEWEST_HOMEBREW_CORE_MACOS_RUNNER = :golden_gate
+  OLDEST_HOMEBREW_CORE_MACOS_RUNNER = :sequoia
 
   RunnerSpec = T.type_alias { T.any(LinuxRunnerSpec, MacOSRunnerSpec) }
   private_constant :RunnerSpec

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -62,7 +62,7 @@ module OS
     def self.latest_sdk_version
       # TODO: bump version when new Xcode macOS SDK is released
       # NOTE: We only track the major version of the SDK.
-      ::Version.new("26")
+      ::Version.new("27")
     end
 
     sig { returns(String) }

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -19,7 +19,8 @@ module OS
       def self.latest_version(macos: MacOS.version)
         macos = macos.strip_patch
         case macos
-        when "26", "15" then "26.3"
+        when "27", "26" then "27.0"
+        when "15" then "26.3"
         when "14" then "16.2"
         when "13" then "15.2"
         when "12" then "14.2"
@@ -229,7 +230,8 @@ module OS
         when "14.0.3" then "14.3.1"
         when "15.0.0" then "15.4"
         when "16.0.0" then "16.2"
-        else               "26.3"
+        when "17.0.0" then "26.3"
+        else               "27.0"
         end
       end
 
@@ -323,8 +325,8 @@ module OS
       sig { returns(String) }
       def self.latest_clang_version
         case MacOS.version
-        when "27" then "2100.3.20.102"
-        when "26", "15" then "1700.6.4.2"
+        when "27", "26" then "2100.3.34.2"
+        when "15" then "1700.6.4.2"
         when "14" then "1600.0.26.6"
         when "13" then "1500.1.0.2.5"
         when "12" then "1400.0.29.202"

--- a/Library/Homebrew/test/bottle_transition_spec.rb
+++ b/Library/Homebrew/test/bottle_transition_spec.rb
@@ -155,10 +155,17 @@ RSpec.describe BottleTransition do
   end
 
   context "when the transition OS is fully supported" do
-    it "ends the transition policy" do
-      stub_const("HOMEBREW_MACOS_NEWEST_SUPPORTED", "27")
+    before { stub_const("HOMEBREW_MACOS_NEWEST_SUPPORTED", "27") }
 
+    it "ends the transition policy" do
       expect(transition.required?(current)).to be false
+    end
+
+    it "does not require a merge-group event payload" do
+      ENV["GITHUB_EVENT_NAME"] = "merge_group"
+      ENV.delete("GITHUB_EVENT_PATH")
+
+      expect { transition.check!(current, tags: []) }.not_to raise_error
     end
   end
 

--- a/Library/Homebrew/test/dev-cmd/pr-upload_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-upload_spec.rb
@@ -131,6 +131,7 @@ RSpec.describe Homebrew::DevCmd::PrUpload do
 
     context "when the formula belongs to another tap" do
       it "does not apply the core transition policy" do
+        stub_const("HOMEBREW_MACOS_NEWEST_SUPPORTED", "26")
         allow(current).to receive(:tap).and_return(Tap.fetch("user/test"))
         allow(Formulary).to receive(:factory).with(current.path).and_return(current)
         allow_any_instance_of(BottleTransition).to receive(:required?).and_call_original

--- a/Library/Homebrew/test/github_runner_matrix_spec.rb
+++ b/Library/Homebrew/test/github_runner_matrix_spec.rb
@@ -45,6 +45,27 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
   end
 
   describe "#active_runner_specs_hash" do
+    it "builds bottles for Golden Gate, Tahoe and Sequoia" do
+      runners = described_class.new([], [], all_supported: true, dependent_matrix: false)
+                               .active_runner_specs_hash
+
+      expect(runners.map { |runner| runner.fetch(:name) })
+        .to eq(["macOS 27-arm64", "macOS 26-arm64", "macOS 15-arm64"])
+    end
+
+    it "uses a self-hosted runner for Golden Gate dependents with a two-hour timeout" do
+      ENV["GITHUB_RUN_ID"] = "12345"
+      allow(Formula).to receive(:all).and_return([testball, testball_depender].map(&:formula))
+      runners = described_class.new([testball], [], all_supported: false, dependent_matrix: true)
+                               .active_runner_specs_hash
+
+      expect(runners).to include(
+        include(name: "macOS 27-arm64", runner: "27-arm64-12345-deps", timeout: 120),
+        include(name: "macOS 26-arm64", runner: "macos-26", timeout: 360),
+        include(name: "macOS 15-arm64", runner: "macos-15", timeout: 360),
+      )
+    end
+
     context "when bootstrapping a macOS release" do
       before do
         stub_const("GitHubRunnerMatrix::NEWEST_HOMEBREW_CORE_MACOS_RUNNER", :tahoe)

--- a/Library/Homebrew/test/macos_version_spec.rb
+++ b/Library/Homebrew/test/macos_version_spec.rb
@@ -88,6 +88,24 @@ RSpec.describe MacOSVersion do
     expect(described_class.new("1000").unsupported_release?).to be true
   end
 
+  describe "release support" do
+    it "supports Sequoia, Tahoe and Golden Gate" do
+      expect(%w[15 26 27].map { |release| described_class.new(release).unsupported_release? }).to all(be false)
+    end
+
+    context "when running Sonoma" do
+      it "classifies the release as outdated" do
+        expect(described_class.new("14").outdated_release?).to be true
+      end
+    end
+
+    context "when running macOS 28" do
+      it "classifies the release as a prerelease" do
+        expect(described_class.new("28").prerelease?).to be true
+      end
+    end
+  end
+
   describe "after Big Sur" do
     specify "comparison with :big_sur" do
       expect(big_sur_major).to eq :big_sur

--- a/Library/Homebrew/test/os/mac/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/mac/diagnostic_spec.rb
@@ -175,8 +175,8 @@ RSpec.describe Homebrew::Diagnostic::Checks do
     end
 
     it "triggers when built_on version differs from current macOS version" do
-      allow(MacOS).to receive(:version).and_return(MacOSVersion.new("14"))
-      allow(tab).to receive(:built_on).and_return({ "os_version" => "13" })
+      allow(MacOS).to receive(:version).and_return(MacOSVersion.new("15"))
+      allow(tab).to receive(:built_on).and_return({ "os_version" => "14" })
 
       expect(checks.check_pkgconf_macos_sdk_mismatch&.to_s).to include("brew reinstall pkgconf")
     end

--- a/Library/Homebrew/test/os/mac/xcode_spec.rb
+++ b/Library/Homebrew/test/os/mac/xcode_spec.rb
@@ -4,7 +4,25 @@
 require "os/mac/xcode"
 
 RSpec.describe OS::Mac::Xcode, :needs_macos do
+  describe ".latest_version" do
+    it "returns the Xcode version for Golden Gate" do
+      expect(described_class.latest_version(macos: MacOSVersion.new("27"))).to eq("27.0")
+    end
+
+    it "returns Xcode 27 for Tahoe" do
+      expect(described_class.latest_version(macos: MacOSVersion.new("26"))).to eq("27.0")
+    end
+  end
+
   describe ".detect_version" do
+    it "infers Xcode 27 from the Command Line Tools compiler" do
+      allow(described_class).to receive_messages(installed?: false, prefix: nil)
+      allow(OS::Mac::CLT).to receive(:installed?).and_return(true)
+      allow(DevelopmentTools).to receive(:clang_version).and_return(Version.new("21.0.0"))
+
+      expect(described_class.detect_version).to eq("27.0")
+    end
+
     it "loads Plist when version.plist exists" do
       contents = mktmpdir/"Contents"
       contents.mkpath
@@ -24,7 +42,23 @@ RSpec.describe OS::Mac::Xcode, :needs_macos do
     end
   end
 
+  describe ".detect_version_from_clang_version" do
+    it "preserves Xcode 26.3 for clang 17" do
+      expect(described_class.detect_version_from_clang_version(Version.new("17.0.0"))).to eq("26.3")
+    end
+  end
+
   describe OS::Mac::CLT do
+    describe ".latest_clang_version" do
+      test_each(%w[27 26]) do |macos|
+        it "recommends the Xcode 27 compiler on macOS #{macos}" do
+          allow(OS::Mac).to receive(:version).and_return(MacOSVersion.new(macos))
+
+          expect(described_class.latest_clang_version).to eq("2100.3.34.2")
+        end
+      end
+    end
+
     describe ".update_instructions" do
       it "recommends Software Update on prerelease macOS" do
         allow(OS::Mac).to receive(:version).and_return(MacOSVersion.new(HOMEBREW_MACOS_NEWEST_UNSUPPORTED))

--- a/Library/Homebrew/test/requirements/macos_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/macos_requirement_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe MacOSRequirement do
 
   let(:macos_oldest_allowed) { MacOSVersion.new(HOMEBREW_MACOS_OLDEST_ALLOWED) }
   let(:macos_newest_allowed) { MacOSVersion.new(HOMEBREW_MACOS_NEWEST_UNSUPPORTED) }
+  let(:macos_newest_supported) { MacOSVersion.new(HOMEBREW_MACOS_NEWEST_SUPPORTED) }
   let(:tahoe_major) { MacOSVersion.new("26.0") }
 
   it "disables Catalina requirements" do
@@ -47,9 +48,9 @@ RSpec.describe MacOSRequirement do
     context "when running on Linux", :needs_linux do
       it "returns false" do
         expect(requirement.satisfied?).to be false
-        requirement = described_class.new([macos_newest_allowed.to_sym])
+        requirement = described_class.new([macos_newest_supported.to_sym])
         expect(requirement.satisfied?).to be false
-        requirement = described_class.new([macos_newest_allowed.to_sym], comparator: "<=")
+        requirement = described_class.new([macos_newest_supported.to_sym], comparator: "<=")
         expect(requirement.satisfied?).to be false
       end
     end

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -26,7 +26,7 @@ The installer ignores an override that does not meet these requirements and fall
 ## macOS requirements
 
 * An Apple Silicon CPU; using a 64-bit Intel CPU is a [Tier 3](Support-Tiers.md#tier-3) configuration <sup>[1](#1)</sup>
-* macOS Sonoma (14) (or higher) installed on officially supported hardware<sup>[2](#2)</sup>
+* macOS Sequoia (15) (or higher) installed on officially supported hardware<sup>[2](#2)</sup>
 * Command Line Tools (CLT) for Xcode (from `xcode-select --install` or
   [https://developer.apple.com/download/all/](https://developer.apple.com/download/all/)) or
   [Xcode](https://itunes.apple.com/us/app/xcode/id497799835) <sup>[3](#3)</sup>
@@ -95,7 +95,9 @@ Uninstallation is documented in the [FAQ](FAQ.md#how-do-i-uninstall-homebrew).
 
 <a data-proofer-ignore name="1"><sup>1</sup></a> For 32-bit or PPC support see [MacPorts](https://www.macports.org) or [Tigerbrew](https://github.com/mistydemeo/tigerbrew).
 
-<a data-proofer-ignore name="2"><sup>2</sup></a> On Apple Silicon, macOS 14 (Sonoma) or higher is best and supported; macOS 11 (Big Sur) – 13 (Ventura) are unsupported but may work. All Intel Mac configurations that can run Homebrew, including those using OpenCore Legacy Patcher, are [Tier 3](Support-Tiers.md#tier-3). macOS 10.15 (Catalina) and older will not run Homebrew at all.
+<a data-proofer-ignore name="2"><sup>2</sup></a> On Apple Silicon, macOS 15 (Sequoia) through 27 (Golden Gate) is best and supported; macOS 11 (Big Sur) – 14 (Sonoma) are unsupported but may work.
+All Intel Mac configurations that can run Homebrew, including those using OpenCore Legacy Patcher, are [Tier 3](Support-Tiers.md#tier-3).
+macOS 10.15 (Catalina) and older will not run Homebrew at all.
 
 <a data-proofer-ignore name="3"><sup>3</sup></a> Xcode or the CLT is required to build formulae from source and remains a requirement for a supported installation. Casks and bottles can be installed without developer tools. Downloading Xcode may require an Apple Developer account on older versions of Mac OS X. Sign up for free at [Apple's website](https://developer.apple.com/account/).
 

--- a/docs/Support-Tiers.md
+++ b/docs/Support-Tiers.md
@@ -136,17 +136,7 @@ The following timeline outlines expected Tier classifications based on Apple’s
 - As of September 2026:
 
   Apple Silicon:
-  - Tier 1: macOS Tahoe 26, Sequoia 15, Sonoma 14
-  - Tier 3: macOS Big Sur 11 through Ventura 13
-
-  Intel x86_64:
-  - Tier 3: macOS Catalina 10.15 through Tahoe 26
-  - Unsupported: macOS Mojave 10.14 and earlier
-
-- Expected in or after September 2026:
-
-  Apple Silicon:
-  - Tier 1: macOS 27, Tahoe 26, Sequoia 15
+  - Tier 1: macOS Golden Gate 27, Tahoe 26, Sequoia 15
   - Tier 3: macOS Big Sur 11 through Sonoma 14
 
   Intel x86_64:
@@ -156,7 +146,7 @@ The following timeline outlines expected Tier classifications based on Apple’s
 - Expected in or after September 2027:
 
   Apple Silicon:
-  - Tier 1: macOS 28, 27, Tahoe 26
+  - Tier 1: macOS 28, Golden Gate 27, Tahoe 26
   - Tier 3: macOS Monterey 12 through Sequoia 15
   - Unsupported: macOS Big Sur 11
 

--- a/package/Distribution.xml
+++ b/package/Distribution.xml
@@ -4,7 +4,7 @@
   <options customize="never" hostArchitectures="arm64" rootVolumeOnly="true"/>
   <volume-check>
     <allowed-os-versions>
-        <os-version min="14.0.0"/>
+        <os-version min="15.0.0"/>
     </allowed-os-versions>
   </volume-check>
   <choices-outline>
@@ -27,7 +27,7 @@
   <license file="LICENSE.rtf"/>
   <conclusion file="CONCLUSION.rtf" />
   <allowed-os-versions>
-    <os-version min="14.0.0"/>
+    <os-version min="15.0.0"/>
   </allowed-os-versions>
 
   <script>


### PR DESCRIPTION
Homebrew 7.0.0 fully supports macOS Golden Gate, so this promotes it to Tier 1 and moves the support window forward. Sonoma leaves default bottle CI and becomes Tier 3, while its bottle tags, release name and `depends_on macos:` symbol are unchanged.

Xcode 27 becomes the latest release for both Golden Gate and Tahoe, and the SDK and Command Line Tools compiler follow. The compiler mapping gains an explicit clang 17 entry so the previous toolchain still maps to its own Xcode, and newer compilers map forward rather than falling back to a stale version, which had left the wrong Xcode in `built_on` metadata on machines with the CLT and no Xcode.app.

GitHub does not host a macOS 27 image, so dependent testing falls back to a self-hosted Golden Gate runner while Tahoe and Sequoia stay on GitHub runners. The `BottleTransition` checks from #23918 stop applying now that Golden Gate is fully supported, and its constructor no longer validates a merge group payload it cannot act on. Removing the class is left for separate cleanup.

The installer package minimum rises to Sequoia, so the 7.0.0 package will not install on Sonoma.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the change and pass with it, and ran `brew lgtm --online` plus targeted specs.

-----
