### PR TITLE
info: show installed keg's actual dependencies

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -546,12 +546,37 @@ module Homebrew
         else
           [].freeze
         end
+
+        has_tab_runtime_deps = kegs.any? && tab_runtime_deps.present?
+        current_direct_dep_names = formula.deps.reject(&:build?).to_set(&:name)
+        direct_tab_deps, indirect_tab_deps = if has_tab_runtime_deps
+          tab_runtime_deps.partition do |dep|
+            dep_name = dep["full_name"]&.then { Utils.name_from_full_name(it) }
+            dep_name && current_direct_dep_names.include?(dep_name)
+          end
+        else
+          [[], []]
+        end
+        recursive_runtime_deps = has_tab_runtime_deps ? indirect_tab_deps : tab_runtime_deps
+
         dependency_lines = %w[build required recommended optional].filter_map do |type|
           next if type == "build" &&
                   (kegs.all? { |keg| keg.tab.poured_from_bottle } ||
                    (kegs.empty? &&
                     (formula.requirements.any? { |requirement| self.class.requirement_for_other_os?(requirement) } ||
                      (stable.present? ? stable.bottled? && formula.pour_bottle? : formula.head.blank?))))
+
+          if has_tab_runtime_deps
+            next if ["recommended", "optional"].include?(type)
+
+            if type == "required"
+              direct_deps = tab_deps_to_dependencies(direct_tab_deps)
+              next if direct_deps.empty?
+
+              next "Required (#{direct_deps.count}): " \
+                   "#{decorate_dependencies(direct_deps, mark_uninstalled: true, missing_library_deps:)}"
+            end
+          end
 
           deps = formula.deps.public_send(type).uniq
           next if deps.empty?
@@ -561,7 +586,7 @@ module Homebrew
             "#{decorate_dependencies(deps, tab_runtime_deps: tab_deps, mark_uninstalled: kegs.any?,
                                      missing_library_deps:)}"
         end
-        if dependency_lines.present? || tab_runtime_deps.present? || installed_dependents.any?
+        if dependency_lines.present? || recursive_runtime_deps.present? || installed_dependents.any?
           ohai "Dependencies"
           puts dependency_lines
           missing_library_names = missing_libraries.map { |lib| File.basename(lib) }.uniq
@@ -569,16 +594,18 @@ module Homebrew
             decorated = missing_library_names.map { |lib| pretty_uninstalled(lib, bold: false) }.join(", ")
             puts "Missing libraries (#{missing_library_names.count}): #{decorated}"
           end
-          if tab_runtime_deps.present?
-            installed_count = tab_runtime_deps.count do |dep|
-              dep_name = dep["full_name"]&.then { Utils.name_from_full_name(it) }
-              next false unless dep_name
-
-              rack = HOMEBREW_CELLAR/dep_name
-              rack.directory? && !rack.subdirs.empty?
+          if recursive_runtime_deps.present?
+            recursive_deps = tab_deps_to_dependencies(recursive_runtime_deps)
+            recursive_runtime_status = if args.verbose?
+              decorate_dependencies(recursive_deps, mark_uninstalled: true)
+            else
+              installed_count = recursive_deps.count do |dep|
+                rack = HOMEBREW_CELLAR/Utils.name_from_full_name(dep.name)
+                rack.directory? && !rack.subdirs.empty?
+              end
+              self.class.dependency_status_counts(installed_count, recursive_deps.count)
             end
-            puts "Recursive Runtime (#{tab_runtime_deps.count}): " \
-                 "#{self.class.dependency_status_counts(installed_count, tab_runtime_deps.count)}"
+            puts "Recursive Runtime (#{recursive_deps.count}): #{recursive_runtime_status}"
           end
           if installed_dependents.any?
             if args.verbose?
@@ -872,6 +899,11 @@ module Homebrew
           warning = missing_library_deps.include?(Utils.name_from_full_name(dep.name))
           pretty_install_status(display, warning:, installed:, outdated:, mark_uninstalled:, bold: true)
         end.join(", ")
+      end
+
+      sig { params(tab_deps: T::Array[T.untyped]).returns(T::Array[Dependency]) }
+      def tab_deps_to_dependencies(tab_deps)
+        tab_deps.filter_map { |dep| dep["full_name"]&.then { Dependency.new(it) } }
       end
 
       sig { params(requirements: T::Array[Requirement]).returns(String) }

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -577,6 +577,7 @@ RSpec.describe Homebrew::Cmd::Info do
     tab = Tab.empty
     tab.tabfile = keg_path/AbstractTab::FILENAME
     tab.runtime_dependencies = [
+      { "full_name" => "bar", "version" => "1.0" },
       { "full_name" => "installed-dep", "version" => "1.0" },
       { "full_name" => "missing-dep", "version" => "2.0" },
     ]
