### PR TITLE
Drop `gnu/` from ftpmirror.gnu.org URLs

### DIFF
--- a/Library/Homebrew/livecheck/strategy/gnu.rb
+++ b/Library/Homebrew/livecheck/strategy/gnu.rb
@@ -13,6 +13,7 @@ module Homebrew
       #
       # * Archive file URLs:
       #   * `https://ftp.gnu.org/gnu/example/example-1.2.3.tar.gz`
+      #   * `https://ftpmirror.gnu.org/example/example-1.2.3.tar.gz`
       #   * `https://ftp.gnu.org/gnu/example/1.2.3/example-1.2.3.tar.gz`
       # * Homepage URLs:
       #   * `https://www.gnu.org/software/example/`
@@ -37,6 +38,7 @@ module Homebrew
         URL_MATCH_REGEX = %r{
           ^https?://
           (?:(?:[^/]+?\.)*gnu\.org/(?:gnu|software)/(?<project_name>[^/]+)/
+          |ftpmirror\.gnu\.org/(?!non-gnu/)(?<project_name>[^/]+)/
           |(?<project_name>[^/]+)\.gnu\.org/?$)
         }ix
 
@@ -67,7 +69,7 @@ module Homebrew
           return values if project_name.blank?
 
           # The directory listing page for the project's files
-          values[:url] = "https://ftpmirror.gnu.org/gnu/#{project_name}/"
+          values[:url] = "https://ftpmirror.gnu.org/#{project_name}/"
 
           regex_name = Regexp.escape(project_name).gsub("\\-", "-")
 

--- a/Library/Homebrew/rubocops/shared/url_helper.rb
+++ b/Library/Homebrew/rubocops/shared/url_helper.rb
@@ -59,9 +59,9 @@ module RuboCop
         end
 
         # Prefer ftpmirror.gnu.org as suggested by https://www.gnu.org/prep/ftp.en.html
-        gnu_pattern = %r{^(?:https?|ftp)://ftp\.gnu\.org/(.*)}
+        gnu_pattern = %r{^(?:https?|ftp)://ftp\.gnu\.org/(?:gnu/)?(.*)}
         audit_urls(urls, gnu_pattern) do |match, url|
-          problem "#{url} should be: https://ftpmirror.gnu.org/gnu/#{match[1]}"
+          problem "#{url} should be: https://ftpmirror.gnu.org/#{match[1]}"
         end
 
         # Fossies upstream requests they aren't used as primary URLs

--- a/Library/Homebrew/test/livecheck/strategy/gnu_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/gnu_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Homebrew::Livecheck::Strategy::Gnu do
 
   let(:gnu_urls) do
     {
-      no_version_dir: "https://ftpmirror.gnu.org/gnu/abc/abc-1.2.3.tar.gz",
+      no_version_dir: "https://ftpmirror.gnu.org/abc/abc-1.2.3.tar.gz",
       software_page:  "https://www.gnu.org/software/abc/",
       subdomain:      "https://abc.gnu.org",
       savannah:       "https://download.savannah.gnu.org/releases/abc/abc-1.2.3.tar.gz",
@@ -18,15 +18,15 @@ RSpec.describe Homebrew::Livecheck::Strategy::Gnu do
   let(:generated) do
     {
       no_version_dir: {
-        url:   "https://ftpmirror.gnu.org/gnu/abc/",
+        url:   "https://ftpmirror.gnu.org/abc/",
         regex: %r{href=.*?abc[._-]v?(\d+(?:\.\d+)*)(?:\.[a-z]+|/)}i,
       },
       software_page:  {
-        url:   "https://ftpmirror.gnu.org/gnu/abc/",
+        url:   "https://ftpmirror.gnu.org/abc/",
         regex: %r{href=.*?abc[._-]v?(\d+(?:\.\d+)*)(?:\.[a-z]+|/)}i,
       },
       subdomain:      {
-        url:   "https://ftpmirror.gnu.org/gnu/abc/",
+        url:   "https://ftpmirror.gnu.org/abc/",
         regex: %r{href=.*?abc[._-]v?(\d+(?:\.\d+)*)(?:\.[a-z]+|/)}i,
       },
       savannah:       {},

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Urls do
 
   let(:offense_list) do
     [{
-      "url" => "https://ftp.gnu.org/lightning/lightning-2.1.0.tar.gz",
-      "msg" => "https://ftp.gnu.org/lightning/lightning-2.1.0.tar.gz should be: " \
-               "https://ftpmirror.gnu.org/gnu/lightning/lightning-2.1.0.tar.gz",
+      "url" => "https://ftp.gnu.org/gnu/lightning/lightning-2.1.0.tar.gz",
+      "msg" => "https://ftp.gnu.org/gnu/lightning/lightning-2.1.0.tar.gz should be: " \
+               "https://ftpmirror.gnu.org/lightning/lightning-2.1.0.tar.gz",
       "col" => 2,
     }, {
       "url" => "https://fossies.org/linux/privat/monit-5.23.0.tar.gz",


### PR DESCRIPTION
-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Fix was done by Fable 5.1 and I have reviewed myself.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

- `ftpmirror.gnu.org` appends the request path to each mirror's `gnu/` directory, so `/gnu/<project>/` URLs resolve to `<mirror>/gnu//gnu/<project>/` and 404 on most mirrors, which broke `wget`, `gcc` and other homebrew-core builds from 2026-09-10.