### PR TITLE
Read terminal size without invoking stty

### DIFF
--- a/Library/Homebrew/test/utils/tty_spec.rb
+++ b/Library/Homebrew/test/utils/tty_spec.rb
@@ -1,6 +1,9 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "io/console"
+require "pty"
+
 RSpec.describe Tty do
   describe "::strip_ansi" do
     it "removes ANSI escape codes from a string" do
@@ -66,34 +69,63 @@ RSpec.describe Tty do
   describe "::size" do
     before do
       described_class.remove_instance_variable(:@size) if described_class.instance_variable_defined?(:@size)
+      allow(Utils).to receive(:popen_read_text).and_raise("unexpected subprocess")
     end
 
     after do
       described_class.remove_instance_variable(:@size) if described_class.instance_variable_defined?(:@size)
     end
 
-    it "memoises a failed `stty size` probe instead of respawning it" do
-      expect(Utils).to receive(:popen_read_text).with("/bin/stty", "size", err: File::NULL).once.and_return("")
+    it "reads and memoises the terminal size without a subprocess" do
+      PTY.open do |controller, terminal|
+        controller.winsize = [40, 160]
+        $stdin.reopen(terminal)
+        size = described_class.size
+        controller.winsize = [50, 180]
+
+        expect([size, described_class.size]).to eq([[40, 160], [40, 160]])
+      end
+    end
+
+    it "returns nil when stdin is redirected" do
+      $stdin.reopen(File::NULL)
+
+      expect(described_class.size).to be_nil
+    end
+
+    it "returns nil when stdin is closed" do
+      original_stdin = $stdin
+      $stdin = $stdin.dup
+      $stdin.close
+
+      expect(described_class.size).to be_nil
+    ensure
+      $stdin = original_stdin
+    end
+
+    it "memoises a failed terminal size probe" do
+      allow($stdin).to receive(:tty?).and_return(true)
+      allow($stdin).to receive(:winsize).and_invoke(proc { raise Errno::ENOTTY }, proc { [40, 160] })
 
       # We call this twice to check the failure is memoised
-      expect(described_class.size).to be_nil
-      expect(described_class.size).to be_nil
+      expect([described_class.size, described_class.size]).to eq([nil, nil])
     end
 
     it "does not expose an unfinished size to another thread" do
       probe_started = Queue.new
       release_probe = Queue.new
-      allow(Utils).to receive(:popen_read_text).with("/bin/stty", "size", err: File::NULL).and_invoke(
+      allow($stdin).to receive(:tty?).and_return(true)
+      allow($stdin).to receive(:winsize).and_invoke(
         proc {
           probe_started << true
           release_probe.pop
-          "40 160"
+          [40, 160]
         },
-        proc { "40 160" },
+        proc { [40, 160] },
       )
 
       probing_thread = Thread.new { described_class.size }
-      probe_started.pop
+      probe_started.pop(timeout: 5)
 
       expect(described_class.size).to eq([40, 160])
     ensure

--- a/Library/Homebrew/utils/tty.rb
+++ b/Library/Homebrew/utils/tty.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "io/console"
 require "utils/popen"
 
 # Various helper functions for interacting with TTYs.
@@ -141,9 +142,9 @@ module Tty
     def size
       return @size if defined?(@size)
 
-      height, width = Utils.popen_read_text("/bin/stty", "size", err: File::NULL).presence&.split&.map(&:to_i)
-      size = [height, width] if height && width
-      @size = T.let(size, T.nilable([Integer, Integer]))
+      @size = T.let(($stdin.winsize if $stdin.tty?), T.nilable([Integer, Integer]))
+    rescue IOError, SystemCallError
+      @size = nil
     end
 
     sig { returns(Integer) }


### PR DESCRIPTION
- Query stdin with `IO#winsize` so uutils `stty` cannot stop in a background process group and hang Homebrew commands.
- Preserve cached results and fallbacks for redirected stdin or failed terminal queries, with regression coverage.

Fixes #23951

-----

<!-- Only tick a checkbox once you've done it; honesty keeps reviews smooth. -->
<!-- Tick with [x] before creating, or click the boxes afterwards. -->
<!-- Don't delete these checkboxes or this pull request is closed automatically. -->

- [x] Have you followed our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) guidelines?
- [x] Have you checked for other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you explained what your changes do? Performance claims (e.g. "this is faster") must include `brew benchmark` results.
- [x] Have you explained why you'd like these changes included, not just what they do?
- [x] For bug fixes, have you given step-by-step `brew` commands to reproduce the bug?
- [x] Have you written new tests (excluding integration tests)? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) locally?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Codex with GPT 6 Astra at Extra High effort, with local review and testing.

-----