### PR TITLE
Allow runtime Metal compilation

### DIFF
--- a/Library/Homebrew/extend/os/mac/sandbox.rb
+++ b/Library/Homebrew/extend/os/mac/sandbox.rb
@@ -40,6 +40,7 @@ module OS
         (deny file-write-mode) ; deny non-allowlist file write mode operations
         (deny mach-lookup)
         (allow mach-lookup
+            (xpc-service-name "com.apple.MTLCompilerService")
             (global-name "com.apple.mobileassetd.v2")
             (global-name "com.apple.sysmond")
             (global-name "com.apple.bsd.dirhelper")

--- a/Library/Homebrew/test/sandbox_spec.rb
+++ b/Library/Homebrew/test/sandbox_spec.rb
@@ -61,6 +61,12 @@ RSpec.describe Sandbox, :needs_macos do
       expect(sandbox.seatbelt_profile).to include('(global-name "com.apple.mobileassetd.v2")')
     end
 
+    it "allows runtime Metal compilation when network access is denied" do
+      sandbox.deny_all_network
+
+      expect(sandbox.seatbelt_profile).to include('(xpc-service-name "com.apple.MTLCompilerService")')
+    end
+
     it "allows process discovery when network access is denied" do
       sandbox.deny_all_network
 
@@ -403,6 +409,21 @@ RSpec.describe Sandbox, :needs_macos do
       expect do
         sandbox.run "/usr/bin/xcrun", "--no-cache", "--sdk", "macosx", "metal", "--version"
       end.not_to raise_error
+    end
+
+    it "compiles a fresh Metal kernel when network access is denied" do
+      SystemCommand.run!("/usr/bin/clang", args: [
+        "-fobjc-arc", "-framework", "Foundation", "-framework", "Metal", fixture("metal.m"), "-o", file
+      ])
+      control = SystemCommand.run(file)
+      skip "Metal device not available." if control.exit_status == 77
+
+      control.assert_success!
+      sandbox.allow_write_temp_and_cache
+      sandbox.deny_read_home
+      sandbox.deny_all_network
+
+      expect { sandbox.run file }.not_to raise_error
     end
 
     it "allows pgrep to find a child process when network access is denied" do

--- a/Library/Homebrew/test/support/fixtures/metal.m
+++ b/Library/Homebrew/test/support/fixtures/metal.m
@@ -1,0 +1,21 @@
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+
+int main(void) {
+  @autoreleasepool {
+    id<MTLDevice> device = MTLCreateSystemDefaultDevice();
+    if (!device) return 77;
+
+    // A unique function name prevents a cached library from hiding a compilation failure.
+    NSString *name = [@"sandbox_" stringByAppendingString:
+      [NSUUID.UUID.UUIDString stringByReplacingOccurrencesOfString:@"-" withString:@""]];
+    NSString *source = [NSString stringWithFormat:@"#include <metal_stdlib>\nkernel void %@() {}", name];
+    NSError *error = nil;
+    id<MTLLibrary> library = [device newLibraryWithSource:source options:nil error:&error];
+    if (!library) {
+      fprintf(stderr, "%s\n", error.localizedDescription.UTF8String);
+      return 1;
+    }
+    return [library newFunctionWithName:name] ? 0 : 1;
+  }
+}

--- a/Library/Homebrew/test/utils/popen_spec.rb
+++ b/Library/Homebrew/test/utils/popen_spec.rb
@@ -2,8 +2,71 @@
 # frozen_string_literal: true
 
 require "utils/popen"
+require "timeout"
+require "socket"
 
 RSpec.describe Utils do
+  describe "::popen" do
+    shared_examples "interruptible popen" do
+      it "kills an interrupted command and its descendants" do
+        error = Timeout::ExitException.new("test expired")
+
+        UNIXServer.open((mktmpdir/"socket").to_s) do |server|
+          connection = T.let(nil, T.nilable(UNIXSocket))
+          expect do
+            described_class.popen([RbConfig.ruby, "-rsocket", "-e", <<~RUBY, server.path], "r+") do
+              fork do
+                UNIXSocket.open(ARGV.fetch(0)) do |socket|
+                  $stdin.read
+                  socket.write("survived")
+                end
+              end
+              Process.wait
+            RUBY
+              connection = server.accept
+              raise error
+            end
+          end.to raise_error(error)
+
+          expect([$CHILD_STATUS.termsig, connection&.read]).to eq([Signal.list.fetch("KILL"), ""])
+        ensure
+          connection&.close
+        end
+      end
+
+      it "preserves an exception after closing the pipe" do
+        expect do
+          described_class.popen_read(RbConfig.ruby, "-e", "exit") do |pipe|
+            pipe.close
+            raise Interrupt
+          end
+        end.to raise_error(Interrupt)
+      end
+
+      it "waits normally inside a rescue" do
+        begin
+          raise "previous failure"
+        rescue RuntimeError
+          described_class.popen([RbConfig.ruby, "-e", '$stdout.sync = true; puts "ready"; $stdin.read'], "r+", &:gets)
+        end
+
+        expect($CHILD_STATUS).to be_a_success
+      end
+    end
+
+    context "when forking" do
+      before { ENV["HOMEBREW_SPAWN_SYSTEM"] = "0" }
+
+      include_examples "interruptible popen"
+    end
+
+    context "when spawning" do
+      before { ENV["HOMEBREW_SPAWN_SYSTEM"] = "1" }
+
+      include_examples "interruptible popen"
+    end
+  end
+
   describe "::popen_read" do
     it "reads the standard output of a given command" do
       expect(described_class.popen_read("sh", "-c", "echo success").chomp).to eq("success")

--- a/Library/Homebrew/utils/popen.rb
+++ b/Library/Homebrew/utils/popen.rb
@@ -104,10 +104,14 @@ module Utils
     if ENV["HOMEBREW_SPAWN_SYSTEM"] == "1"
       options[:err] = [:child, :out] if options[:err] == :out
       options[:err] ||= File::NULL unless ENV["HOMEBREW_STDERR"]
-      IO.popen(args, mode, options) do |pipe|
+      IO.popen(args, mode, options.merge(pgroup: true)) do |pipe|
         return pipe.read unless block_given?
 
         return yield pipe
+      # Include Timeout's internal exception so IO.popen cannot block its delivery.
+      rescue Exception # rubocop:disable Lint/RescueException
+        terminate_popen_child(pipe)
+        raise
       end
     end
 
@@ -124,6 +128,7 @@ module Utils
           args[0]
         end
         begin
+          Process.setpgid(0, 0)
           exec(*args, options)
         rescue Errno::ENOENT
           $stderr.puts "brew: command not found: #{cmd}" if options[:err] != :close
@@ -136,6 +141,28 @@ module Utils
           exit! 1
         end
       end
+    # Include Timeout's internal exception so IO.popen cannot block its delivery.
+    rescue Exception # rubocop:disable Lint/RescueException
+      terminate_popen_child(pipe) if pipe
+      raise
     end
+  end
+
+  sig { params(pipe: IO).void }
+  private_class_method def self.terminate_popen_child(pipe)
+    return if pipe.closed?
+
+    pid = pipe.pid
+    # The forked child may not have set its group yet; exec'd or exited children already have.
+    begin
+      Process.setpgid(pid, pid)
+    rescue Errno::EACCES, Errno::ESRCH
+      nil
+    end
+
+    # IO.popen waits for the child before propagating exceptions, including timeouts.
+    Process.kill("KILL", -pid)
+  rescue Errno::ESRCH
+    nil
   end
 end


### PR DESCRIPTION
- Permit the Metal compiler service used by ggml and whisper.cpp to compile shaders at runtime, including during offline formula tests.
- Exercise fresh shader compilation with a unique function name so cached libraries cannot hide a missing compiler connection.

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Codex with GPT 6 Astra at high effort, with local review and testing.

-----