### PR TITLE
Unify sandbox temporary directory handling

### DIFF
--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -92,6 +92,8 @@ module Homebrew
                 *exec_args,
                 step:                 "testing #{f.full_name}",
                 warn_without_sandbox: false,
+                retain_tmp:           args.keep_tmp?,
+                debug:                args.debug?,
               ) do |sandbox|
                 f.logs.mkpath
                 sandbox.record_log(f.logs/"test.sandbox.log")

--- a/Library/Homebrew/extend/os/linux/sandbox.rb
+++ b/Library/Homebrew/extend/os/linux/sandbox.rb
@@ -80,9 +80,11 @@ module OS
           args:                  T.any(String, ::Pathname),
           passthrough_stdin:     T::Boolean,
           child_message_handler: T.nilable(T.proc.params(message: String).returns(T.nilable(String))),
+          retain_tmp:            T::Boolean,
+          debug:                 T::Boolean,
         ).void
       }
-      def run(*args, passthrough_stdin: true, child_message_handler: nil)
+      def run(*args, passthrough_stdin: true, child_message_handler: nil, retain_tmp: false, debug: false)
         landlock.run { super }
       end
 

--- a/Library/Homebrew/extend/os/mac/sandbox.rb
+++ b/Library/Homebrew/extend/os/mac/sandbox.rb
@@ -128,11 +128,6 @@ module OS
         [SANDBOX_EXEC, "-f", seatbelt.path, *args]
       end
 
-      sig { returns(T::Boolean) }
-      def allow_network_for_error_pipe?
-        true
-      end
-
       sig { void }
       def ensure_child_tty_available
         # We're opening and immediately closing so this is safe.

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1734,9 +1734,6 @@ class Formula
       self.build = Tab.for_formula(self)
 
       new_env = {
-        TMPDIR:        HOMEBREW_TEMP,
-        TEMP:          HOMEBREW_TEMP,
-        TMP:           HOMEBREW_TEMP,
         HOMEBREW_PATH: nil,
         PATH:          PATH.new(ORIGINAL_PATHS),
       }
@@ -1745,11 +1742,7 @@ class Formula
       # the entire `postinstall.rb` process is already sandboxed by its parent.
       Dir.mktmpdir("#{name}-postinstall-", HOMEBREW_TEMP) do |home|
         postinstall_home = Pathname(home)
-        new_env[:HOME] = postinstall_home.to_s
         new_env.merge!(common_sandbox_env(postinstall_home))
-        # Keep postinstall Java temp files in Homebrew temp while the common
-        # sandbox environment points Java's user home at the cache.
-        new_env[:_JAVA_OPTIONS] += " -Djava.io.tmpdir=#{HOMEBREW_TEMP}"
         setup_home postinstall_home
 
         with_env(new_env) do
