### PR TITLE
Report tiers and refresh stale bottle metadata

### DIFF
--- a/Library/Homebrew/bottle.rb
+++ b/Library/Homebrew/bottle.rb
@@ -279,11 +279,15 @@ class Bottle
 
   sig { returns(T::Hash[String, T.untyped]) }
   def tab_attributes
-    if (resource = github_packages_manifest_resource) && resource.downloaded?
-      return resource.tab
-    end
+    resource = github_packages_manifest_resource
+    return {} unless resource&.downloaded?
 
-    {}
+    begin
+      resource.tab
+    rescue Resource::BottleManifest::Error
+      fetch_tab(quiet: true)
+      resource.tab
+    end
   end
 
   sig { returns(T.nilable(Integer)) }

--- a/Library/Homebrew/cmd/doctor.rb
+++ b/Library/Homebrew/cmd/doctor.rb
@@ -86,7 +86,7 @@ module Homebrew
         end
 
         finding_maps = finding_collection.map(&:to_h)
-        tier = (finding_maps.max_by { |f| f[:tier] } || {}).fetch(:tier, 1)
+        tier = Diagnostic::Finding.support_tier(finding_collection.map(&:tier))
         if args.json?
           puts JSON.pretty_generate({ tier:, findings: finding_maps }).gsub(/\[\n\n\s*\]/, "[]")
 

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -24,19 +24,33 @@ module Homebrew
   module Diagnostic
     extend Utils::Output::Mixin
 
+    sig { returns(T::Array[T.any(Integer, Symbol)]) }
+    def self.support_tiers
+      @support_tiers ||= T.let([], T.nilable(T::Array[T.any(Integer, Symbol)]))
+    end
+
+    sig { void }
+    def self.report_support_tier
+      message = Finding.support_tier_message(tier: Finding.support_tier(support_tiers))
+      support_tiers.clear
+      $stderr.puts "\n", message if message
+    end
+
+    at_exit { Homebrew::Diagnostic.report_support_tier }
+
     sig { params(type: Symbol, fatal: T::Boolean).void }
     def self.checks(type, fatal: true)
-      @checks ||= T.let(Checks.new, T.nilable(Checks))
+      checks = Checks.new
       failed = T.let(false, T::Boolean)
-      @checks.public_send(type).each do |check|
-        out = @checks.public_send(check)
-        next if out.nil?
-
-        if fatal
-          failed ||= true
-          ofail out.to_s
-        else
-          opoo out.to_s
+      checks.public_send(type).each do |check|
+        Array(checks.public_send(check)).each do |finding|
+          support_tiers << finding.tier
+          if fatal
+            failed = true
+            ofail finding.to_s
+          else
+            opoo finding.to_s
+          end
         end
       end
       exit 1 if failed && fatal
@@ -137,7 +151,10 @@ module Homebrew
 
       sig { returns(T::Array[String]) }
       def supported_configuration_checks
-        [].freeze
+        %w[
+          check_homebrew_prefix
+          check_for_nix_homebrew
+        ].freeze
       end
 
       sig { returns(T::Array[String]) }
@@ -1234,6 +1251,7 @@ module Homebrew
       sig { returns(T.nilable(Finding)) }
       def check_homebrew_prefix
         return if Homebrew.default_prefix?