@@ -610,6 +611,85 @@ RSpec.describe Homebrew::Cmd::Info do
     expect { info.info_formula(formula) }
       .to output(expected_output).to_stdout
       .and not_to_output(/^Dependencies: /).to_stdout
+      .and not_to_output.to_stderr
+  end
+
+  it "prefers the installed keg's actual runtime dependency graph over the current recipe" do
+    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+    info = described_class.new(["--verbose"])
+    formula = formula("testball") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/testball-0.1.tar.gz"
+      homepage "https://brew.sh/testball"
+      desc "Some test"
+
+      depends_on "old-dep"
+      depends_on "new-dep"
+    end
+
+    keg_path = HOMEBREW_CELLAR/"testball/0.1"
+    keg_path.mkpath
+    tab = Tab.empty
+    tab.tabfile = keg_path/AbstractTab::FILENAME
+    tab.runtime_dependencies = [
+      { "full_name" => "old-dep", "version" => "1.0" },
+      { "full_name" => "removed-dep", "version" => "2.0" },
+    ]
+    tab.write
+
+    old_dep_path = HOMEBREW_CELLAR/"old-dep/1.0"
+    old_dep_path.mkpath
+    old_dep_tab = Tab.empty
+    old_dep_tab.tabfile = old_dep_path/AbstractTab::FILENAME
+    old_dep_tab.write
+
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+    allow(formula).to receive_messages(core_formula?: false, missing_library_linkage: [[], Set.new])
+
+    expect { info.info_formula(formula) }
+      .to output(/Required \(1\): .*old-dep.*✔\nRecursive Runtime \(1\): .*removed-dep.*✘/).to_stdout
+      .and not_to_output(/new-dep/).to_stdout
+      .and not_to_output.to_stderr
+  end
+
+  it "lists recursive runtime dependency names inline under Dependencies with --verbose" do
+    allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+    info = described_class.new(["--verbose"])
+    formula = formula("testball") do
+      T.bind(self, T.class_of(Formula))
+      url "https://brew.sh/testball-0.1.tar.gz"
+      homepage "https://brew.sh/testball"
+      desc "Some test"
+
+      depends_on "bar"
+    end
+    direct_dependency = formula.deps.required.first
+
+    keg_path = HOMEBREW_CELLAR/"testball/0.1"
+    keg_path.mkpath
+    tab = Tab.empty
+    tab.tabfile = keg_path/AbstractTab::FILENAME
+    tab.runtime_dependencies = [
+      { "full_name" => "installed-dep", "version" => "1.0" },
+      { "full_name" => "missing-dep", "version" => "2.0" },
+    ]
+    tab.write
+
+    installed_dep_path = HOMEBREW_CELLAR/"installed-dep/1.0"
+    installed_dep_path.mkpath
+    installed_dep_tab = Tab.empty
+    installed_dep_tab.tabfile = installed_dep_path/AbstractTab::FILENAME
+    installed_dep_tab.write
+
+    allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
+    allow(formula).to receive_messages(core_formula?: false, missing_library_linkage: [[], Set.new])
+    allow(direct_dependency).to receive(:satisfied?).and_return(true)
+
+    expect { info.info_formula(formula) }
+      .to output(/Recursive Runtime \(2\): .*installed-dep.*✔.*, .*missing-dep.*✘/).to_stdout
+      .and not_to_output(/\d+ installed/).to_stdout
       .and not_to_output.to_stderr
   end
 
@@ -725,7 +805,6 @@ RSpec.describe Homebrew::Cmd::Info do
 
       depends_on "bar"
     end
-    direct_dependency = formula.deps.required.first
 
     keg_path = HOMEBREW_CELLAR/"testball/0.1"
     keg_path.mkpath
@@ -741,7 +820,7 @@ RSpec.describe Homebrew::Cmd::Info do
     bar_tab.write
 
     bar_formula = instance_double(Formula, outdated?: false)
-    allow(direct_dependency).to receive(:to_formula).and_return(bar_formula)
+    allow_any_instance_of(Dependency).to receive(:to_formula).and_return(bar_formula)
 
     allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
     allow(formula).to receive_messages(core_formula?: false, missing_library_linkage: [[], Set.new])
