### PR TITLE
Use GitHub runners for Golden Gate dependents

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -134,7 +134,8 @@ class GitHubRunnerMatrix
                                                        NEWEST_GITHUB_ACTIONS_ARM_MACOS_RUNNER)
 
       runner, timeout = if use_github_runner && github_runner_available
-        ["macos-#{version}", GITHUB_ACTIONS_RUNNER_TIMEOUT]
+        prefix = (macos_version >= "27") ? "xcode" : "macos"
+        ["#{prefix}-#{version}", GITHUB_ACTIONS_RUNNER_TIMEOUT]
       elsif macos_version >= :monterey
         ["#{version}-arm64#{ephemeral_suffix}", @runner_timeout]
       else
@@ -296,7 +297,7 @@ class GitHubRunnerMatrix
     end, T.nilable(String))
   end
 
-  NEWEST_GITHUB_ACTIONS_ARM_MACOS_RUNNER = :tahoe
+  NEWEST_GITHUB_ACTIONS_ARM_MACOS_RUNNER = :golden_gate
   OLDEST_GITHUB_ACTIONS_ARM_MACOS_RUNNER = :sonoma
   GITHUB_ACTIONS_RUNNER_TIMEOUT = 360
   private_constant :NEWEST_GITHUB_ACTIONS_ARM_MACOS_RUNNER, :OLDEST_GITHUB_ACTIONS_ARM_MACOS_RUNNER,

--- a/Library/Homebrew/test/github_runner_matrix_spec.rb
+++ b/Library/Homebrew/test/github_runner_matrix_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
     allow(ENV).to receive(:fetch).and_call_original
     allow(ENV).to receive(:fetch).with("HOMEBREW_LINUX_SELF_HOSTED", "false").and_return("false")
     allow(ENV).to receive(:fetch).with("HOMEBREW_MACOS_LONG_TIMEOUT", "false").and_return("false")
-    allow(ENV).to receive(:fetch).with("HOMEBREW_MACOS_BUILD_ON_GITHUB_RUNNER", "false").and_return("false")
+    ENV["HOMEBREW_MACOS_BUILD_ON_GITHUB_RUNNER"] = "false"
     allow(ENV).to receive(:fetch).with("GITHUB_RUN_ID").and_return("12345")
     allow(ENV).to receive(:fetch).with("HOMEBREW_EVAL_ALL", nil).and_call_original
     allow(ENV).to receive(:fetch).with("HOMEBREW_SIMULATE_MACOS_ON_LINUX", nil).and_call_original
@@ -53,16 +53,41 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
         .to eq(["macOS 27-arm64", "macOS 26-arm64", "macOS 15-arm64"])
     end
 
-    it "uses a self-hosted runner for Golden Gate dependents with a two-hour timeout" do
-      ENV["GITHUB_RUN_ID"] = "12345"
+    it "uses GitHub runners for macOS dependents with a six-hour timeout" do
       allow(Formula).to receive(:all).and_return([testball, testball_depender].map(&:formula))
       runners = described_class.new([testball], [], all_supported: false, dependent_matrix: true)
                                .active_runner_specs_hash
 
       expect(runners).to include(
-        include(name: "macOS 27-arm64", runner: "27-arm64-12345-deps", timeout: 120),
+        include(name: "macOS 27-arm64", runner: "xcode-27", timeout: 360, cleanup: true),
         include(name: "macOS 26-arm64", runner: "macos-26", timeout: 360),
         include(name: "macOS 15-arm64", runner: "macos-15", timeout: 360),
+      )
+    end
+
+    it "uses a GitHub runner for Golden Gate bottles when requested" do
+      ENV["HOMEBREW_MACOS_BUILD_ON_GITHUB_RUNNER"] = "true"
+      runners = described_class.new([testball], [], all_supported: false, dependent_matrix: false)
+                               .active_runner_specs_hash
+
+      expect(runners).to include(
+        include(name: "macOS 27-arm64", runner: "xcode-27", timeout: 360, cleanup: true),
+      )
+    end
+
+    it "preserves GitHub runner labels when older macOS symbols are removed" do
+      allow(BottleTransition).to receive(:active?).and_return(false)
+      stub_const("MacOSVersion::SYMBOLS", { future: "28" }.merge(MacOSVersion::SYMBOLS.except(:golden_gate)))
+      stub_const("GitHubRunnerMatrix::NEWEST_HOMEBREW_CORE_MACOS_RUNNER", :future)
+      stub_const("GitHubRunnerMatrix::NEWEST_GITHUB_ACTIONS_ARM_MACOS_RUNNER", :future)
+      ENV["HOMEBREW_MACOS_BUILD_ON_GITHUB_RUNNER"] = "true"
+      runners = described_class.new([], [], all_supported: true, dependent_matrix: false)
+                               .active_runner_specs_hash
+
+      expect(runners).to include(
+        include(name: "macOS 28-arm64", runner: "xcode-28", timeout: 360, cleanup: true),
+        include(name: "macOS 26-arm64", runner: "macos-26", timeout: 360, cleanup: true),
+        include(name: "macOS 15-arm64", runner: "macos-15", timeout: 360, cleanup: true),
       )
     end
 


### PR DESCRIPTION
#23928 fell back to a self-hosted runner for Golden Gate dependent testing because GitHub did not yet host macOS 27. GitHub now provides macOS 27 arm64 under the `xcode-27` label ([changelog](https://github.blog/changelog/2026-09-10-xcode-27-runner-image-now-runs-on-macos-27/)), so Golden Gate dependents move onto GitHub runners with the same six-hour timeout and cleanup as Tahoe and Sequoia.

Labels from macOS 27 onward use the Xcode name rather than `macos-NN`, so the label is derived from the version instead of hard-coding one release, and a spec simulating macOS 28 covers the next bump. Bottle builds and long-timeout dependent runs stay on self-hosted runners.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) drafted the implementation and tests; I reviewed the diff, verified the new tests fail without the change and pass with it, and ran `brew lgtm` plus targeted specs.

-----