@@ -3420,9 +3413,6 @@ class Formula
     @prefix_returns_versioned_prefix = T.let(true, T.nilable(T::Boolean))
 
     test_env = {
-      TMPDIR:        HOMEBREW_TEMP,
-      TEMP:          HOMEBREW_TEMP,
-      TMP:           HOMEBREW_TEMP,
       TERM:          "dumb",
       PATH:          PATH.new(ENV.fetch("PATH"), HOMEBREW_PREFIX/"bin"),
       HOMEBREW_TERM: ENV.fetch("TERM", nil),
@@ -3441,9 +3431,7 @@ class Formula
       raise "Test path is unexpectedly unset." if testpath.nil?
 
       @testpath = T.let(testpath, T.nilable(Pathname))
-      test_env[:HOME] = testpath
       test_env.merge!(common_sandbox_env(testpath))
-      test_env[:_JAVA_OPTIONS] += " -Djava.io.tmpdir=#{HOMEBREW_TEMP}"
       setup_home testpath
       begin
         with_logging("test") do
@@ -3865,7 +3853,13 @@ class Formula
   # Common environment variables used by sandboxed fetch, build, test and postinstall phases.
   sig { params(home: Pathname).returns(T::Hash[Symbol, String]) }
   def common_sandbox_env(home)
-    Homebrew::PackageManagerCache.env.merge(
+    env = Homebrew::PackageManagerCache.env
+    env.merge(
+      _JAVA_OPTIONS:           [env[:_JAVA_OPTIONS], "-Djava.io.tmpdir=#{HOMEBREW_TEMP}"].compact.join(" "),
+      HOME:                    home.to_s,
+      TMPDIR:                  HOMEBREW_TEMP.to_s,
+      TEMP:                    HOMEBREW_TEMP.to_s,
+      TMP:                     HOMEBREW_TEMP.to_s,
       GIT_CONFIG_GLOBAL:       Utils::Git.no_global_config_file,
       GIT_TERMINAL_PROMPT:     "0",
       GOENV:                   "off",
@@ -3945,10 +3939,7 @@ class Formula
         HOMEBREW_PATH: nil,
       }
 
-      unless interactive
-        stage_env[:HOME] = env_home
-        stage_env.merge!(common_sandbox_env(env_home))
-      end
+      stage_env.merge!(common_sandbox_env(env_home)) unless interactive
 
       setup_home env_home
       # Don't dirty the git tree for git clones.

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1151,6 +1151,7 @@ on_request: installed_on_request?, options:)
 
   sig { void }
   def build
+    retain_tmp = keep_tmp? || debug_symbols? || interactive?
     FileUtils.rm_rf(formula.logs)
 
     @start_time = Time.now
@@ -1168,7 +1169,7 @@ on_request: installed_on_request?, options:)
     #    installation has a pristine ENV when it starts, forking now is
     #    the easiest way to do this
     with_env(HOMEBREW_BUILD_STAGING_PATH: staging_path, HOMEBREW_BUILD_FETCH_PHASE: nil) do
-      Sandbox.run_or_fork(*build_args(formula_path), step: "building") do |sandbox|
+      Sandbox.run_or_fork(*build_args(formula_path), step: "building", retain_tmp:, debug: debug?) do |sandbox|
         add_build_sandbox_rules(sandbox, formula_path, log_name: "build")
         if interactive?
           sandbox.allow_write_path(Dir.home)
@@ -1213,7 +1214,7 @@ on_request: installed_on_request?, options:)
   ensure
     # The build child removes the shared staging directory unless it has to
     # be kept, so this only matters when no child got as far as staging.
-    FileUtils.rm_rf(staging_path) if staging_path && !keep_tmp? && !debug_symbols? && !interactive? && !debug?
+    FileUtils.rm_rf(staging_path) if staging_path && !retain_tmp && !debug?
   end
 
   # Runs the formula's `fetch` method with network access before `install`
@@ -1222,8 +1223,9 @@ on_request: installed_on_request?, options:)
   def run_fetch(staging_path: nil)
     @formula = Homebrew::API::Formula.source_download_formula(formula) if formula.loaded_from_api?
 
+    retain_tmp = keep_tmp? || debug_symbols? || interactive?
     with_env(HOMEBREW_BUILD_FETCH_PHASE: "1", HOMEBREW_BUILD_STAGING_PATH: staging_path) do
-      Sandbox.run_or_fork(*build_args(formula_path), step: "fetching") do |sandbox|
+      Sandbox.run_or_fork(*build_args(formula_path), step: "fetching", retain_tmp:, debug: debug?) do |sandbox|
         add_build_sandbox_rules(sandbox, formula_path, log_name: "fetch")
         sandbox.deny_read_home
         sandbox.allow_write_temp_and_cache
@@ -1471,7 +1473,7 @@ on_request: installed_on_request?, options:)
     args << post_install_formula_path
 
     Sandbox.with_preserved_brew_file do
-      Sandbox.run_or_fork(*args, step: "running post-install") do |sandbox|
+      Sandbox.run_or_fork(*args, step: "running post-install", debug: debug?) do |sandbox|
         formula.logs.mkpath
         sandbox.record_log(formula.logs/"postinstall.sandbox.log")
         sandbox.allow_write_log(formula)

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -6,6 +6,7 @@ require "io/console"
 require "pty"
 require "tempfile"
 require "exceptions"
