### PR TITLE
create: preserve formula template newlines

### DIFF
--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -146,7 +146,7 @@ module Homebrew
       end
 
       path.dirname.mkpath
-      path.write ERB.new(template, trim_mode: ">").result(binding)
+      path.write ERB.new(template, trim_mode: "<>").result(binding)
       path
     end
 

--- a/Library/Homebrew/test/formula_creator_spec.rb
+++ b/Library/Homebrew/test/formula_creator_spec.rb
@@ -101,6 +101,10 @@ RSpec.describe Homebrew::FormulaCreator do
         described_class.new(url: "https://brew.sh/foo-0.1.tgz", mode:).write_formula!
       end
 
+      it "writes a formula with valid syntax when using #{mode} template" do
+        expect { Formulary.factory(formula) }.not_to raise_error
+      end
+
       specify "when using #{mode} template" do
         expect(formula).to be_a_file
         contents = formula.read


### PR DESCRIPTION
- Preserve newlines after ERB expressions so generated formulae have valid Ruby syntax.
- Check that generated formulae load and `brew create --rust` succeeds.

Fixes #23946

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Codex with GPT 6 Astra at Extra High effort, with local review and testing.

-----