### PR TITLE
Stop leaking BUNDLER_VERSION into child processes

### DIFF
--- a/Library/Homebrew/standalone/init.rb
+++ b/Library/Homebrew/standalone/init.rb
@@ -59,7 +59,6 @@ HOMEBREW_LIBRARY_PATH = Pathname(dir).parent.realpath.freeze
 HOMEBREW_USING_PORTABLE_RUBY = RbConfig.ruby.include?("/vendor/portable-ruby/").freeze
 
 HOMEBREW_BUNDLER_VERSION = ENV.fetch("HOMEBREW_BUNDLER_VERSION").freeze
-ENV["BUNDLER_VERSION"] = HOMEBREW_BUNDLER_VERSION
 
 require_relative "../utils/gem_setup"
 Utils::GemSetup.setup_gem_environment!(setup_path: false)

--- a/Library/Homebrew/test/dev-cmd/ruby_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/ruby_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Homebrew::DevCmd::Ruby do
       end
 
       abort if T::Utils.signature_for_method(SorbetRuntimeTest.instance_method(:check))
+      abort if ENV.key?("BUNDLER_VERSION")
     RUBY
     env = {
       "HOMEBREW_DEV_CMD_RUN"             => "1",


### PR DESCRIPTION
<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [ ] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Fable 5.1 is used to check what effect can be happen when I remove the env, and summarize this commit message. I have reviewed manually.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

- `standalone/init.rb` exported `BUNDLER_VERSION` so RubyGems would pick our vendored Bundler, so every subprocess (notably formula builds running their own `bundle`) inherited an exact version requirement it could not satisfy, e.g. `swiftgen` with the system Ruby: `Could not find 'bundler' (4.0.16) required by $BUNDLER_VERSION`.
- It also defeated the `BUNDLE_VERSION=system` default superenv sets for formulae, since RubyGems consults `BUNDLER_VERSION` first.
- The assignment is unnecessary: `vendor/bundle/bundler/setup` is a standalone setup file and Portable Ruby ships a single Bundler matching `Gemfile.lock`, so RubyGems resolves it without help. Drop it and cover the environment in the `brew ruby` integration test.