+        return if ENV["HOMEBREW_INTEGRATION_TEST"]
 
         Finding.new(
           <<~EOS,

--- a/Library/Homebrew/diagnostic/finding.rb
+++ b/Library/Homebrew/diagnostic/finding.rb
@@ -88,20 +88,27 @@ module Homebrew
         EOS
       end
 
+      sig { params(tiers: T::Array[T.any(Integer, Symbol)]).returns(T.any(Integer, Symbol)) }
+      def self.support_tier(tiers)
+        return :unsupported if tiers.include?(:unsupported)
+
+        tiers.grep(Integer).max || 1
+      end
+
       sig { params(tier: T.any(Integer, String, Symbol)).returns(T.nilable(String)) }
       def self.support_tier_message(tier:)
         return if tier.to_s == "1"
 
         tier_title, tier_slug, tier_issues = if tier.to_s == "unsupported"
-          ["Unsupported", "unsupported", "Do not report any issues"]
+          ["an Unsupported", "unsupported", "Do not report any issues"]
         else
-          ["Tier #{tier}", "tier-#{tier.to_s.downcase}", "You can report issues with Tier #{tier} configurations"]
+          ["a Tier #{tier}", "tier-#{tier.to_s.downcase}", "You can report issues with Tier #{tier} configurations"]
         end
 
         tier_issues = "Report issues to the upstream Nix project, not" if OS.nix_managed_homebrew?
 
         <<~EOS
-          This is a #{tier_title} configuration:
+          This is #{tier_title} configuration:
             #{Formatter.url("https://docs.brew.sh/Support-Tiers##{tier_slug}")}
           #{Formatter.bold("#{tier_issues} to Homebrew/* repositories!")}
             #{Formatter.url(OS::ISSUES_URL) if defined?(OS::ISSUES_URL)}

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -722,14 +722,7 @@ class BuildError < RuntimeError
     end
 
     require "diagnostic"
-    checks = Homebrew::Diagnostic::Checks.new
-    checks.build_error_checks.each do |check|
-      out = checks.public_send(check)
-      next if out.nil?
-
-      puts
-      ofail out
-    end
+    Homebrew::Diagnostic.checks(:build_error_checks, fatal: false)
   end
 end
 

--- a/Library/Homebrew/extend/os/linux/diagnostic.rb
+++ b/Library/Homebrew/extend/os/linux/diagnostic.rb
@@ -29,11 +29,11 @@ module OS
 
         sig { returns(T::Array[String]) }
         def supported_configuration_checks
-          %w[
+          (super + %w[
             check_glibc_minimum_version
             check_kernel_minimum_version
             check_supported_architecture
-          ].freeze
+          ]).freeze
         end
 
         sig { returns(T.nilable(::Homebrew::Diagnostic::Finding)) }

--- a/Library/Homebrew/extend/os/linux/formula_installer.rb
+++ b/Library/Homebrew/extend/os/linux/formula_installer.rb
@@ -5,6 +5,6 @@ class FormulaInstaller
   sig { params(formula: Formula).returns(T.nilable(T::Boolean)) }
   def fresh_install?(formula)
     !Homebrew::EnvConfig.developer? &&
-      (installed_on_request? || !formula.any_version_installed?)
+      !formula.any_version_installed?
   end
 end

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -94,9 +94,9 @@ module OS
 
         sig { returns(T::Array[String]) }
         def supported_configuration_checks
-          %w[
+          (super + %w[
             check_for_unsupported_macos
-          ].freeze
+          ]).freeze
         end
 
         sig { returns(T::Array[String]) }

--- a/Library/Homebrew/extend/os/mac/formula_installer.rb
+++ b/Library/Homebrew/extend/os/mac/formula_installer.rb
@@ -13,7 +13,7 @@ module OS
         ::Hardware::CPU.arm? &&
           !::Homebrew::EnvConfig.developer? &&
           !OS::Mac.version.outdated_release? &&
-          (installed_on_request? || !formula.any_version_installed?)
+          !formula.any_version_installed?
       end
     end
   end

--- a/Library/Homebrew/extend/os/mac/reinstall.rb
+++ b/Library/Homebrew/extend/os/mac/reinstall.rb
@@ -29,7 +29,8 @@ module OS
           context = build_install_context(pkgconf, flags: [])
 
           begin
-            Homebrew::Install.fetch_formulae([context.formula_installer])
+            return if Homebrew::Install.fetch_formulae([context.formula_installer]).empty?
+
             reinstall_formula(context)
             ohai "Reinstalled pkgconf due to macOS version mismatch"
           rescue

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -450,13 +450,8 @@ class FormulaInstaller
 
       if message
         message += <<~EOS
-          If you're feeling brave, you can try to install from source with:
+          If no compatible bottle is available, you can try to install from source with:
             brew install --build-from-source #{formula}
-
-          This is a Tier 3 configuration:
-            #{Formatter.url("https://docs.brew.sh/Support-Tiers#tier-3")}
-          #{Formatter.bold("Do not report any issues to Homebrew/* repositories!")}
-          Read the above document instead before opening any issues or PRs.
         EOS
         raise CannotInstallFormulaError, message
       end

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -39,11 +39,8 @@ module Homebrew
       def check_cc_argv(cc)
         return unless cc
 
-        opoo <<~EOS
-          You passed `--cc=#{cc}`.
-
-          #{Diagnostic::Finding.support_tier_message(tier: 3)}
-        EOS
+        opoo "You passed `--cc=#{cc}`."
+        Diagnostic.support_tiers << 3
       end
 
       sig { params(all_fatal: T::Boolean).void }

--- a/Library/Homebrew/test/bottle/tab_attributes_spec.rb
+++ b/Library/Homebrew/test/bottle/tab_attributes_spec.rb
@@ -1,0 +1,66 @@
+# typed: true
+# frozen_string_literal: true
+
+require "bottle"
+require "bottle_specification"
+
+RSpec.describe Bottle do
+  describe "#tab_attributes" do
+    let(:bottle) do
+      bottle_spec = BottleSpecification.new
+      bottle_spec.root_url(HOMEBREW_BOTTLE_DEFAULT_DOMAIN)
+      bottle_spec.sha256(cellar: :any_skip_relocation, arm64_golden_gate: "deadbeef" * 8)
+      described_class.new(nil, bottle_spec, Utils::Bottles::Tag.from_symbol(:arm64_golden_gate),
+                          name: "pkgconf", pkg_version: PkgVersion.new(Version.new("1.2.3"), 0))
+    end
+    let(:manifest_resource) { bottle.github_packages_manifest_resource || raise("Expected a bottle manifest") }
+    let(:manifest) do
+      {
+        "manifests" => [{
+          "annotations" => {
+            "org.opencontainers.image.ref.name" => "1.2.3.arm64_golden_gate",
+            "sh.brew.bottle.digest"             => "deadbeef" * 8,
+            "sh.brew.tab"                       => { "built_on" => { "os_version" => "macOS 27.0" } }.to_json,
+          },
+        }],
+      }
+    end
+
+    before do
+      manifest_resource.cached_download.dirname.mkpath
+      manifest_resource.cached_download.write({ "manifests" => [{ "annotations" => {} }] }.to_json)
+      allow(manifest_resource.downloader).to receive(:fetch) do
+        manifest_resource.cached_download.write(manifest.to_json) unless manifest_resource.downloaded?
+      end
+    end
+
+    it "refreshes cached metadata missing the bottle checksum before checking compatibility" do
+      expect([bottle.compatible_locations?, bottle.tab_attributes])
+        .to eq([true, { "built_on" => { "os_version" => "macOS 27.0" } }])
+    end
+
+    it "does not keep retrying invalid metadata across repeated accesses", timeout: 5 do
+      manifest.fetch("manifests").fetch(0).fetch("annotations").delete("sh.brew.bottle.digest")
+      expect(manifest_resource).to receive(:clear_cache).once.and_call_original
+
+      bottle.compatible_locations?
+
+      expect { bottle.tab_attributes }.to raise_error(Resource::BottleManifest::Error,
+                                                      "Couldn't find manifest matching bottle checksum.")
+    end
+
+    it "does not fetch metadata that is already valid" do
+      manifest_resource.cached_download.write(manifest.to_json)
+      expect(manifest_resource.downloader).not_to receive(:fetch)
+
+      bottle.tab_attributes
+    end
+
+    it "keeps metadata fetching lazy when nothing is cached" do
+      manifest_resource.clear_cache
+      expect(manifest_resource.downloader).not_to receive(:fetch)
+
+      expect(bottle.tab_attributes).to eq({})
+    end
+  end
+end

--- a/Library/Homebrew/test/cmd/doctor_spec.rb
+++ b/Library/Homebrew/test/cmd/doctor_spec.rb
@@ -19,6 +19,25 @@ RSpec.describe Homebrew::Cmd::Doctor do
       .to output(/"tier": 1/).to_stdout
   end
 
+  [
+    [[], 1],
+    [[1, 2, 3, 2], 3],
+    [[3, :unsupported, 2], :unsupported],
+  ].each do |tiers, expected_tier|
+    specify "reports one support tier for #{tiers.inspect}" do
+      T.bind(self, RSpec::Core::ExampleGroup)
+
+      checks = Homebrew::Diagnostic::Checks.new
+      allow(Homebrew::Diagnostic::Checks).to receive(:new).and_return(checks)
+      allow(checks).to receive(:check_access_directories).and_return(
+        tiers.map { |tier| Homebrew::Diagnostic::Finding.new("Configuration warning", tier:) },
+      )
+
+      expect { described_class.new(["check_access_directories", "--json"]).run }
+        .to output(/"tier": #{expected_tier.to_json}/).to_stdout
+    end
+  end
+
   specify "check_missing_deps reports formula and cask dependencies", :cask do
     formula = instance_double(Formula, full_name:            "needs-foo",
                                        missing_dependencies: [instance_double(Dependency, to_s: "foo")])

--- a/Library/Homebrew/test/cmd/shared_examples/reinstall_pkgconf_if_needed.rb
+++ b/Library/Homebrew/test/cmd/shared_examples/reinstall_pkgconf_if_needed.rb
@@ -17,7 +17,7 @@ RSpec.shared_examples "reinstall_pkgconf_if_needed" do
       before do
         allow(OS).to receive(:mac?).and_return(true)
         allow(Formula).to receive(:[]).with("pkgconf").and_return(formula)
-        allow(Homebrew::Install).to receive(:fetch_formulae).with([formula_installer])
+        allow(Homebrew::Install).to receive(:fetch_formulae).with([formula_installer]).and_return([formula_installer])
         allow(Homebrew::Reinstall).to receive(:build_install_context).and_return(context)
       end
 

--- a/Library/Homebrew/test/diagnostic/finding_spec.rb
+++ b/Library/Homebrew/test/diagnostic/finding_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Homebrew::Diagnostic::Finding do
 
     it "describes unsupported configurations" do
       message = described_class.support_tier_message(tier: :unsupported)
-      expect(message).to include("This is a Unsupported configuration:")
+      expect(message).to include("This is an Unsupported configuration:")
         .and include("https://docs.brew.sh/Support-Tiers#unsupported")
     end
 

--- a/Library/Homebrew/test/diagnostic_spec.rb
+++ b/Library/Homebrew/test/diagnostic_spec.rb
@@ -1,0 +1,56 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "diagnostic"
+require "install"
+
+RSpec.describe Homebrew::Diagnostic do
+  before do
+    allow(described_class).to receive(:support_tiers).and_return([])
+  end
+
+  it "reports only the least supported tier after all checks" do
+    checks = instance_double(Homebrew::Diagnostic::Checks,
+                             supported_configuration_checks: ["check_access_directories"],
+                             check_access_directories:       [
+                               Homebrew::Diagnostic::Finding.new("First warning", tier: 2),
+                               Homebrew::Diagnostic::Finding.new("Second warning", tier: 3),
+                             ])
+    allow(Homebrew::Diagnostic::Checks).to receive(:new).and_return(checks)
+
+    expect do
+      described_class.checks(:supported_configuration_checks, fatal: false)
+      described_class.report_support_tier
+      described_class.report_support_tier
+    end.to output(<<~EOS).to_stderr
+      Warning: First warning
+      Warning: Second warning
+
+      #{Homebrew::Diagnostic::Finding.support_tier_message(tier: 3)&.chomp}
+    EOS
+  end
+
+  it "includes a custom compiler in the final tier without repeating the tier warning" do
+    expect do
+      Homebrew::Install.check_cc_argv("clang")
+      described_class.support_tiers << 2
+      described_class.report_support_tier
+    end.to output(<<~EOS).to_stderr
+      Warning: You passed `--cc=clang`.
+
+      #{Homebrew::Diagnostic::Finding.support_tier_message(tier: 3)&.chomp}
+    EOS
+  end
+
+  it "reports the final tier on exit without depending on brew.rb" do
+    _, stderr, status = Open3.capture3(
+      *HOMEBREW_RUBY_EXEC_ARGS,
+      "-I", $LOAD_PATH.join(File::PATH_SEPARATOR),
+      "-rglobal", "-rdiagnostic",
+      "-e", 'Homebrew::Diagnostic.support_tiers.concat([2, 3, 2]); abort "command failed"'
+    )
+
+    expect([stderr.scan(/^This is a Tier \d configuration:/), status.exitstatus])
+      .to eq([["This is a Tier 3 configuration:"], 1])
+  end
+end

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -1188,6 +1188,30 @@ RSpec.describe FormulaInstaller do
   end
 
   describe "#check_install_sanity" do
+    it "does not assign a support tier when a bottle is unavailable" do
+      installer = described_class.new(Testball.new, ignore_deps: true)
+      allow(Homebrew).to receive(:default_prefix?).and_return(true)
+      allow(installer.formula).to receive(:tap).and_return(CoreTap.instance)
+      allow(installer).to receive_messages(pour_bottle?: false, fresh_install?: true)
+
+      expect { installer.check_install_sanity }.to raise_error(CannotInstallFormulaError, <<~EOS)
+        testball: no bottle available!
+        If no compatible bottle is available, you can try to install from source with:
+          brew install --build-from-source testball
+      EOS
+    end
+
+    it "allows reinstalling an explicitly requested formula without a bottle" do
+      installer = described_class.new(Testball.new, installed_on_request: true, ignore_deps: true)
+      allow(Homebrew).to receive(:default_prefix?).and_return(true)
+      allow(Homebrew::EnvConfig).to receive(:developer?).and_return(false)
+      allow(Hardware::CPU).to receive(:arm?).and_return(true)
+      allow(installer.formula).to receive_messages(tap: CoreTap.instance, any_version_installed?: true)
+      allow(installer).to receive(:pour_bottle?).and_return(false)
+
+      expect { installer.check_install_sanity }.not_to raise_error
+    end
+
     it "raises on direct cyclic dependency" do
       ENV["HOMEBREW_DEVELOPER"] = "1"
 

--- a/Library/Homebrew/test/os/mac/reinstall_spec.rb
+++ b/Library/Homebrew/test/os/mac/reinstall_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Homebrew::Reinstall do
 
     before do
       allow(Formula).to receive(:[]).with("pkgconf").and_return(formula)
-      allow(Homebrew::Install).to receive(:fetch_formulae).with([formula_installer])
+      allow(Homebrew::Install).to receive(:fetch_formulae).with([formula_installer]).and_return([formula_installer])
       allow(described_class).to receive(:build_install_context).and_return(context)
     end
 
@@ -63,6 +63,15 @@ RSpec.describe Homebrew::Reinstall do
 
         described_class.reinstall_pkgconf_if_needed!
       end
+    end
+
+    it "does not reinstall or report success when fetching fails" do
+      allow(Homebrew::Pkgconf).to receive(:macos_sdk_mismatch).and_return(["26", "27"])
+      allow(Homebrew::Install).to receive(:fetch_formulae).with([formula_installer]).and_return([])
+      expect(described_class).not_to receive(:reinstall_formula)
+      expect(described_class).not_to receive(:ohai)
+
+      described_class.reinstall_pkgconf_if_needed!
     end
   end
 end


### PR DESCRIPTION
- Keep missing bottles from downgrading supported configurations.
- Bound stale manifest refreshes to one retry across repeated accesses.
- Handle unsupported findings alongside numeric diagnostic tiers.
- Preserve source fallback for reinstalls and stop automatic `pkgconf` reinstalls after failed fetches.

Fixes #23930

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Codex with GPT 6 Astra at Extra High effort, with local review and testing.

-----