### PR TITLE
extend/pathname: accept `Pathname` as a hash value

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -44,7 +44,7 @@ class Pathname
   sig {
     params(sources: T.any(
       Resource, Resource::Partial, String, Pathname,
-      T::Array[T.any(String, Pathname)], T::Hash[T.any(String, Pathname), String]
+      T::Array[T.any(String, Pathname)], T::Hash[T.any(String, Pathname), T.any(String, Pathname)]
     )).void
   }
   def install(*sources)
@@ -77,7 +77,8 @@ class Pathname
   # @api public
   sig {
     params(
-      sources: T.any(String, Pathname, T::Array[T.any(String, Pathname)], T::Hash[T.any(String, Pathname), String]),
+      sources: T.any(String, Pathname, T::Array[T.any(String, Pathname)],
+                     T::Hash[T.any(String, Pathname), T.any(String, Pathname)]),
     ).void
   }
   def install_symlink(*sources)

--- a/Library/Homebrew/test/pathname_spec.rb
+++ b/Library/Homebrew/test/pathname_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe Pathname do
     end
 
     it "supports renaming multiple files" do
-      dst.install(src/"a.txt" => "c.txt", src/"b.txt" => "d.txt")
+      dst.install(src/"a.txt" => "c.txt", src/"b.txt" => Pathname("d.txt"))
 
       expect(dst/"c.txt").to exist, "c.txt was not installed"
       expect(dst/"d.txt").to exist, "d.txt was not installed"
@@ -290,7 +290,7 @@ RSpec.describe Pathname do
     end
 
     it "can install relative paths as symlinks" do
-      dst.install_symlink "foo" => "bar"
+      dst.install_symlink "foo" => Pathname("bar")
       expect((dst/"bar").readlink).to eq(described_class.new("foo"))
     end
 

--- a/Library/Homebrew/test/pathname_spec.rb
+++ b/Library/Homebrew/test/pathname_spec.rb
@@ -290,8 +290,9 @@ RSpec.describe Pathname do
     end
 
     it "can install relative paths as symlinks" do
-      dst.install_symlink "foo" => Pathname("bar")
+      dst.install_symlink "foo" => Pathname("bar"), "baz" => "qux"
       expect((dst/"bar").readlink).to eq(described_class.new("foo"))
+      expect((dst/"qux").readlink).to eq(described_class.new("baz"))
     end
 
     it "can install relative symlinks in a symlinked directory" do


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Accept `Pathname` as a value in `Hash` for `install` and `install_symlink` methods, f.e.:

```ruby
dest = source.basename.gsub("xprog", "yprog")
source.dirname.install source => dest
```

Fixes https://github.com/Homebrew/homebrew-core/actions/runs/34603558353/job/103276809233#step:4:230