+require "mktemp"
 require "utils/fork"
 require "utils/output"
 
@@ -140,14 +141,16 @@ class Sandbox
       args:                 T.any(String, Pathname),
       step:                 String,
       warn_without_sandbox: T::Boolean,
+      retain_tmp:           T::Boolean,
+      debug:                T::Boolean,
       _block:               T.proc.params(sandbox: Sandbox).void,
     ).void
   }
-  def self.run_or_fork(*args, step:, warn_without_sandbox: true, &_block)
+  def self.run_or_fork(*args, step:, warn_without_sandbox: true, retain_tmp: false, debug: false, &_block)
     if use_for?(step, warn_without_sandbox:)
       sandbox = new
       yield sandbox
-      sandbox.run(*args)
+      sandbox.run(*args, retain_tmp:, debug:)
     else
       Utils.safe_fork { exec(*args) }
     end
@@ -562,15 +565,23 @@ class Sandbox
       args:                  T.any(String, Pathname),
       passthrough_stdin:     T::Boolean,
       child_message_handler: T.nilable(T.proc.params(message: String).returns(T.nilable(String))),
+      retain_tmp:            T::Boolean,
+      debug:                 T::Boolean,
     ).void
   }
-  def run(*args, passthrough_stdin: true, child_message_handler: nil)
-    Dir.mktmpdir("homebrew-sandbox", HOMEBREW_TEMP) do |tmpdir|
-      allow_network path: File.join(tmpdir, "socket"), type: :literal if allow_network_for_error_pipe?
+  def run(*args, passthrough_stdin: true, child_message_handler: nil, retain_tmp: false, debug: false)
+    Mktemp.new("sandbox", retain: retain_tmp).run(chdir: false) do |staging|
+      temporary = staging.tmpdir
+      raise "Sandbox temporary directory is unexpectedly unset." if temporary.nil?
+
+      tmpdir = temporary.to_s
+      allow_write_path(tmpdir)
+      allow_network path: tmpdir, type: :subpath
       @start = T.let(Time.now, T.nilable(Time))
 
       begin
         command = sandbox_command(args, tmpdir)
+        env = { "HOMEBREW_TEMP" => tmpdir, "TMPDIR" => tmpdir, "TEMP" => tmpdir, "TMP" => tmpdir }
         # Start sandbox in a pseudoterminal to prevent access of the parent terminal.
         PTY.open do |controller, worker|
           # Set the PTY's window size to match the parent terminal.
@@ -622,7 +633,7 @@ class Sandbox
 
                 worker.close_on_exec = true
                 apply_sandbox
-                exec(*command, in: worker, out: worker, err: worker) # And map everything to the PTY.
+                exec(env, *command, in: worker, out: worker, err: worker) # And map everything to the PTY.
               else
                 # Parent side
                 worker.close
@@ -668,7 +679,9 @@ class Sandbox
             write_to_pty.call
           end
         end
-      rescue
+      # Preserve temporary files for debugging, including interrupted commands.
+      rescue StandardError, SignalException
+        staging.retain! if debug
         @failed = true
         raise
       ensure
@@ -724,11 +737,6 @@ class Sandbox
   sig { params(_args: T::Array[T.any(String, Pathname)], _tmpdir: String).returns(T::Array[T.any(String, Pathname)]) }
   def sandbox_command(_args, _tmpdir)
     raise NotImplementedError, "Sandbox is not implemented for this OS."
-  end
-
-  sig { returns(T::Boolean) }
-  def allow_network_for_error_pipe?
-    false
   end
 
   sig { void }

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -3830,6 +3830,25 @@ RSpec.describe Formula do
       expect(f.common_sandbox_env(mktmpdir)[:BUNDLE_COOLDOWN]).to eq("1")
     end
 
