### PR TITLE
Shorten sandbox temporary directory names

### DIFF
--- a/Library/Homebrew/mktemp.rb
+++ b/Library/Homebrew/mktemp.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "utils/interrupts"
+require "securerandom"
 
 require "utils/output"
 
@@ -18,14 +19,18 @@ class Mktemp
   # With `path`, reuse that existing directory (e.g. one shared between the
   # fetch and build phases) rather than creating a temporary one.
   # Otherwise create the directory under `parent`, unless retaining it in cache.
+  # With `compact`, use one prefix character and eight random characters. Under
+  # `/private/tmp`, this leaves 78 bytes for descendants within libassuan's
+  # 102-byte Unix socket path limit on macOS.
   sig {
     params(prefix: String, retain: T::Boolean, retain_in_cache: T::Boolean, path: T.nilable(Pathname),
-           parent: Pathname).void
+           parent: Pathname, compact: T::Boolean).void
   }
-  def initialize(prefix, retain: false, retain_in_cache: false, path: nil, parent: HOMEBREW_TEMP)
+  def initialize(prefix, retain: false, retain_in_cache: false, path: nil, parent: HOMEBREW_TEMP, compact: false)
     @prefix = prefix
     @path = path
     @parent = parent
+    @compact = compact
     @retain_in_cache = retain_in_cache
     @retain = T.let(retain || @retain_in_cache, T::Boolean)
     @quiet = T.let(false, T::Boolean)
@@ -96,6 +101,14 @@ class Mktemp
       chmod_rm_rf(tmp_dir) # clear out previous staging directory
       tmp_dir.mkpath
       tmp_dir
+    elsif @compact
+      begin
+        compact_dir = @parent/"#{prefix_name[0]}-#{SecureRandom.alphanumeric(8)}"
+        compact_dir.mkdir(0700)
+        compact_dir
+      rescue Errno::EEXIST
+        retry
+      end
     else
       Pathname.new(Dir.mktmpdir("#{prefix_name}-", @parent.to_s))
     end

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -570,7 +570,7 @@ class Sandbox
     ).void
   }
   def run(*args, passthrough_stdin: true, child_message_handler: nil, retain_tmp: false, debug: false)
-    Mktemp.new("sandbox", retain: retain_tmp).run(chdir: false) do |staging|
+    Mktemp.new("sandbox", retain: retain_tmp, compact: true).run(chdir: false) do |staging|
       temporary = staging.tmpdir
       raise "Sandbox temporary directory is unexpectedly unset." if temporary.nil?
 

--- a/Library/Homebrew/test/mktemp_spec.rb
+++ b/Library/Homebrew/test/mktemp_spec.rb
@@ -1,0 +1,24 @@
+# typed: true
+# frozen_string_literal: true
+
+require "mktemp"
+
+RSpec.describe Mktemp do
+  it "names compact temporary directories" do
+    described_class.new("sandbox", compact: true, parent: mktmpdir).run(chdir: false) do |staging|
+      directory = staging.tmpdir
+      raise "Temporary directory is unexpectedly unset." if directory.nil?
+
+      expect(directory.basename.to_s).to match(/\As-[A-Za-z0-9]{8}\z/)
+    end
+  end
+
+  it "creates compact temporary directories with mode 0700" do
+    described_class.new("sandbox", compact: true, parent: mktmpdir).run(chdir: false) do |staging|
+      directory = staging.tmpdir
+      raise "Temporary directory is unexpectedly unset." if directory.nil?
+
+      expect(directory.stat.mode & 0777).to eq(0700)
+    end
+  end
+end

--- a/Library/Homebrew/test/sandbox_spec.rb
+++ b/Library/Homebrew/test/sandbox_spec.rb
@@ -119,6 +119,8 @@ RSpec.describe Sandbox, :needs_macos do
   end
 
   describe "#run" do
+    let(:gpgme_test_home) { Pathname("gpgme-20260911-52880-n7d0ah/gpgme-2.2.0/tests/gpg") }
+
     let(:handlers_for_scheme) do
       lambda do |scheme|
         SystemCommand.run!("/usr/bin/osascript", args: ["-l", "JavaScript", "-e", <<~JS, scheme]).stdout
@@ -223,24 +225,39 @@ RSpec.describe Sandbox, :needs_macos do
       end.not_to raise_error
     end
 
