### PR TITLE
Scrub invalid UTF-8 relocation diagnostics

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -231,6 +231,17 @@ module Homebrew
         [mismatches, checksums]
       end
 
+      # `strings -` uses locale-dependent `isprint()`, so a match can contain invalid
+      # UTF-8. Scrub it instead of dropping it, or a build prefix could go undetected.
+      sig { params(match: String, relative_path: Pathname, offset: String).returns(String) }
+      def binary_relocation_diagnostic_string(match, relative_path, offset)
+        utf8_match = match.dup.force_encoding(Encoding::UTF_8)
+        return utf8_match if utf8_match.valid_encoding?
+
+        opoo "Scrubbing string with invalid encoding in #{relative_path} at offset 0x#{offset}"
+        utf8_match.scrub
+      end
+
       private
 
       sig {
@@ -285,7 +296,7 @@ module Homebrew
 
               diagnostic = {
                 "path"   => relative_path.to_s,
-                "string" => match,
+                "string" => binary_relocation_diagnostic_string(match, relative_path, offset),
                 "offset" => offset.to_i(16),
               }
               binary_relocation_diagnostics << diagnostic unless binary_relocation_diagnostics.include?(diagnostic)

--- a/Library/Homebrew/test/dev-cmd/bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bottle_spec.rb
@@ -35,6 +35,41 @@ RSpec.describe Homebrew::DevCmd::Bottle do
 
   it_behaves_like "parseable arguments"
 
+  describe "#binary_relocation_diagnostic_string" do
+    let(:bottle) { described_class.new(["--no-rebuild", "testball"]) }
+    let(:relative_path) { Pathname("bin/dbus-daemon") }
+
+    it "returns the match unchanged when it is valid UTF-8" do
+      # Matches are always tagged `ASCII-8BIT`, as `Utils.popen_read` reads in binary mode.
+      match = "/opt/homebrew/Cellar".b
+
+      result = bottle.binary_relocation_diagnostic_string(match, relative_path, "1000")
+
+      expect(result).to eq("/opt/homebrew/Cellar").and have_attributes(encoding: Encoding::UTF_8)
+    end
+
+    it "warns when scrubbing a match that is not valid UTF-8" do
+      # Mimics `strings -` gluing invalid UTF-8 bytes onto an adjacent real string.
+      match = "\xFF\xFF\xFF\xFF/opt/homebrew/Cellar".b
+
+      expect(bottle).to receive(:opoo)
+        .with("Scrubbing string with invalid encoding in #{relative_path} at offset 0x203cc")
+
+      bottle.binary_relocation_diagnostic_string(match, relative_path, "203cc")
+    end
+
+    it "scrubs a match that is not valid UTF-8, keeping the rest of the string" do
+      # Mimics `strings -` gluing invalid UTF-8 bytes onto an adjacent real string.
+      match = "\xFF\xFF\xFF\xFF/opt/homebrew/Cellar".b
+      allow(bottle).to receive(:opoo)
+
+      result = bottle.binary_relocation_diagnostic_string(match, relative_path, "203cc")
+
+      expect(result).to have_attributes(encoding: Encoding::UTF_8, valid_encoding?: true)
+        .and end_with("/opt/homebrew/Cellar")
+    end
+  end
+
   it "does not restore locations when placeholdering fails" do
     formula = formula("testball") do
       T.bind(self, T.class_of(Formula))

--- a/Library/Homebrew/test/keg_relocate/text_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/text_spec.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "keg_relocate"
+require "stringio"
 
 RSpec.describe Keg do
   subject(:keg) { described_class.new(HOMEBREW_CELLAR/"foo/1.0.0") }
@@ -45,6 +46,20 @@ RSpec.describe Keg do
 
     result = described_class.text_matches_in_file(file, dir.to_s, [], [], nil)
     expect(result.count).to eq 2
+  end
+
+  specify "::each_candidate_string still yields runs that are not valid UTF-8" do
+    setup_file
+
+    # `strings -` uses locale-dependent `isprint()`, so a run can include invalid
+    # UTF-8. Detection must not drop it, or the build prefix could go undetected.
+    fake_output = "2a53 \xFF\xFE#{dir}/bad\n1000 #{dir}/file.txt\n".b
+    allow(Utils).to receive(:popen_read).and_yield(StringIO.new(fake_output))
+
+    candidates = []
+    described_class.each_candidate_string(file, dir.to_s) { |candidate| candidates << candidate }
+
+    expect(candidates).to eq [["2a53", "\xFF\xFE#{dir}/bad".b], ["1000", "#{dir}/file.txt"]]
   end
 
   describe "#replace_text_in_files" do


### PR DESCRIPTION
`brew install dbus && brew bottle dbus` crashes with `Error: "\xFF" from ASCII-8BIT to UTF-8`. The cause is `strings -`, which Homebrew uses to scan non-ELF binaries for leftover build paths. It uses locale-dependent `isprint()` instead of a fixed ASCII check, so which bytes count as printable varies by environment, and under the default macOS locale that includes bytes that are never valid UTF-8. `dbus-daemon` and `dbus-daemon-launch-helper` hit exactly this: a 4-byte binary field sits with no NUL separator right before a compiled-in path list. The resulting match still correctly detects the build prefix, so that part isn't a bug, but it also isn't valid UTF-8. `JSON.pretty_generate` requires valid UTF-8 when writing that match into `binary_relocation_diagnostics`, so bottling fails.

`Keg.each_candidate_string` is left untouched: dropping the match there, instead of where it's used, would risk losing the only detection of a build prefix some other formula's bottle still needs pinning for. Instead, a new `binary_relocation_diagnostic_string` scrubs the string only where it's written into the JSON, and warns with `opoo` so the file and offset stay traceable instead of failing with an opaque backtrace.

Fixes #23927.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code with Sonnet 5, with local review and testing.

-----