+    it "uses the phase home and Homebrew temporary directory" do
+      home = mktmpdir
+
+      expect(f.common_sandbox_env(home)).to include(
+        HOME:          home.to_s,
+        TMPDIR:        HOMEBREW_TEMP.to_s,
+        TEMP:          HOMEBREW_TEMP.to_s,
+        TMP:           HOMEBREW_TEMP.to_s,
+        _JAVA_OPTIONS: "-Duser.home=#{Homebrew::PackageManagerCache.path("java_cache")} " \
+                       "-Djava.io.tmpdir=#{HOMEBREW_TEMP}",
+      )
+    end
+
+    it "sets the Java temporary directory without cache options" do
+      allow(Homebrew::PackageManagerCache).to receive(:env).and_return({})
+
+      expect(f.common_sandbox_env(mktmpdir)[:_JAVA_OPTIONS]).to eq("-Djava.io.tmpdir=#{HOMEBREW_TEMP}")
+    end
+
     it "does not configure Cargo cooldown before stable support" do
       expect(f.common_sandbox_env(mktmpdir).keys & [
         :CARGO_REGISTRY_GLOBAL_MIN_PUBLISH_AGE,

--- a/Library/Homebrew/test/sandbox_linux_spec.rb
+++ b/Library/Homebrew/test/sandbox_linux_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe Sandbox, :needs_linux do
       end.not_to raise_error
     end
 
-    it "forwards child message handling options" do
+    it "forwards child message handling and temporary directory options" do
+      stub_const("HOMEBREW_TEMP", mktmpdir)
       messages = []
       handler = proc do |message|
         messages << message.chomp
@@ -59,7 +60,7 @@ RSpec.describe Sandbox, :needs_linux do
       RUBY
 
       sandbox.run RUBY_PATH, "-rsocket", "-e", script,
-                  passthrough_stdin: false, child_message_handler: handler
+                  passthrough_stdin: false, child_message_handler: handler, retain_tmp: true, debug: true
 
       expect(messages).to eq(["privileged step"])
     end

--- a/Library/Homebrew/test/sandbox_shared_spec.rb
+++ b/Library/Homebrew/test/sandbox_shared_spec.rb
@@ -41,9 +41,10 @@ RSpec.describe Sandbox do
 
     it "configures and uses the sandbox when available" do
       allow(described_class).to receive_messages(new: command_sandbox, use_for?: true)
-      expect(command_sandbox).to receive(:run).with("command", "argument")
+      expect(command_sandbox).to receive(:run).with("command", "argument", retain_tmp: true, debug: true)
 
-      described_class.run_or_fork("command", "argument", step: "running a command") do |configured|
+      described_class.run_or_fork("command", "argument", step: "running a command",
+                                 retain_tmp: true, debug: true) do |configured|
         expect(configured).to eq(command_sandbox)
       end
     end
@@ -56,6 +57,69 @@ RSpec.describe Sandbox do
       described_class.run_or_fork("command", step: "running a command") do
         raise "sandbox should not be configured"
       end
+    end
+  end
+
+  describe "#run temporary directory" do
+    before do
+      stub_const("HOMEBREW_TEMP", HOMEBREW_TEMP/"sandbox")
+      HOMEBREW_TEMP.mkpath
+      allow(described_class).to receive(:terminal_ioctl_request).and_return(0)
+      allow(PTY).to receive(:open).and_wrap_original do |original, &block|
+        original.call do |controller, worker|
+          allow(worker).to receive(:ioctl).with(0, 0)
+          block.call(controller, worker)
+        end
+      end
+      allow(sandbox).to receive(:sandbox_command) { |args, _tmpdir| args }
+      allow(sandbox).to receive(:ensure_child_tty_available)
+      allow(sandbox).to receive(:apply_sandbox)
+      allow(sandbox).to receive(:record_sandbox_log)
+    end
+
+    it "gives the child a private writable socket directory and removes it afterwards" do
+      sandbox.deny_all_network
+      expect(sandbox).to receive(:sandbox_command) do |args, tmpdir|
+        expect(sandbox.profile.rules.select { |rule| rule.allow && rule.operation == "network*" }
+          .map { |rule| [rule.filter&.path, rule.filter&.type] }).to eq([[tmpdir, :subpath]])
+        args
+      end
+      expect do
+        sandbox.run RbConfig.ruby, "-e", <<~RUBY, HOMEBREW_TEMP
+          temporary = ENV.fetch("HOMEBREW_TEMP")
+          abort "Shared temporary directory" unless File.dirname(temporary) == ARGV.fetch(0)
+          abort "Unexpected permissions" unless File.stat(temporary).mode & 0777 == 0700
+          abort "Inconsistent environment" unless %w[TMPDIR TEMP TMP].all? { |key| ENV[key] == temporary }
+          File.write(File.join(temporary, "child-file"), "written")
+        RUBY
+      end.not_to raise_error
+      expect(sandbox.profile.rules).to include(have_attributes(allow: false, operation: "network*", filter: nil))
+      expect(HOMEBREW_TEMP.children).to be_empty
+    end
+
+    it "retains temporary files when requested" do
+      sandbox.run RbConfig.ruby, "-e", "exit", retain_tmp: true
+
+      expect(HOMEBREW_TEMP.children.length).to eq(1)
+    end
+
+    it "retains temporary files on failure when debugging" do
+      expect { sandbox.run RbConfig.ruby, "-e", "exit 1", debug: true }.to raise_error(ErrorDuringExecution)
+      expect(HOMEBREW_TEMP.children.length).to eq(1)
+    end
+
+    it "retains temporary files on interruption when debugging" do
+      allow(sandbox).to receive(:sandbox_command).and_raise(Interrupt)
+
+      expect { sandbox.run "command", debug: true }.to raise_error(Interrupt)
+      expect(HOMEBREW_TEMP.children.length).to eq(1)
+    end
+
+    it "does not retain temporary files for fatal exceptions when debugging" do
+      allow(sandbox).to receive(:sandbox_command).and_raise(NoMemoryError)
+
+      expect { sandbox.run "command", debug: true }.to raise_error(NoMemoryError)
+      expect(HOMEBREW_TEMP.children).to be_empty
     end
   end
 

--- a/Library/Homebrew/test/sandbox_spec.rb
+++ b/Library/Homebrew/test/sandbox_spec.rb
@@ -189,17 +189,14 @@ RSpec.describe Sandbox, :needs_macos do
       end
     end
 
-    it "runs a private Unix socket service online and offline" do
-      sandbox.allow_write_path(dir)
-
+    it "runs a private Unix socket task host online and offline" do
       expect do
         [true, false].each do |network_access_allowed|
           sandbox.deny_all_network unless network_access_allowed
-          sandbox.allow_network path: dir, type: :subpath
-          sandbox.run RbConfig.ruby, "-rsocket", "-rtimeout", "-e", <<~'RUBY', dir
-            Dir.chdir(ARGV.fetch(0))
+          sandbox.run RbConfig.ruby, "-rsocket", "-rtimeout", "-e", <<~'RUBY'
+            Dir.chdir(ENV.fetch("TMPDIR"))
             Dir.mkdir("sockets")
-            UNIXServer.open("sockets/database.sock") do |server|
+            UNIXServer.open("sockets/CoreFxPipe_task") do |server|
               pid = fork do
                 Timeout.timeout(5) do
                   client = server.accept
@@ -209,7 +206,7 @@ RSpec.describe Sandbox, :needs_macos do
               end
               begin
                 Timeout.timeout(5) do
-                  UNIXSocket.open("sockets/database.sock") do |client|
+                  UNIXSocket.open("sockets/CoreFxPipe_task") do |client|
                     client.sendmsg("query\n")
                     abort "Unexpected service response" unless client.gets == "QUERY\n"
                   end
@@ -219,10 +216,32 @@ RSpec.describe Sandbox, :needs_macos do
               end
               abort "Service failed" unless $?.success?
             end
-            File.unlink("sockets/database.sock")
+            File.unlink("sockets/CoreFxPipe_task")
             Dir.rmdir("sockets")
           RUBY
         end
+      end.not_to raise_error
+    end
+
+    it "connects to a private GnuPG agent when network access is denied" do
+      gpgconf = which("gpgconf", ENV.fetch("HOMEBREW_PATH"))
+      gpg_connect_agent = which("gpg-connect-agent", ENV.fetch("HOMEBREW_PATH"))
+      skip "GnuPG not installed." if !gpgconf || !gpg_connect_agent
+
+      # GnuPG uses absolute socket paths, which must fit macOS's 104-byte limit.
+      stub_const("HOMEBREW_TEMP", Pathname("/private/tmp"))
+      sandbox.deny_all_network
+
+      expect do
+        sandbox.run RbConfig.ruby, "-e", <<~RUBY, gpgconf, gpg_connect_agent
+          ENV["GNUPGHOME"] = File.join(ENV.fetch("TMPDIR"), "gnupg")
+          Dir.mkdir(ENV.fetch("GNUPGHOME"), 0700)
+          begin
+            abort "Agent connection failed" unless system(ARGV.fetch(1), "GETINFO pid", "/bye")
+          ensure
+            system(ARGV.fetch(0), "--kill", "all")
+          end
+        RUBY
       end.not_to raise_error
     end
 

--- a/Library/Homebrew/test/utils/fork_spec.rb
+++ b/Library/Homebrew/test/utils/fork_spec.rb
@@ -29,6 +29,24 @@ RSpec.describe Utils do
   end
 
   describe "#safe_fork" do
+    it "preserves a parent failure while the child error pipe is open" do
+      IO.pipe do |ready_read, ready_write|
+        expect do
+          described_class.safe_fork(yield_parent: true) do |error_pipe|
+            if error_pipe
+              ready_read.close
+              ready_write.puts "ready"
+              ready_write.close
+            else
+              ready_write.close
+              ready_read.gets
+              raise "parent failed"
+            end
+          end
+        end.to raise_error(RuntimeError, "parent failed")
+      end
+    end
+
     it "responds to messages from the forked child" do
       messages = []
       handler = proc do |message|

--- a/Library/Homebrew/utils/fork.rb
+++ b/Library/Homebrew/utils/fork.rb
@@ -214,6 +214,8 @@ module Utils
             child_reaped = true
           end
         ensure
+          # Stop the reader so closing its pipe cannot mask the original exception.
+          reader.kill if $ERROR_INFO
           # Close the pipes before reaping: a child blocked waiting for a
           # response must see EOF and exit or `waitpid` would deadlock.
           [error_read, error_write, response_read, response_write].compact.each do |pipe|

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1499,6 +1499,10 @@ brew search --fink foo
 
 If in your local Homebrew build of your new formula, you see `Operation not permitted` errors, this will be because your new formula tried to write to the disk outside of your sandbox area. This is enforced on macOS by `sandbox-exec`.
 
+Each sandboxed command receives a private temporary directory under the configured `HOMEBREW_TEMP`, exposed through `TMPDIR`, `TEMP` and `TMP`.
+On macOS, the sandbox allows Unix socket connections within this directory, including when network access is disabled, so tools such as MSBuild can communicate with their task hosts.
+Connections to other Unix sockets remain restricted.
+
 ### Fortran
 
 Some software requires a Fortran compiler. This can be declared by adding `depends_on "gcc"` to a formula.


### PR DESCRIPTION
- Reuse each sandbox's private directory for temporary files and local task-host sockets across fetch, build, test and install operations.
- Share phase environments, cleanup and retention while preserving offline restrictions and the existing options for debugging failures.
- Cover private Unix socket communication online and offline and private GnuPG agents without requiring a .NET SDK for the tests.
- Preserve parent failures during error-pipe cleanup so diagnostics are not replaced by reader-thread errors.

Fixes #23934

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Codex with GPT Astra 6 at High effort, with local review and testing.

-----