@@ -762,7 +841,6 @@ RSpec.describe Homebrew::Cmd::Info do
 
       depends_on "bar"
     end
-    direct_dependency = formula.deps.required.first
 
     keg_path = HOMEBREW_CELLAR/"testball/0.1"
     keg_path.mkpath
@@ -778,7 +856,7 @@ RSpec.describe Homebrew::Cmd::Info do
     bar_tab.write
 
     bar_formula = instance_double(Formula, outdated?: true)
-    allow(direct_dependency).to receive(:to_formula).and_return(bar_formula)
+    allow_any_instance_of(Dependency).to receive(:to_formula).and_return(bar_formula)
 
     allow(info).to receive(:github_info).with(formula).and_return("https://example.com/testball.rb")
     allow(formula).to receive_messages(core_formula?: false, missing_library_linkage: [[], Set.new])


### PR DESCRIPTION
`brew info`'s `Required` line comes from the *current* formula recipe, not from what your installed keg actually needed when it was built. For a formula that's fallen behind, that makes `Required` show deps that only a newer version needs as if they were missing from your (perfectly fine) install:

```
❯ brew info ffmpeg -v
==> ffmpeg ↑: 3.4.2 → stable 9.0.1, HEAD
...
==> Dependencies
Required (11): dav1d ✔, lame ✔, libvmaf ✔, libvpx ↑, openssl@3 ↑, opus ✔, sdl2-compat ✘, svt-av1 ✘, x264 ↑, x265 ✘, xz ✔
Recursive Runtime (3): lame ✔, x264 ✔, xvid ✔
```

My installed `ffmpeg` is `3.4.2` from 2018 (never rebuilt since). `dav1d`, `libvmaf`, `openssl@3`, `sdl2-compat`, `svt-av1` and `x265` are all dependencies the *current* `9.0.1` formula needs, not ones `3.4.2` ever linked against — `sdl2-compat ✘`/`svt-av1 ✘` look like something's broken, but nothing is.

This also made `Recursive Runtime` look pointless: it's a flattened, recursive view of the same install, so on a formula with a shallow dependency tree it's often just a subset of (or identical to) `Required` restated.

### What changed

- When a keg is installed and has recorded runtime deps, split them into direct and indirect by cross-checking against the *current* formula's own direct deps:
  - **Direct** (matches a current direct dep by name) → shown as `Required`, using the install's actual dependency graph rather than the current recipe.
  - **Indirect** (everything else — a transitive dependency, or one the current recipe dropped entirely) → shown as `Recursive Runtime`, which no longer repeats `Required`.
- `Recommended`/`Optional` labels aren't recoverable from the install's recorded data, so those are only shown for formulae that aren't installed yet, where the current recipe is the only available source anyway.
- `-v` also lists `Recursive Runtime` dependency names (decorated like everywhere else) instead of collapsing to a bare pass/fail count.

After, on the same install:

```
❯ brew info ffmpeg
==> ffmpeg ↑: 3.4.2 → stable 9.0.1, HEAD
Play, record, convert, and stream select audio and video codecs
https://ffmpeg.org/
Aliases: ffmpeg@9
Installed (on request)
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/f/ffmpeg.rb
License: GPL-3.0-or-later
==> Installed Versions
ffmpeg ↑ 3.4.2 → 9.0.1_1 (248 files, 53.4MB) [Linked]
==> Dependencies
Required (2): lame ✔, x264 ↑
Recursive Runtime (1): all installed ✔
```

Only `lame`/`x264` are genuinely part of this install; `x264 ↑` correctly shows it's upgradable rather than just "installed". The 9 dependencies that only the newer recipe needs no longer show up as if they were missing from a working install.

And with `-v`, `Recursive Runtime` names its dependencies (decorated the same way as everywhere else) instead of collapsing to a bare count:

```
❯ brew info ffmpeg -v
...
==> Dependencies
Required (2): lame ✔, x264 ↑
Recursive Runtime (1): xvid ↑
```

`xvid` isn't in the current `9.0.1` recipe at all, direct or indirect — `ffmpeg` dropped it as a dependency at some point — but this install still links against it, so it's worth seeing by name rather than as a bare pass/fail count.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Claude Code (Sonnet 5) wrote the code and tests, from a plain-language bug report and back-and-forth discussion of the intended behaviour. I reviewed the diff and manually tested `brew info` against my own installed formulae (including the `ffmpeg` case above) before opening this PR, and will handle review comments myself.

-----

