### PR TITLE
cask/utils: check ownership before using sudo chown

### DIFF
--- a/Library/Homebrew/cask/utils.rb
+++ b/Library/Homebrew/cask/utils.rb
@@ -92,9 +92,6 @@ module Cask
       ).void
     }
     def self.gain_permissions(path, command_args, command, &_block)
-      # `T.let` because Sorbet does not model `retry` as a back edge, so it
-      # would otherwise narrow both to `FalseClass` and treat everything after
-      # the first `retry` as unreachable.
       tried_permissions = T.let(false, T::Boolean)
       tried_ownership = T.let(false, T::Boolean)
       begin

--- a/Library/Homebrew/cask/utils.rb
+++ b/Library/Homebrew/cask/utils.rb
@@ -92,8 +92,11 @@ module Cask
       ).void
     }
     def self.gain_permissions(path, command_args, command, &_block)
-      tried_permissions = false
-      tried_ownership = false
+      # `T.let` because Sorbet does not model `retry` as a back edge, so it
+      # would otherwise narrow both to `FalseClass` and treat everything after
+      # the first `retry` as unreachable.
+      tried_permissions = T.let(false, T::Boolean)
+      tried_ownership = T.let(false, T::Boolean)
       begin
         yield path
       rescue
@@ -117,10 +120,8 @@ module Cask
           retry # rmtree
         end
 
-        unless tried_ownership
-          # in case of ownership problems
-          # TODO: Further examine files to see if ownership is the problem
-          #       before using `sudo` and `chown`.
+        # in case of ownership problems
+        if !tried_ownership && ownership_problem?(path, recursive: command_args.include?("-R"))
           ohai "Using sudo to gain ownership of path '#{path}'"
           command.run("chown",
                       args: command_args + ["--", User.current.to_s, path],
@@ -133,6 +134,23 @@ module Cask
 
         raise
       end
+    end
+
+    # Whether `sudo chown` could plausibly fix the failure we just rescued: the
+    # `chflags`/`chmod` above run without `sudo`, so they only fail on paths we
+    # do not own. `lstat` rather than `owned?`, which would follow a symlink.
+    sig { params(path: Pathname, recursive: T::Boolean).returns(T::Boolean) }
+    def self.ownership_problem?(path, recursive:)
+      return false if Process.euid.zero?
+
+      paths = recursive ? path.find : [path]
+      paths.any? do |candidate|
+        candidate.lstat.uid != Process.euid
+      rescue SystemCallError
+        false
+      end
+    rescue SystemCallError
+      false
     end
 
     sig { params(path: Pathname).returns(T::Boolean) }

--- a/Library/Homebrew/cask/utils.rb
+++ b/Library/Homebrew/cask/utils.rb
@@ -118,7 +118,8 @@ module Cask
         end
 
         # in case of ownership problems
-        if !tried_ownership && ownership_problem?(path, recursive: command_args.include?("-R"))
+        recursive = command_args.include?("-R")
+        if !tried_ownership && ownership_problem?(path, recursive:)
           ohai "Using sudo to gain ownership of path '#{path}'"
           command.run("chown",
                       args: command_args + ["--", User.current.to_s, path],

--- a/Library/Homebrew/test/cask/utils_spec.rb
+++ b/Library/Homebrew/test/cask/utils_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Cask::Utils do
   let(:dir) { mktmpdir }
   let(:path) { dir/"a/b/c" }
   let(:link) { dir/"link" }
+  let(:file) { dir/"file" }
+  let(:foreign_uid) { Process.euid + 1 }
 
   describe "::gain_permissions_mkpath" do
     it "creates a directory" do
@@ -91,6 +93,63 @@ RSpec.describe Cask::Utils do
       expect(path/"sub").to be_a_directory
 
       path.chmod(0700)
+    end
+  end
+
+  describe "::ownership_problem?" do
+    it "is false when the path is owned by the current user" do
+      FileUtils.touch file
+
+      expect(described_class.ownership_problem?(file, recursive: false)).to be false
+    end
+
+    it "is true when the path is owned by another user" do
+      FileUtils.touch file
+      allow(Process).to receive(:euid).and_return(foreign_uid)
+
+      expect(described_class.ownership_problem?(file, recursive: false)).to be true
+    end
+
+    it "stats the symlink itself rather than its target" do
+      FileUtils.ln_s dir/"missing", link
+      allow(Process).to receive(:euid).and_return(foreign_uid)
+
+      expect(described_class.ownership_problem?(link, recursive: false)).to be true
+    end
+
+    it "is false when running as root" do
+      FileUtils.touch file
+      allow(Process).to receive(:euid).and_return(0)
+
+      expect(described_class.ownership_problem?(file, recursive: false)).to be false
+    end
+
+    it "is false when the path does not exist" do
+      allow(Process).to receive(:euid).and_return(foreign_uid)
+
+      expect(described_class.ownership_problem?(file, recursive: false)).to be false
+      expect(described_class.ownership_problem?(file, recursive: true)).to be false
+    end
+
+    it "is false when a subdirectory cannot be read" do
+      path.mkpath
+      FileUtils.chmod 0000, path.dirname
+
+      expect(described_class.ownership_problem?(dir, recursive: true)).to be false
+    ensure
+      FileUtils.chmod 0755, path.dirname
+    end
+  end
+
+  describe "::gain_permissions" do
+    it "does not gain ownership when the current user already owns the path" do
+      FileUtils.touch file
+      allow(command).to receive(:run)
+      expect(command).not_to receive(:run).with("chown", any_args)
+
+      expect do
+        described_class.gain_permissions(file, [], command) { raise Errno::EACCES, file.to_s }
+      end.to raise_error(Errno::EACCES)
     end
   end
 end

--- a/Library/Homebrew/test/cask/utils_spec.rb
+++ b/Library/Homebrew/test/cask/utils_spec.rb
@@ -128,6 +128,11 @@ RSpec.describe Cask::Utils do
       allow(Process).to receive(:euid).and_return(foreign_uid)
 
       expect(described_class.ownership_problem?(file, recursive: false)).to be false
+    end
+
+    it "is false when the path does not exist and the check is recursive" do
+      allow(Process).to receive(:euid).and_return(foreign_uid)
+
       expect(described_class.ownership_problem?(file, recursive: true)).to be false
     end
 


### PR DESCRIPTION
gain_permissions retries a failed removal in two steps: fix flags/permissions, then sudo chown. The second step runs even when the current user already owns the path, so brew prompts for a password when chown can't change anything (see the TODO, and #19903).
This adds Utils.ownership_problem? and checks it before chown. It compares lstat.uid with Process.euid, walks the tree for -R, and returns false as root or on unreadable paths. Specs cover these cases. Behaviour is otherwise unchanged; only the password prompt goes away.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [ ] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
AI (Claude Code) was used to review the existing diff, and draft this PR description.
I reviewed its output and verified the changes with the targeted spec and brew lgtm.