-    it "connects to a private GnuPG agent when network access is denied" do
+    it "connects to a private GnuPG agent at the gpgme build path when network access is denied" do
       gpgconf = which("gpgconf", ENV.fetch("HOMEBREW_PATH"))
       gpg_connect_agent = which("gpg-connect-agent", ENV.fetch("HOMEBREW_PATH"))
       skip "GnuPG not installed." if !gpgconf || !gpg_connect_agent
 
-      # GnuPG uses absolute socket paths, which must fit macOS's 104-byte limit.
+      # libassuan limits absolute Unix socket paths to 102 bytes on macOS.
       stub_const("HOMEBREW_TEMP", Pathname("/private/tmp"))
       sandbox.deny_all_network
 
       expect do
-        sandbox.run RbConfig.ruby, "-e", <<~RUBY, gpgconf, gpg_connect_agent
-          ENV["GNUPGHOME"] = File.join(ENV.fetch("TMPDIR"), "gnupg")
-          Dir.mkdir(ENV.fetch("GNUPGHOME"), 0700)
+        sandbox.run RbConfig.ruby, "-rfileutils", "-e", <<~RUBY, gpgconf, gpg_connect_agent, gpgme_test_home
+          home = File.join(ENV.fetch("TMPDIR"), ARGV.fetch(2))
+          FileUtils.mkdir_p(home, mode: 0700)
+          ENV["GNUPGHOME"] = home
           begin
             abort "Agent connection failed" unless system(ARGV.fetch(1), "GETINFO pid", "/bye")
           ensure
             system(ARGV.fetch(0), "--kill", "all")
           end
+        RUBY
+      end.not_to raise_error
+    end
+
+    it "keeps gpgme's private Unix socket paths within libassuan's macOS limit" do
+      stub_const("HOMEBREW_TEMP", Pathname("/private/tmp"))
+      sandbox.deny_all_network
+
+      expect do
+        sandbox.run RbConfig.ruby, "-rfileutils", "-rsocket", "-e", <<~'RUBY', gpgme_test_home
+          socket = File.join(ENV.fetch("TMPDIR"), ARGV.fetch(0), "S.gpg-agent.browser")
+          abort "Socket path exceeds libassuan's macOS limit: #{socket.bytesize} bytes" if socket.bytesize > 102
+          FileUtils.mkdir_p(File.dirname(socket), mode: 0700)
+          UNIXServer.open(socket, &:close)
         RUBY
       end.not_to raise_error
     end

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1501,6 +1501,7 @@ If in your local Homebrew build of your new formula, you see `Operation not perm
 
 Each sandboxed command receives a private temporary directory under the configured `HOMEBREW_TEMP`, exposed through `TMPDIR`, `TEMP` and `TMP`.
 On macOS, the sandbox allows Unix socket connections within this directory, including when network access is disabled, so tools such as MSBuild can communicate with their task hosts.
+macOS limits Unix socket paths to 104 bytes; C clients that terminate the path get 103 bytes, and libassuan allows only 102 bytes.
 Connections to other Unix sockets remain restricted.
 
 ### Fortran


### PR DESCRIPTION
#23940 nests each build's temporary directory under the sandbox's private directory, which added 29 bytes to every socket path a build tree creates. gpgme's `make` starts a `gpg-agent` fixture with `GNUPGHOME=$(abs_builddir)`, so its `S.gpg-agent.browser` socket path is now 112 bytes, beyond the 102 bytes libassuan allows on macOS, and the build fails; Homebrew/homebrew-core#306990 is working around it in the formula.

This names sandbox directories `s-` plus eight random alphanumerics instead of `Dir.mktmpdir`'s `sandbox-YYYYMMDD-PID-random`, still created atomically with mode 0700, which brings gpgme's socket path to 93 bytes. Only `Sandbox#run` uses the compact name because the formula staging directory name is user-facing with `--keep-tmp`. GnuPG's own `make check` (Homebrew/homebrew-core#305110) is a separate policy problem: gpgscm puts its `GNUPGHOME` directly under `/tmp`, outside the sandbox directory, so its agent socket is denied rather than too long.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude Code (Opus 5) reviewed the implementation and tests across several rounds and I applied the resulting repairs; I verified the new tests fail without the change and pass with it, and ran `brew lgtm --online` plus targeted specs.

-----
